### PR TITLE
Update docs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This operator ships four CRDs :
 | Version | Docs                           | Examples                    |
 | ------- | ------------------------------ | --------------------------- |
 | HEAD    | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/samples) |
+| [v0.1.0](https://github.com/shipwright-io/build/releases/tag/v0.1.0)    | [Docs @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/docs) | [Examples @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/samples) |
 
 ## Examples
 


### PR DESCRIPTION
The v0.1.0  was missing on the table. This follows the approach used by the Tekton folks, see https://github.com/tektoncd/pipeline/tree/v0.16.2#read-the-docs