### PR TITLE
Add genclient tags to build resources

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -124,6 +124,8 @@ type BuildStatus struct {
 	Reason string `json:"reason,omitempty"`
 }
 
+// +genclient
+// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Build is the Schema representing a Build definition

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -84,6 +84,8 @@ type ServiceAccount struct {
 	Generate bool `json:"generate,omitempty"`
 }
 
+// +genclient
+// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BuildRun is the Schema representing an instance of build execution

--- a/pkg/apis/build/v1alpha1/buildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/buildstrategy_types.go
@@ -24,6 +24,8 @@ type BuildStep struct {
 type BuildStrategyStatus struct {
 }
 
+// +genclient
+// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BuildStrategy is the Schema representing a strategy in the namespace scope to build images from source code.

--- a/pkg/apis/build/v1alpha1/clusterbuildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/clusterbuildstrategy_types.go
@@ -8,6 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +genclient
+// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterBuildStrategy is the Schema representing a strategy in the cluster scope to build images from source code.

--- a/pkg/apis/build/v1alpha1/register.go
+++ b/pkg/apis/build/v1alpha1/register.go
@@ -20,4 +20,7 @@ var (
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+
+	// AddToScheme is used in the generated kube code
+	AddToScheme = SchemeBuilder.AddToScheme
 )


### PR DESCRIPTION
In order to use `code-gen` to create a client that has support for our
new types like `build`, or `buildrun`, there need to be `genclient` tags
set in the code at the specific types.

Add `+genclient` and `+genclient:noStatus` to the required types.

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>