### PR TITLE
Add ramp-up duration metrics to build

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,13 +10,19 @@ Following build metrics are exposed at service `build-operator-metrics` on port 
 | `build_buildruns_completed_total` | Counter | Number of total completed BuildRuns. | buildstrategy=<build_buildstrategy_name> | experimental |
 | `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
 | `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
+| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
+| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
 
 Environment variables can be set to use custom buckets for the histogram metrics:
 
-| Metric                                       | Environment variable             | Default                                  |
-| -------------------------------------------- | -------------------------------- | ---------------------------------------- |
-| `build_buildrun_establish_duration_seconds`  | `PROMETHEUS_BR_EST_DUR_BUCKETS`  | `0,1,2,3,5,7,10,15,20,30`                |
-| `build_buildrun_completion_duration_seconds` | `PROMETHEUS_BR_COMP_DUR_BUCKETS` | `50,100,150,200,250,300,350,400,450,500` |
+| Metric                                               | Environment variable               | Default                                  |
+| ---------------------------------------------------- | ---------------------------------- | ---------------------------------------- |
+| `build_buildrun_establish_duration_seconds`          | `PROMETHEUS_BR_EST_DUR_BUCKETS`    | `0,1,2,3,5,7,10,15,20,30`                |
+| `build_buildrun_completion_duration_seconds`         | `PROMETHEUS_BR_COMP_DUR_BUCKETS`   | `50,100,150,200,250,300,350,400,450,500` |
+| `build_buildrun_rampup_duration_seconds`             | `PROMETHEUS_BR_RAMPUP_DUR_BUCKETS` | `0,1,2,3,4,5,6,7,8,9,10`                 |
+| `build_buildrun_taskrun_rampup_duration_seconds`     | `PROMETHEUS_BR_RAMPUP_DUR_BUCKETS` | `0,1,2,3,4,5,6,7,8,9,10`                 |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | `PROMETHEUS_BR_RAMPUP_DUR_BUCKETS` | `0,1,2,3,4,5,6,7,8,9,10`                 |
 
 The values have to be a comma-separated list of numbers. You need to set the environment variable for the build operator for your customization to become active. When running locally, set the variable right before starting the operator:
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,12 +23,14 @@ const (
 	// environment variable to override the buckets
 	metricBuildRunCompletionDurationBucketsEnvVar = "PROMETHEUS_BR_COMP_DUR_BUCKETS"
 	metricBuildRunEstablishDurationBucketsEnvVar  = "PROMETHEUS_BR_EST_DUR_BUCKETS"
+	metricBuildRunRampUpDurationBucketsEnvVar     = "PROMETHEUS_BR_RAMPUP_DUR_BUCKETS"
 )
 
 var (
 	// arrays are not possible as constants
 	metricBuildRunCompletionDurationBuckets = prometheus.LinearBuckets(50, 50, 10)
 	metricBuildRunEstablishDurationBuckets  = []float64{0, 1, 2, 3, 5, 7, 10, 15, 20, 30}
+	metricBuildRunRampUpDurationBuckets     = prometheus.LinearBuckets(0, 1, 10)
 )
 
 // Config hosts different parameters that
@@ -43,6 +45,7 @@ type Config struct {
 type PrometheusConfig struct {
 	BuildRunCompletionDurationBuckets []float64
 	BuildRunEstablishDurationBuckets  []float64
+	BuildRunRampUpDurationBuckets     []float64
 }
 
 // NewDefaultConfig returns a new Config, with context timeout and default Kaniko image.
@@ -53,6 +56,7 @@ func NewDefaultConfig() *Config {
 		Prometheus: PrometheusConfig{
 			BuildRunCompletionDurationBuckets: metricBuildRunCompletionDurationBuckets,
 			BuildRunEstablishDurationBuckets:  metricBuildRunEstablishDurationBuckets,
+			BuildRunRampUpDurationBuckets:     metricBuildRunRampUpDurationBuckets,
 		},
 	}
 }
@@ -89,6 +93,15 @@ func (c *Config) SetConfigFromEnv() error {
 			return err
 		}
 		c.Prometheus.BuildRunEstablishDurationBuckets = buildRunEstablishDurationBuckets
+	}
+
+	buildRunRampUpDurationBucketsEnvVarValue := os.Getenv(metricBuildRunRampUpDurationBucketsEnvVar)
+	if buildRunRampUpDurationBucketsEnvVarValue != "" {
+		buildRunRampUpDurationBuckets, err := stringToFloat64Array(strings.Split(buildRunRampUpDurationBucketsEnvVarValue, ","))
+		if err != nil {
+			return err
+		}
+		c.Prometheus.BuildRunRampUpDurationBuckets = buildRunRampUpDurationBuckets
 	}
 
 	return nil

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -369,11 +369,48 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 
 				// Increase BuildRun count in metrics
 				buildmetrics.BuildRunCountInc(buildRun.Status.BuildSpec.StrategyRef.Name)
-				// Add BuildRun establish and completion times in metrics
-				buildRunCompletionDuring := buildRun.Status.CompletionTime.Time.Sub(buildRun.CreationTimestamp.Time)
-				buildRunEstablishDuring := buildRun.Status.StartTime.Time.Sub(buildRun.CreationTimestamp.Time)
-				buildmetrics.BuildRunEstablishObserve(buildRun.Status.BuildSpec.StrategyRef.Name, buildRun.Namespace, buildRunEstablishDuring)
-				buildmetrics.BuildRunCompletionObserve(buildRun.Status.BuildSpec.StrategyRef.Name, buildRun.Namespace, buildRunCompletionDuring)
+
+				// buildrun established duration (time between the creation of the buildrun and the start of the buildrun)
+				buildmetrics.BuildRunEstablishObserve(
+					buildRun.Status.BuildSpec.StrategyRef.Name,
+					buildRun.Namespace,
+					buildRun.Status.StartTime.Time.Sub(buildRun.CreationTimestamp.Time),
+				)
+
+				// buildrun completetion duration (total time between the creation of the buildrun and the buildrun completion)
+				buildmetrics.BuildRunCompletionObserve(
+					buildRun.Status.BuildSpec.StrategyRef.Name,
+					buildRun.Namespace,
+					buildRun.Status.CompletionTime.Time.Sub(buildRun.CreationTimestamp.Time),
+				)
+
+				// buildrun ramp-up duration (time between buildrun creation and taskrun creation)
+				buildmetrics.BuildRunRampUpDurationObserve(
+					buildRun.Status.BuildSpec.StrategyRef.Name,
+					buildRun.Namespace,
+					lastTaskRun.CreationTimestamp.Time.Sub(buildRun.CreationTimestamp.Time),
+				)
+
+				// Look for the pod created by the taskrun
+				var pod = &corev1.Pod{}
+				if err := r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: lastTaskRun.Status.PodName}, pod); err == nil {
+					lastInitPodIdx := len(pod.Status.InitContainerStatuses) - 1
+					lastInitPod := pod.Status.InitContainerStatuses[lastInitPodIdx]
+
+					// taskrun ramp-up duration (time between taskrun creation and taskrun pod creation)
+					buildmetrics.TaskRunRampUpDurationObserve(
+						buildRun.Status.BuildSpec.StrategyRef.Name,
+						buildRun.Namespace,
+						pod.CreationTimestamp.Time.Sub(lastTaskRun.CreationTimestamp.Time),
+					)
+
+					// taskrun pod ramp-up (time between pod creation and last init container completion)
+					buildmetrics.TaskRunPodRampUpDurationObserve(
+						buildRun.Status.BuildSpec.StrategyRef.Name,
+						buildRun.Namespace,
+						lastInitPod.State.Terminated.FinishedAt.Sub(pod.CreationTimestamp.Time),
+					)
+				}
 			}
 
 			ctxlog.Info(ctx, "updating buildRun status", namespace, request.Namespace, name, request.Name)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -28,9 +28,12 @@ var (
 		},
 		[]string{buildStrategyLabel})
 
-	buildRunEstablishDuration *prometheus.HistogramVec
-
+	buildRunEstablishDuration  *prometheus.HistogramVec
 	buildRunCompletionDuration *prometheus.HistogramVec
+
+	buildRunRampUpDuration   *prometheus.HistogramVec
+	taskRunRampUpDuration    *prometheus.HistogramVec
+	taskRunPodRampUpDuration *prometheus.HistogramVec
 
 	initialized = false
 )
@@ -59,6 +62,30 @@ func InitPrometheus(config *config.Config) {
 		},
 		[]string{buildStrategyLabel, namespaceLabel})
 
+	buildRunRampUpDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "build_buildrun_rampup_duration_seconds",
+			Help:    "BuildRun ramp-up duration in seconds (time between buildrun creation and taskrun creation).",
+			Buckets: config.Prometheus.BuildRunRampUpDurationBuckets,
+		},
+		[]string{buildStrategyLabel, namespaceLabel})
+
+	taskRunRampUpDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "build_buildrun_taskrun_rampup_duration_seconds",
+			Help:    "BuildRun taskrun ramp-up duration in seconds (time between taskrun creation and taskrun pod creation).",
+			Buckets: config.Prometheus.BuildRunRampUpDurationBuckets,
+		},
+		[]string{buildStrategyLabel, namespaceLabel})
+
+	taskRunPodRampUpDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "build_buildrun_taskrun_pod_rampup_duration_seconds",
+			Help:    "BuildRun taskrun pod ramp-up duration in seconds (time between pod creation and last init container completion).",
+			Buckets: config.Prometheus.BuildRunRampUpDurationBuckets,
+		},
+		[]string{buildStrategyLabel, namespaceLabel})
+
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(
 		buildCount,
@@ -84,5 +111,20 @@ func BuildRunEstablishObserve(buildStrategy, namespace string, duration time.Dur
 
 // BuildRunCompletionObserve sets the build run completion time
 func BuildRunCompletionObserve(buildStrategy, namespace string, duration time.Duration) {
+	buildRunCompletionDuration.WithLabelValues(buildStrategy, namespace).Observe(duration.Seconds())
+}
+
+// BuildRunRampUpDurationObserve processes the observation of a new buildrun ramp-up duration
+func BuildRunRampUpDurationObserve(buildStrategy string, namespace string, duration time.Duration) {
+	buildRunCompletionDuration.WithLabelValues(buildStrategy, namespace).Observe(duration.Seconds())
+}
+
+// TaskRunRampUpDurationObserve processes the observation of a new taskrun ramp-up duration
+func TaskRunRampUpDurationObserve(buildStrategy string, namespace string, duration time.Duration) {
+	buildRunCompletionDuration.WithLabelValues(buildStrategy, namespace).Observe(duration.Seconds())
+}
+
+// TaskRunPodRampUpDurationObserve processes the observation of a new taskrun pod ramp-up duration
+func TaskRunPodRampUpDurationObserve(buildStrategy string, namespace string, duration time.Duration) {
 	buildRunCompletionDuration.WithLabelValues(buildStrategy, namespace).Observe(duration.Seconds())
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/shipwright-io/build/pkg/config"
 )
@@ -24,28 +25,40 @@ var _ = Describe("Custom Metrics", func() {
 
 		BuildCountInc(buildStrategy)
 		BuildRunCountInc(buildStrategy)
-		buildRunEstablishTime := time.Duration(1) * time.Second
-		buildRunExecutionTime := time.Duration(200) * time.Second
-		BuildRunEstablishObserve(buildStrategy, namespace, buildRunEstablishTime)
-		BuildRunCompletionObserve(buildStrategy, namespace, buildRunExecutionTime)
+		BuildRunEstablishObserve(buildStrategy, namespace, time.Duration(1)*time.Second)
+		BuildRunCompletionObserve(buildStrategy, namespace, time.Duration(200)*time.Second)
+		BuildRunRampUpDurationObserve(buildStrategy, namespace, time.Duration(1)*time.Second)
+		TaskRunRampUpDurationObserve(buildStrategy, namespace, time.Duration(2)*time.Second)
+		TaskRunPodRampUpDurationObserve(buildStrategy, namespace, time.Duration(3)*time.Second)
 
 		It("should increase the kaniko build count", func() {
 			buildCount, _ := buildCount.GetMetricWithLabelValues(buildStrategy)
 			Expect(testutil.ToFloat64(buildCount)).To(Equal(float64(1)))
 		})
+
 		It("should increase the kaniko buildrun count", func() {
 			buildRunCount, _ := buildRunCount.GetMetricWithLabelValues(buildStrategy)
 			Expect(testutil.ToFloat64(buildRunCount)).To(Equal(float64(1)))
 		})
+
 		It("should record the kaniko buildrun establish time", func() {
 			buildRunEstablishDuration, err := buildRunEstablishDuration.GetMetricWithLabelValues(buildStrategy, namespace)
 			Expect(buildRunEstablishDuration).NotTo(BeNil())
 			Expect(err).To(BeNil())
 		})
+
 		It("should record the kaniko buildrun completion time", func() {
 			buildRunCompletionDuration, err := buildRunCompletionDuration.GetMetricWithLabelValues(buildStrategy, namespace)
 			Expect(buildRunCompletionDuration).NotTo(BeNil())
 			Expect(err).To(BeNil())
+		})
+
+		It("should record the kaniko ramp-up durations", func() {
+			for _, metric := range []*prometheus.HistogramVec{buildRunRampUpDuration, taskRunRampUpDuration, taskRunPodRampUpDuration} {
+				metricRampUpDuration, err := metric.GetMetricWithLabelValues(buildStrategy, namespace)
+				Expect(metricRampUpDuration).NotTo(BeNil())
+				Expect(err).To(BeNil())
+			}
 		})
 	})
 
@@ -57,28 +70,40 @@ var _ = Describe("Custom Metrics", func() {
 
 		BuildCountInc(buildStrategy)
 		BuildRunCountInc(buildStrategy)
-		buildRunEstablishTime := time.Duration(1) * time.Second
-		buildRunExecutionTime := time.Duration(100) * time.Second
-		BuildRunEstablishObserve(buildStrategy, namespace, buildRunEstablishTime)
-		BuildRunCompletionObserve(buildStrategy, namespace, buildRunExecutionTime)
+		BuildRunEstablishObserve(buildStrategy, namespace, time.Duration(1)*time.Second)
+		BuildRunCompletionObserve(buildStrategy, namespace, time.Duration(100)*time.Second)
+		BuildRunRampUpDurationObserve(buildStrategy, namespace, time.Duration(1)*time.Second)
+		TaskRunRampUpDurationObserve(buildStrategy, namespace, time.Duration(2)*time.Second)
+		TaskRunPodRampUpDurationObserve(buildStrategy, namespace, time.Duration(3)*time.Second)
 
 		It("should increase the buildpacks build count", func() {
 			buildCount, _ := buildCount.GetMetricWithLabelValues(buildStrategy)
 			Expect(testutil.ToFloat64(buildCount)).To(Equal(float64(1)))
 		})
+
 		It("should increase the buildpacks buildrun count", func() {
 			buildRunCount, _ := buildRunCount.GetMetricWithLabelValues(buildStrategy)
 			Expect(testutil.ToFloat64(buildRunCount)).To(Equal(float64(1)))
 		})
+
 		It("should record the buildpacks buildrun establish time", func() {
 			buildRunEstablishDuration, err := buildRunEstablishDuration.GetMetricWithLabelValues(buildStrategy, namespace)
 			Expect(buildRunEstablishDuration).NotTo(BeNil())
 			Expect(err).To(BeNil())
 		})
+
 		It("should record the buildpacks buildrun completion time", func() {
 			buildRunCompletionDuration, err := buildRunCompletionDuration.GetMetricWithLabelValues(buildStrategy, namespace)
 			Expect(buildRunCompletionDuration).NotTo(BeNil())
 			Expect(err).To(BeNil())
+		})
+
+		It("should record the buildpacks ramp-up durations", func() {
+			for _, metric := range []*prometheus.HistogramVec{buildRunRampUpDuration, taskRunRampUpDuration, taskRunPodRampUpDuration} {
+				metricRampUpDuration, err := metric.GetMetricWithLabelValues(buildStrategy, namespace)
+				Expect(metricRampUpDuration).NotTo(BeNil())
+				Expect(err).To(BeNil())
+			}
 		})
 	})
 })


### PR DESCRIPTION
When building, a couple of Kubernetes resources are created to run the
respective build strategy to compile the app. Depending on the system
load or utilisation, it may take more or less time to create the
resources to kick the run. The time to ramp-up a specific part of the
build can be useful for monitoring and alerting.

Add three ramp-up duration metrics to `build`:
- between buildrun creation and taskrun creation (buildrun ramp-up)
- between taskrun creation and taskrun pod creation (taskrun ramp-up)
- between pod creation and last init container completion (pod ramp-up)

Note: The ramp-up durations usually range between zero (not measurable)
and one second. Therefore, the default bucket range is simply counting
up from zero to ten seconds.