### PR TITLE
Remove reference to a service account on auto-generation

### DIFF
--- a/samples/buildrun/buildrun_buildah_cr.yaml
+++ b/samples/buildrun/buildrun_buildah_cr.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   buildRef:
     name: buildah-golang-build
-

--- a/samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml
@@ -7,5 +7,4 @@ spec:
   buildRef:
     name: buildpack-nodejs-build-heroku
   serviceAccount:
-    name: pipeline
     generate: true

--- a/samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -7,5 +7,4 @@ spec:
   buildRef:
     name: buildpack-nodejs-build-namespaced-heroku
   serviceAccount:
-    name: pipeline
     generate: true

--- a/samples/buildrun/buildrun_buildpacks-v3_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3_cr.yaml
@@ -7,5 +7,4 @@ spec:
   buildRef:
     name: buildpack-nodejs-build
   serviceAccount:
-    name: pipeline
     generate: true

--- a/samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml
@@ -7,5 +7,4 @@ spec:
   buildRef:
     name: buildpack-nodejs-build-namespaced
   serviceAccount:
-    name: pipeline
     generate: true

--- a/test/data/buildrun_buildpacks-v3_nodejs_runtime-image_cr.yaml
+++ b/test/data/buildrun_buildpacks-v3_nodejs_runtime-image_cr.yaml
@@ -7,5 +7,4 @@ spec:
   buildRef:
     name: buildpack-nodejs-build-heroku
   serviceAccount:
-    name: pipeline
     generate: true


### PR DESCRIPTION
Having the `spec.serviceAccount.name` while `spec.serviceAccount.generate` is set to true
is confusing in the samples, while the name is not used anywhere. And a autogenerated name will be used for
a service account creation.