### PR TITLE
Initial Release Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,13 @@ script:
   - make test-unit-coverage
   - make test-e2e TEST_IMAGE_REPO="$(./hack/install-registry.sh show):5000/shipwright-io/build-e2e"
   - set +e
+deploy:
+  - provider: script
+    script: make release TAG=latest
+    on:
+      branch: master
+  - provider: script
+    script: make release TAG=$TRAVIS_TAG
+    on:
+      tags: true
+      all_branches: true

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ TEST_PRIVATE_GITLAB ?=
 # private repository authentication secret
 TEST_SOURCE_SECRET ?=
 
+# Image settings for building and pushing images
+IMAGE_HOST ?= quay.io
+IMAGE ?= shipwright/shipwright-operator
+TAG ?= latest
+CONTAINER_RUNTIME ?= docker
+DOCKERFILE ?= Dockerfile
+
 .EXPORT_ALL_VARIABLES:
 
 default: build
@@ -76,6 +83,18 @@ $(OPERATOR): vendor
 .PHONY: build-plain
 build-plain: 
 	go build $(GO_FLAGS) -o $(OPERATOR) cmd/manager/main.go
+
+.PHONY: build-image
+build-image:
+	$(CONTAINER_RUNTIME) build -t $(IMAGE_HOST)/$(IMAGE):$(TAG) -f $(DOCKERFILE) .
+
+.PHONY: push-image 
+push-image:
+	$(CONTAINER_RUNTIME) push $(IMAGE_HOST)/$(IMAGE):$(TAG)
+
+.PHONY: release
+release:
+	hack/release.sh
 
 install-ginkgo:
 	go get -u github.com/onsi/ginkgo/ginkgo

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+echo "Logging into container registry $IMAGE_HOST"
+echo "$REGISTRY_PASSWORD" | $CONTAINER_RUNTIME login -u "$REGISTRY_USERNAME" --password-stdin "$IMAGE_HOST"
+
+echo "Building container image $IMAGE_HOST/$IMAGE:$TAG"
+make build-image
+
+echo "Pushing container image to $IMAGE_HOST"
+make push-image
+
+set +e


### PR DESCRIPTION
Creating an initial image release pipeline for the shipwright operator.
This makes use of the travis docker service to build the image and push
it to quay.io when release tags are made and PRs merge in the main
branch.

In the future we will want to dogfood our own operator and use
Shipwright to build and push the image.