### PR TITLE
Switch from GCR to DockerHub

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -69,7 +69,7 @@ The [buildpacks-v3][buildpacks] BuildStrategy/ClusterBuildStrategy uses a Cloud 
 
 - [`heroku/buildpacks:18`][hubheroku]
 - [`cloudfoundry/cnb:bionic`][hubcloudfoundry]
-- [`gcr.io/paketo-buildpacks/builder:latest`](https://console.cloud.google.com/gcr/images/paketo-buildpacks/GLOBAL/builder?gcrImageListsize=30)
+- [`docker.io/paketobuildpacks/builder:latest`](https://hub.docker.com/r/paketobuildpacks/builder/tags)
 
 ### Installing Buildpacks v3 Strategy
 

--- a/docs/proposals/buildstrategy-steps-resources.md
+++ b/docs/proposals/buildstrategy-steps-resources.md
@@ -159,7 +159,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-prepare
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 0
         capabilities:
@@ -179,7 +179,7 @@ spec:
           cpu: "10m"
           memory: "128Mi"
     - name: step-detect
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -199,7 +199,7 @@ spec:
           cpu: "250m"
           memory: "50Mi"
     - name: step-restore
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -214,7 +214,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-build
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -235,7 +235,7 @@ spec:
           cpu: "500m"
           memory: "1Gi"
     - name: step-export
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-prepare
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 0
         capabilities:
@@ -26,7 +26,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: step-detect
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -46,7 +46,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-restore
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -68,7 +68,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-build
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -89,7 +89,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-export
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-prepare
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 0
         capabilities:
@@ -26,7 +26,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: step-detect
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -46,7 +46,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-restore
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -68,7 +68,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-build
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:
@@ -89,7 +89,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-export
-      image: gcr.io/paketo-buildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:latest
       securityContext:
         runAsUser: 1000
       command:


### PR DESCRIPTION
Fix #404 

Based on a discussion in [paketo buildpacks slack](https://paketobuildpacks.slack.com/archives/CULAS8ACD/p1600670275004100), it seems the Google Container Registry will not be used anymore some time in the near future. They recommend switching to DockerHub, where the same images are hosted.

Replace all occurrences of `gcr.io/paketo-buildpacks` with the DockerHub alternative `docker.io/paketobuildpacks`.

Update link to DockerHub images list.