### PR TITLE
Fix badge for travis and add new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@
     <a alt="GoReport" href="https://goreportcard.com/report/github.com/shipwright-io/build">
         <img src="https://goreportcard.com/badge/github.com/shipwright-io/build">
     </a>
-    <a alt="Travis-CI Status" href="https://travis-ci.com/shipwright-io/build">
-        <img src="https://travis-ci.com/shipwright-io/build.svg?branch=master">
+    <a alt="Travis-CI Status" href="https://travis-ci.org/github/shipwright-io/build">
+        <img src="https://travis-ci.org/shipwright-io/build.svg?branch=master">
     </a>
+    <img alt="License" src="https://img.shields.io/github/license/shipwright-io/build">
+    <a href="https://pkg.go.dev/mod/github.com/shipwright-io/build"> <img src="https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white"></a>
 </p>
 
 # The `build` Kubernetes API
 
 Codenamed build-v2
 
-An API to build container-images on Kubernetes using popular strategies and tools like `source-to-image`, `buildpack-v3`, `kaniko`, `jib` and `buildah`, in an extensible way.
+An API to build container-images on Kubernetes using popular strategies and tools like `source-to-image`, `buildpack-v3`, `kaniko` and `buildah`, in an extensible way.
 
 ## Dependencies
 


### PR DESCRIPTION
Add new badges for license and go.dev reference

Fix Readme, while it included a reference to "jib" tool that we do not use.