### PR TITLE
Retry RPC error

### DIFF
--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -78,6 +78,7 @@ func isRetryableError(err error) bool {
 		apierrors.IsTimeout(err) ||
 		apierrors.IsTooManyRequests(err) ||
 		err.Error() == "etcdserver: request timed out" ||
+		err.Error() == "rpc error: code = Unavailable desc = transport is closing" ||
 		strings.Contains(err.Error(), "net/http: request canceled while waiting for connection") {
 		return true
 	}


### PR DESCRIPTION
We just had this error in our regular e2e test runs:

```
Error retrieving a buildRun
    Unexpected error:
        <*errors.StatusError | 0xc000813ea0>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "Failure",
                Message: "rpc error: code = Unavailable desc = transport is closing",
                Reason: "",
                Details: nil,
                Code: 500,
            },
        }
        rpc error: code = Unavailable desc = transport is closing
    occurred

    /build/test/e2e/validators.go:233

    Full Stack Trace
    github.com/shipwright-io/build/test/e2e.validateBuildRunToSucceed.func4(0x0, 0x0)
    	/build/test/e2e/validators.go:233 +0x18e
```

I am marking this error retryable.