### PR TITLE
Enable linguist for our build repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# This file is documented at https://git-scm.com/docs/gitattributes.
+# Linguist-specific attributes are documented at
+# https://github.com/github/linguist.
+
+**/zz_generated.*.go linguist-generated=true
+/pkg/clients/** linguist-generated=true


### PR DESCRIPTION
Based on https://docs.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github
this should be useful to keep certain files from displaying in diffs by default, or counting
toward the repository language.

This should help when PRs with vendor folders or generated clients are adding/removing changes.