### PR TITLE
Grant Tekton additional privileges on OpenShift

### DIFF
--- a/hack/install-tekton.sh
+++ b/hack/install-tekton.sh
@@ -14,9 +14,45 @@ TEKTON_VERSION="${TEKTON_VERSION:-v0.14.2}"
 
 TEKTON_HOST="github.com"
 TEKTON_HOST_PATH="tektoncd/pipeline/releases/download"
-
-echo "# Deploying Tekton Pipelines Operator '${TEKTON_VERSION}'"
+PLATFORM="${1:-k8s}"
+echo "# Deploying Tekton Pipelines Operator '${TEKTON_VERSION}' on ${PLATFORM}"
 
 kubectl apply \
     --filename="https://${TEKTON_HOST}/${TEKTON_HOST_PATH}/${TEKTON_VERSION}/release.yaml" \
     --output="yaml"
+
+if [[ ${PLATFORM} == "openshift" ]]; then
+    echo "Granting additional privileges to the tekton-pipelines-controller"
+    kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: privileged-scc-role
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+- apiGroups: [security.openshift.io]
+  resourceNames: [privileged]
+  resources: [securitycontextconstraints]
+  verbs: [use]
+EOF
+    kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-privileged
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-scc-role
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+EOF
+fi


### PR DESCRIPTION
When deploying Tekton on openshift, grant the tekton-pipelines-
controller use of the priveleged security context constraint. This
will let the Tekton controller create privileged containers. Build
strategies such as buildah currently require use of the priveleged SCC.

Fixes #378