### PR TITLE
Update to Kaniko 1.0

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ const (
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
 	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
-	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v0.24.0"
+	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.0.0"
 	// kanikoImageEnvVar environment variable for Kaniko container image, for instance:
 	// KANIKO_CONTAINER_IMAGE="gcr.io/kaniko-project/executor:v0.24.0"
 	kanikoImageEnvVar = "KANIKO_CONTAINER_IMAGE"

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v0.24.0
+      image: gcr.io/kaniko-project/executor:v1.0.0
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -31,6 +31,7 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=/workspace/source/$(build.source.contextDir)
         - --destination=$(build.output.image)
+        - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
       resources:
         limits:


### PR DESCRIPTION
Updating Kaniko to their 1.0.0 version. Also adding `--oci-layout-path` argument to the strategy. This causes Kaniko to write a JSON file with the image information which is picked up by the `step-image-digest-exporter` step of Tekton. See [--oci-layout-path](https://github.com/GoogleContainerTools/kaniko/blob/82f5ec961246bb1aca003f7b16089d96e3de758b/README.md#--oci-layout-path).

It will cause this warning no to appear anymore: `{"level":"info","ts":1600437444.6745567,"logger":"fallback-logger","caller":"imagedigestexporter/main.go:59","msg":"No index.json found for: image","commit":"20da4cf"}`

The image sha will then be in the taskrun status. We can pick that up at some point and put it into the buildrun status.