### PR TITLE
Fix PathContext to ContextDir

### DIFF
--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -22,7 +22,7 @@ const (
 	inputGitSourceRevision     = "revision"
 	inputParamBuilderImage     = "BUILDER_IMAGE"
 	inputParamDockerfile       = "DOCKERFILE"
-	inputParamPathContext      = "PATH_CONTEXT"
+	inputParamContextDir       = "CONTEXT_DIR"
 	outputImageResourceName    = "image"
 	outputImageResourceURL     = "url"
 )
@@ -35,7 +35,7 @@ func getStringTransformations(fullText string) string {
 		"$(build.output.image)":      "$(outputs.resources.image.url)",
 		"$(build.builder.image)":     fmt.Sprintf("$(inputs.params.%s)", inputParamBuilderImage),
 		"$(build.dockerfile)":        fmt.Sprintf("$(inputs.params.%s)", inputParamDockerfile),
-		"$(build.source.contextDir)": fmt.Sprintf("$(inputs.params.%s)", inputParamPathContext),
+		"$(build.source.contextDir)": fmt.Sprintf("$(inputs.params.%s)", inputParamContextDir),
 	}
 
 	// Run the text through all possible replacements
@@ -81,10 +81,10 @@ func GenerateTaskSpec(
 				},
 			},
 			{
-				// PATH_CONTEXT comes from the git source specification
+				// CONTEXT_DIR comes from the git source specification
 				// in the Build object
 				Description: "The root of the code",
-				Name:        inputParamPathContext,
+				Name:        inputParamContextDir,
 				Default: &v1beta1.ArrayOrString{
 					Type:      v1beta1.ParamTypeString,
 					StringVal: ".",
@@ -276,7 +276,7 @@ func GenerateTaskRun(
 	}
 	if build.Spec.Source.ContextDir != nil {
 		inputParams = append(inputParams, v1beta1.Param{
-			Name: inputParamPathContext,
+			Name: inputParamContextDir,
 			Value: v1beta1.ArrayOrString{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: *build.Spec.Source.ContextDir,

--- a/pkg/controller/buildrun/generate_taskrun_test.go
+++ b/pkg/controller/buildrun/generate_taskrun_test.go
@@ -58,7 +58,7 @@ var _ = Describe("GenerateTaskrun", func() {
 				Expect(err).To(BeNil())
 
 				expectedCommandOrArg = []string{
-					"bud", "--tag=$(outputs.resources.image.url)", fmt.Sprintf("--file=$(inputs.params.%s)", "DOCKERFILE"), fmt.Sprintf("$(inputs.params.%s)", "PATH_CONTEXT"),
+					"bud", "--tag=$(outputs.resources.image.url)", fmt.Sprintf("--file=$(inputs.params.%s)", "DOCKERFILE"), fmt.Sprintf("$(inputs.params.%s)", "CONTEXT_DIR"),
 				}
 			})
 
@@ -230,7 +230,7 @@ var _ = Describe("GenerateTaskrun", func() {
 					if param.Name == "DOCKERFILE" {
 						Expect(param.Value.StringVal).To(Equal(dockerfile))
 					}
-					if param.Name == "PATH_CONTEXT" {
+					if param.Name == "CONTEXT_DIR" {
 						Expect(param.Value.StringVal).To(Equal(contextDir))
 					}
 				}

--- a/test/buildstrategy_samples.go
+++ b/test/buildstrategy_samples.go
@@ -76,7 +76,7 @@ spec:
         - $(build.dockerfile)
         - -t
         - $(build.output.image)
-        - $(build.pathContext)
+        - $(build.source.contextDir)
       resources:
         limits:
           cpu: 500m


### PR DESCRIPTION
During the PR: https://github.com/shipwright-io/build/commit/10386f9c65e4689e2d34886b1926bc49e7ad64ad#diff-c8bae8bebf9ceb3609b947afd6c4af05

We switch the `pathContext` parameter to `contextDir`

But we still have some parameter names or a test code still using `pathContext` which makes people confusing.

Let us remove the old `pathContext` and make the code clear.