### PR TITLE
Enhance docs by adding contributing and code-of-conduct files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing Guidelines
+
+Welcome to Shipwright Build. We are excited about the prospect of you contributing to our project. Your support is more than welcome!
+
+## Getting Started
+
+We have initial documentation on how to start contributing here:
+
+- Learn how to [change shipwright and try out your changes on a local cluster](/docs/development/local_development.md)
+- Our main [documentation](/docs/)
+- Our [Code of Conduct](/code-of-conduct.md)
+
+## Creating new Issues
+
+We recommend to open an issue for the following scenarios:
+
+- Asking for help or questions. (_Use the **discussion** or **help_wanted** label_)
+- Reporting a Bug. (_Use the **bug** label_)
+- Requesting a new Feature. (_Use the **enhancement** label_)
+
+The Shipwright maintainers can also be reached in our [Kubernetes Slack channel](https://kubernetes.slack.com/archives/C019ZRGUEJC).
+
+## Writing Pull Requests
+
+Contributions can be submitted by creating a pull request on Github. We recommend you do the following to ensure the maintainers can collaborate on your contribution:
+
+- Fork the project into your personal Github account
+- Create a new feature branch for your contribution
+- Make your changes
+- If you make code changes, ensure unit tests are passing by running `make test-unit`
+- Open a PR with a nice description and a link to the Github issue where the changes were previously discussed.
+
+## Code review process
+
+There is an integration on our Github repository that automatically do things for us. Once a PR is open the tool will assign two members of the project for the code review.
+
+The code review should cover:
+
+- Ensure all related tests(unit, integration and e2e) are passing.
+- Ensure the code style is compliant with the [coding conventions](https://github.com/kubernetes/community/blob/master/contributors/guide/coding-conventions.md)
+- Ensure the code is properly documented, e.g. enough comments where needed.
+- Ensure the code is adding the necessary test cases(unit, integration or e2e) if needed.
+
+## Community Meetings Participation
+
+We run the community meetings every Monday at 13:00 UTC time.
+For each upcoming meeting we generate a new issue where we layout the topics to discuss.
+See our [previous meetings](https://github.com/shipwright-io/build/issues?q=is%3Aissue+label%3Acommunity+is%3Aclosed) outcomes.
+To join, please request an invite in our Slack [channel](https://kubernetes.slack.com/archives/C019ZRGUEJC).
+
+## Contact Information
+
+- [Slack channel](https://kubernetes.slack.com/archives/C019ZRGUEJC)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Contributing Guidelines
 
 Welcome to Shipwright Build. We are excited about the prospect of you contributing to our project. Your support is more than welcome!

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,9 @@
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Shipwright Code of Conduct
 
 Shipwright follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
-# Kubernetes Community Code of Conduct
+# Shipwright Code of Conduct
 
-Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)
+Shipwright follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/docs/development/local_development.md
+++ b/docs/development/local_development.md
@@ -1,3 +1,9 @@
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Running on development mode
 
 The following document highlights how to deploy a Build operator locally for running on development mode.

--- a/docs/development/local_development.md
+++ b/docs/development/local_development.md
@@ -1,0 +1,20 @@
+# Running on development mode
+
+The following document highlights how to deploy a Build operator locally for running on development mode.
+
+**Before generating an instance of the Build operator, ensure the following:**
+
+- Target your Kubernetes cluster. We recommend the usage of KinD for development, which you can launch via our [install-kind.sh](/hack/install-kind.sh) script.
+- On the cluster, ensure the Tekton controllers are running. You can use our Tekton installation script in [install-tekton.sh](/hack/install-tekton.sh)
+
+---
+
+Once the code have been modified, you can generate an instance of the Build operator running locally to validate your changes. For running the Build operator locally via the `local` target:
+
+```sh
+pushd $GOPATH/src/github.com/shipwright-io/build
+  make local
+popd
+```
+
+_Note_: The above target will uninstall/install all related CRDs and start an instance of the operator via the `operator-sdk` binary. All existing CRDs instances will be deleted.


### PR DESCRIPTION
Add code of conduct doc
- We reference to the Kubernetes community one, in the same way
as most of the Kubernetes existing project 

Add contributing doc
- Trying to add some initial words on future contributions. I think we
still need to generate more docs for this, but so far is good to have
this as an initial step.

