### PR TITLE
add more buildv1 features to the roadmap for vetting wrt buildv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,24 @@ spec:
 | Private Builder Image Registry     | ⚪️     |      |    |
 | Runtime Base Image    | ⚪️    |      |    |
 | Binary builds         |       |      |    |
+| Image pull policy     |       |      |    |
+| Inject source via config map         |       |      |    |
+| Inject source via secret         |       |      |    |
+| Inject source via image         |       |      |    |
+| Set image label/ens   |       |      |    |
+| Triggers (SCMs)       |       |      |    |
+| Triggers (imagestream)|       |      |    |
+| Pruning of builds     |       |      |    |
+| Cancelling of builds  |       |      |    |
+| Chaining of builds    |       |      |    |
 | Image Caching         |       |      |    |
+| Max duration / TO     |       |      |    |
+| Parallel vs. serial execution   |       |      |    |
 | ImageStreams support  |       |      |    |
 | Entitlements          |       |      |    |
+| Global Proxy support  |       |      |    |
+| Mirror support        |       |      |    |
+| new-app/build & odo ? |       |      |    |
 
 [corev1container]: https://github.com/kubernetes/api/blob/v0.17.3/core/v1/types.go#L2106
 [pipelinesoperator]: https://www.openshift.com/learn/topics/pipelines


### PR DESCRIPTION
/assign @sbose78 

Hey @sbose78 

Finally got around to submitting updates to the roadmap you started based on some of our initial conversations.

My updates here are based on a feature compare between openshift build v1 and tekton that I did last fall.

As we progress through buildv2 we should look at each of these and decide whether we 
- provide some buildv2 analogous flavor of it
- or document why buildv2 is not doing it as part of I'm assuming the inevitable doc openshift build v2 will have as part of helping devs on build v1 migrate

At the time of my evaluation last fall, the conclusion wrt to tekton and each of these was either 
a) it was already implemented at the tekton API level
b) could be done via the openness of the tekton API, where pods/containers are exposed along with supporting artifacts like secrets/configmap/volumes/pvcs etc., and "more work" on our end as needed.
c) or at least was on the tekton "roadmap" in as much as upstream features were open

And of course aside from discussion here, we can zero in on this on an upcoming build v2 sync call as you like.

From the openshift devex end, as I've mentioned before, I see us trying to facilitate your consumption of such features via work like `obu` or similar utilities, repo refactoring, inclusion of the build v2 scenarios in upcoming design work, whatever we come up with that makes sense and is containable.

@pweil- @adambkaplan @siamaksade @bparees   ... FYI and of course chime in as needed