### PR TITLE
Enable label customization for histograms

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,15 +10,19 @@ The Build component exposes several metrics to help you monitor the health and b
 
 Following build metrics are exposed at service `build-operator-metrics` on port `8383`.
 
-| Name | Type | Description | Label | Status |
-| ---- | ---- | ----------- | ----- | ------ |
+| Name | Type | Description | Labels | Status |
+| ---- | ---- | ----------- | ------ | ------ |
 | `build_builds_registered_total` | Counter | Number of total registered Builds. | buildstrategy=<build_buildstrategy_name> | experimental |
 | `build_buildruns_completed_total` | Counter | Number of total completed BuildRuns. | buildstrategy=<build_buildstrategy_name> | experimental |
-| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
-| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
-| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
-| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
-| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name><br>namespace=<buildrun_namespace> | experimental |
+| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
+| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
+| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
+
+<sup>1</sup> Labels for histograms are disabled by default. See [Configuration of histogram labels](#configuration-of-histogram-labels) to enable them.
+
+## Configuration of histogram buckets
 
 Environment variables can be set to use custom buckets for the histogram metrics:
 
@@ -37,12 +41,43 @@ export PROMETHEUS_BR_COMP_DUR_BUCKETS=30,60,90,120,180,240,300,360,420,480
 make local
 ```
 
-When you are deploying the build operator in your Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [operator.yaml](../deploy/operator.yaml), to add an additional entry:
+When you deploy the build operator in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [operator.yaml](../deploy/operator.yaml). Add an additional entry:
 
 ```yaml
 [...]
   env:
   - name: PROMETHEUS_BR_COMP_DUR_BUCKETS
     value: "30,60,90,120,180,240,300,360,420,480"
+[...]
+```
+
+## Configuration of histogram labels
+
+As the amount of buckets and labels has a direct impact on the number of Prometheus time series, you can selectively enable labels that you are interested in using the `PROMETHEUS_HISTOGRAM_ENABLED_LABELS` environment variable. The supported labels are:
+
+* buildstrategy
+* namespace
+
+Use a comma-separated value to enable multiple labels. For example:
+
+```bash
+export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=namespace
+make local
+```
+
+or
+
+```bash
+export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=buildstrategy,namespace
+make local
+```
+
+When you deploy the build operator in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [operator.yaml](../deploy/operator.yaml). Add an additional entry:
+
+```yaml
+[...]
+  env:
+  - name: PROMETHEUS_HISTOGRAM_ENABLED_LABELS
+    value: namespace
 [...]
 ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,5 @@
 // Copyright The Shipwright Contributors
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package config
@@ -28,6 +28,9 @@ const (
 	metricBuildRunCompletionDurationBucketsEnvVar = "PROMETHEUS_BR_COMP_DUR_BUCKETS"
 	metricBuildRunEstablishDurationBucketsEnvVar  = "PROMETHEUS_BR_EST_DUR_BUCKETS"
 	metricBuildRunRampUpDurationBucketsEnvVar     = "PROMETHEUS_BR_RAMPUP_DUR_BUCKETS"
+
+	// environment variable to enable histogram labels
+	prometheusHistogramEnabledLabelsEnvVar = "PROMETHEUS_HISTOGRAM_ENABLED_LABELS"
 )
 
 var (
@@ -50,6 +53,7 @@ type PrometheusConfig struct {
 	BuildRunCompletionDurationBuckets []float64
 	BuildRunEstablishDurationBuckets  []float64
 	BuildRunRampUpDurationBuckets     []float64
+	HistogramEnabledLabels            []string
 }
 
 // NewDefaultConfig returns a new Config, with context timeout and default Kaniko image.
@@ -107,6 +111,8 @@ func (c *Config) SetConfigFromEnv() error {
 		}
 		c.Prometheus.BuildRunRampUpDurationBuckets = buildRunRampUpDurationBuckets
 	}
+
+	c.Prometheus.HistogramEnabledLabels = strings.Split(os.Getenv(prometheusHistogramEnabledLabelsEnvVar), ",")
 
 	return nil
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,5 +1,5 @@
 // Copyright The Shipwright Contributors
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics
@@ -25,7 +25,10 @@ var _ = Describe("Custom Metrics", func() {
 		buildStrategy = "kaniko"
 		namespace = "default"
 
-		InitPrometheus(config.NewDefaultConfig())
+		config := config.NewDefaultConfig()
+		config.Prometheus.HistogramEnabledLabels = []string{"buildstrategy", "namespace"}
+
+		InitPrometheus(config)
 
 		BuildCountInc(buildStrategy)
 		BuildRunCountInc(buildStrategy)


### PR DESCRIPTION
Fixes #367 

I am introducing an environment variable configuration to allow selective disabling of histogram labels.

I also noticed, that the recently added new metrics were not working and fixed the copy/paste mistake. Sample output of `/metrics` for a single buildrun with `PROMETHEUS_HISTOGRAM_DISABLED_LABELS=namespace`:

```
# HELP build_buildrun_completion_duration_seconds BuildRun completion duration in seconds.
# TYPE build_buildrun_completion_duration_seconds histogram
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="50"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="100"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="150"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="200"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="250"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="300"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="350"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="400"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="450"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="500"} 1
build_buildrun_completion_duration_seconds_bucket{buildstrategy="kaniko",le="+Inf"} 1
build_buildrun_completion_duration_seconds_sum{buildstrategy="kaniko"} 31
build_buildrun_completion_duration_seconds_count{buildstrategy="kaniko"} 1
# HELP build_buildrun_establish_duration_seconds BuildRun establish duration in seconds.
# TYPE build_buildrun_establish_duration_seconds histogram
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="0"} 0
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="1"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="2"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="3"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="5"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="7"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="10"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="15"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="20"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="30"} 1
build_buildrun_establish_duration_seconds_bucket{buildstrategy="kaniko",le="+Inf"} 1
build_buildrun_establish_duration_seconds_sum{buildstrategy="kaniko"} 1
build_buildrun_establish_duration_seconds_count{buildstrategy="kaniko"} 1
# HELP build_buildrun_rampup_duration_seconds BuildRun ramp-up duration in seconds (time between buildrun creation and taskrun creation).
# TYPE build_buildrun_rampup_duration_seconds histogram
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="0"} 0
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="1"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="2"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="3"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="4"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="5"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="6"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="7"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="8"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="9"} 1
build_buildrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="+Inf"} 1
build_buildrun_rampup_duration_seconds_sum{buildstrategy="kaniko"} 1
build_buildrun_rampup_duration_seconds_count{buildstrategy="kaniko"} 1
# HELP build_buildrun_taskrun_pod_rampup_duration_seconds BuildRun taskrun pod ramp-up duration in seconds (time between pod creation and last init container completion).
# TYPE build_buildrun_taskrun_pod_rampup_duration_seconds histogram
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="0"} 0
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="1"} 0
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="2"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="3"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="4"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="5"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="6"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="7"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="8"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="9"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="+Inf"} 1
build_buildrun_taskrun_pod_rampup_duration_seconds_sum{buildstrategy="kaniko"} 2
build_buildrun_taskrun_pod_rampup_duration_seconds_count{buildstrategy="kaniko"} 1
# HELP build_buildrun_taskrun_rampup_duration_seconds BuildRun taskrun ramp-up duration in seconds (time between taskrun creation and taskrun pod creation).
# TYPE build_buildrun_taskrun_rampup_duration_seconds histogram
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="0"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="1"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="2"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="3"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="4"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="5"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="6"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="7"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="8"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="9"} 1
build_buildrun_taskrun_rampup_duration_seconds_bucket{buildstrategy="kaniko",le="+Inf"} 1
build_buildrun_taskrun_rampup_duration_seconds_sum{buildstrategy="kaniko"} 0
build_buildrun_taskrun_rampup_duration_seconds_count{buildstrategy="kaniko"} 1
```

The singleton nature of the metrics package makes it impossible to add unit tests for this.