### PR TITLE
Set ownerReference to build->buildrun

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
   - [Defining the Builder or Dockerfile](#defining-the-builder-or-dockerfile)
   - [Defining the Output](#defining-the-output)
   - [Runtime-Image](#Runtime-Image)
-- [Using Finalizers](#using-finalizers)
+- [BuildRun deletion](#BuildRun-deletion)
 
 ## Overview
 
@@ -266,10 +266,9 @@ Please consider the description of the attributes under `.spec.runtime`:
 
 Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v0.24.0` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build operator deployment](../deploy/operator.yaml).
 
-## Using Finalizers
+## BuildRun deletion
 
-The Build controller support Kubernetes finalizers in order to asynchronously delete resources. For the case of a Build instance with a particular annotation,
-related `BuildRuns` will be deleted prior to deleting the `Build` instance. The flow is very simple, if you want to garbage collect BuildRuns then the `build.build.dev/build-run-deletion` annotation needs to be set to `true` in the `Build` definition, if this behaviour is not desired, then the annotation needs to be set to `false`. By default the annotation is never present in a `Build` definition. See an example of how to define this annotation:
+A `Build` can automatically delete a related `BuildRun`. To enable this feature set the  `build.build.dev/build-run-deletion` annotation to `true` in the `Build` instance. By default the annotation is never present in a `Build` definition. See an example of how to define this annotation:
 
 ```yaml
 apiVersion: build.dev/v1alpha1

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/code-generator v0.18.0
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29
 	k8s.io/kubectl v0.17.4
+	k8s.io/utils v0.0.0-20200124190032-861946025e34
 	knative.dev/pkg v0.0.0-20200528142800-1c6815d7e4c9
 	sigs.k8s.io/controller-runtime v0.5.2
 	sigs.k8s.io/yaml v1.2.0

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -18,7 +18,6 @@ var (
 
 	// AnnotationBuildRunDeletion is a label key for enabling/disabling the BuildRun deletion
 	AnnotationBuildRunDeletion = "build.build.dev/build-run-deletion"
-	BuildFinalizer             = "finalizer.build.build.dev"
 )
 
 // BuildSpec defines the desired state of Build

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -18,10 +18,12 @@ import (
 	buildmetrics "github.com/shipwright-io/build/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -35,20 +37,23 @@ const succeedStatus string = "Succeeded"
 const namespace string = "namespace"
 const name string = "name"
 
+type setOwnerReferenceFunc func(owner, object metav1.Object, scheme *runtime.Scheme) error
+
 // Add creates a new Build Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, c *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContext(ctx, "build-controller")
-	return add(ctx, mgr, NewReconciler(ctx, c, mgr))
+	return add(ctx, mgr, NewReconciler(ctx, c, mgr, controllerutil.SetControllerReference))
 }
 
 // NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager) reconcile.Reconciler {
+func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager, ownerRef setOwnerReferenceFunc) reconcile.Reconciler {
 	return &ReconcileBuild{
-		ctx:    ctx,
-		config: c,
-		client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
+		ctx:                   ctx,
+		config:                c,
+		client:                mgr.GetClient(),
+		scheme:                mgr.GetScheme(),
+		setOwnerReferenceFunc: ownerRef,
 	}
 }
 
@@ -62,7 +67,7 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 
 	pred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			buildRunFinalizer := false
+			buildRunDeletionAnnotation := false
 			// Check if the AnnotationBuildRunDeletion annotation is updated
 			oldAnnot := e.MetaOld.GetAnnotations()
 			newAnnot := e.MetaNew.GetAnnotations()
@@ -76,13 +81,13 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 						name,
 						e.MetaNew.GetName(),
 					)
-					buildRunFinalizer = true
+					buildRunDeletionAnnotation = true
 				}
 			}
 
 			// Ignore updates to CR status in which case metadata.Generation does not change
 			// or BuildRunDeletion annotation does not change
-			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration() || buildRunFinalizer
+			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration() || buildRunDeletionAnnotation
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Evaluates to false if the object has been confirmed deleted.
@@ -106,10 +111,11 @@ var _ reconcile.Reconciler = &ReconcileBuild{}
 type ReconcileBuild struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	ctx    context.Context
-	config *config.Config
-	client client.Client
-	scheme *runtime.Scheme
+	ctx                   context.Context
+	config                *config.Config
+	client                client.Client
+	scheme                *runtime.Scheme
+	setOwnerReferenceFunc setOwnerReferenceFunc
 }
 
 // Reconcile reads that state of the cluster for a Build object and makes changes based on the state read
@@ -130,15 +136,11 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 		return reconcile.Result{}, nil
 	}
 
-	// Add finalizer for build
-	if err := r.configFinalizer(ctx, b); err != nil {
-		return reconcile.Result{}, err
-	}
-	// Check if the build is marked to be deleted, which is
-	// indicated by the deletion timestamp being set.
-	if !b.DeletionTimestamp.IsZero() {
-		ctxlog.Info(ctx, "build is marked for deletion", namespace, b.Namespace, name, b.Name)
-		return reconcile.Result{}, r.finalizeBuildRun(ctx, b)
+	if err := r.validateBuildRunOwnerReferences(ctx, b); err != nil {
+		// we do not want to bail out here if the owerreference validation fails, we ignore this error on purpose
+		// In case we just created the Build, we want the Build reconcile logic to continue, in order to
+		// validate the Build references ( e.g secrets, strategies )
+		ctxlog.Info(ctx, "unexpected error during ownership reference validation", namespace, request.Namespace, name, request.Name, "error", err)
 	}
 
 	// Populate the status struct with default values
@@ -258,7 +260,7 @@ func (r *ReconcileBuild) validateClusterBuildStrategy(ctx context.Context, n str
 	}
 
 	if len(list.Items) == 0 {
-		return errors.Errorf("none ClusterBuildStrategies found")
+		return errors.Errorf("no ClusterBuildStrategies found")
 	}
 
 	if len(list.Items) > 0 {
@@ -312,48 +314,64 @@ func (r *ReconcileBuild) validateSecrets(ctx context.Context, secretNames []stri
 	return nil
 }
 
-func (r *ReconcileBuild) configFinalizer(ctx context.Context, b *build.Build) error {
-	if b.GetAnnotations()[build.AnnotationBuildRunDeletion] == "true" {
-		if !contains(b.GetFinalizers(), build.BuildFinalizer) {
-			ctxlog.Info(ctx, "add finalizer to build", namespace, b.Namespace, name, b.Name)
-			b.SetFinalizers(append(b.GetFinalizers(), build.BuildFinalizer))
-			if err := r.client.Update(ctx, b); err != nil {
-				return err
-			}
-		}
-	} else {
-		if contains(b.GetFinalizers(), build.BuildFinalizer) {
-			ctxlog.Info(ctx, "remove finalizer from build", namespace, b.Namespace, name, b.Name)
-			b.SetFinalizers(remove(b.GetFinalizers(), build.BuildFinalizer))
-			if err := r.client.Update(ctx, b); err != nil {
-				return err
-			}
-		}
+// validateBuildRunOwnerReferences defines or removes the ownerReference for the BuildRun based on
+// an annotation value
+func (r *ReconcileBuild) validateBuildRunOwnerReferences(ctx context.Context, b *build.Build) error {
+
+	buildRunList, err := r.retrieveBuildRunsfromBuild(ctx, b)
+	if err != nil {
+		return err
 	}
+
+	switch b.GetAnnotations()[build.AnnotationBuildRunDeletion] {
+	case "true":
+		// if the buildRun does not have an ownerreference to the Build, lets add it.
+		for _, buildRun := range buildRunList.Items {
+			if index := r.validateBuildOwnerReference(buildRun.OwnerReferences, b); index == -1 {
+				if err := r.setOwnerReferenceFunc(b, &buildRun, r.scheme); err != nil {
+					b.Status.Reason = fmt.Sprintf("unexpected error when trying to set the ownerreference: %v", err)
+					if err := r.client.Status().Update(ctx, b); err != nil {
+						return err
+					}
+				}
+				if err = r.client.Update(ctx, &buildRun); err != nil {
+					return err
+				}
+				ctxlog.Info(ctx, fmt.Sprintf("succesfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
+			}
+		}
+	case "false":
+		// if the buildRun have an ownerreference to the Build, lets remove it
+		for _, buildRun := range buildRunList.Items {
+			if index := r.validateBuildOwnerReference(buildRun.OwnerReferences, b); index != -1 {
+				buildRun.OwnerReferences = removeOwnerReferenceByIndex(buildRun.OwnerReferences, index)
+				if err := r.client.Update(ctx, &buildRun); err != nil {
+					return err
+				}
+				ctxlog.Info(ctx, fmt.Sprintf("succesfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
+			}
+		}
+
+	default:
+		ctxlog.Info(ctx, fmt.Sprintf("the annotation %s was not properly defined, supported values are true or false", build.AnnotationBuildRunDeletion), namespace, b.Namespace, name, b.Name)
+		return fmt.Errorf("the annotation %s was not properly defined, supported values are true or false", build.AnnotationBuildRunDeletion)
+	}
+
 	return nil
 }
 
-func (r *ReconcileBuild) finalizeBuildRun(ctx context.Context, b *build.Build) error {
-	if contains(b.GetFinalizers(), build.BuildFinalizer) {
-		// Run finalization logic for buildFinalizer. If the
-		// finalization logic fails, don't remove the finalizer so
-		// that we can retry during the next reconciliation.
-		if err := r.cleanBuildRun(ctx, b); err != nil {
-			return err
-		}
-
-		// Remove buildFinalizer. Once all finalizers have been
-		// removed, the object will be deleted.
-		b.SetFinalizers(remove(b.GetFinalizers(), build.BuildFinalizer))
-		err := r.client.Update(ctx, b)
-		if err != nil {
-			return err
+// validateOwnerReferences returns an index value if a Build is owning a reference or -1 if this is not the case
+func (r *ReconcileBuild) validateBuildOwnerReference(references []metav1.OwnerReference, build *build.Build) int {
+	for i, ownerRef := range references {
+		if ownerRef.Kind == build.Kind && ownerRef.Name == build.Name {
+			return i
 		}
 	}
-	return nil
+	return -1
 }
 
-func (r *ReconcileBuild) cleanBuildRun(ctx context.Context, b *build.Build) error {
+// retrieveBuildRunsfromBuild returns a list of BuildRuns that are owned by a Build in the same namespace
+func (r *ReconcileBuild) retrieveBuildRunsfromBuild(ctx context.Context, b *build.Build) (*build.BuildRunList, error) {
 	buildRunList := &build.BuildRunList{}
 
 	lbls := map[string]string{
@@ -363,33 +381,13 @@ func (r *ReconcileBuild) cleanBuildRun(ctx context.Context, b *build.Build) erro
 		Namespace:     b.Namespace,
 		LabelSelector: labels.SelectorFromSet(lbls),
 	}
-	if err := r.client.List(ctx, buildRunList, &opts); err != nil {
-		return err
-	}
 
-	for _, buildRun := range buildRunList.Items {
-		ctxlog.Info(ctx, "deleting buildrun", namespace, b.Namespace, name, b.Name, "buildrunname", buildRun.Name)
-		if err := r.client.Delete(ctx, &buildRun); err != nil {
-			return err
-		}
-	}
-	return nil
+	err := r.client.List(ctx, buildRunList, &opts)
+	return buildRunList, err
 }
 
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
-func remove(list []string, s string) []string {
-	for i, v := range list {
-		if v == s {
-			list = append(list[:i], list[i+1:]...)
-		}
-	}
-	return list
+// removeOwnerReferenceByIndex removes the entry by index, this will not keep the same
+// order in the slice
+func removeOwnerReferenceByIndex(references []metav1.OwnerReference, i int) []metav1.OwnerReference {
+	return append(references[:i], references[i+1:]...)
 }

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	crc "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -72,7 +73,7 @@ var _ = Describe("Reconcile Build", func() {
 		buildSample = ctl.BuildWithClusterBuildStrategy(buildName, namespace, buildStrategyName, registrySecret)
 		// Reconcile
 		testCtx := ctxlog.NewContext(context.TODO(), "fake-logger")
-		reconciler = buildController.NewReconciler(testCtx, config.NewDefaultConfig(), manager)
+		reconciler = buildController.NewReconciler(testCtx, config.NewDefaultConfig(), manager, controllerutil.SetControllerReference)
 	})
 
 	Describe("Reconcile", func() {
@@ -371,13 +372,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("none ClusterBuildStrategies found"))
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, "no ClusterBuildStrategies found")
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("none ClusterBuildStrategies found")))
+				Expect(err.Error()).To(ContainSubstring("no ClusterBuildStrategies found"))
 			})
 		})
 		Context("when spec strategy BuildStrategy is specified", func() {
@@ -513,78 +514,6 @@ var _ = Describe("Reconcile Build", func() {
 				result, err := reconciler.Reconcile(request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(reconcile.Result{}).To(Equal(result))
-			})
-		})
-		Context("when the annotation build-run-deletion is defined", func() {
-			var annotationFinalizer map[string]string
-
-			JustBeforeEach(func() {
-				annotationFinalizer = map[string]string{}
-			})
-
-			It("sets a finalizer if annotation equals true", func() {
-				// Fake some client LIST calls and ensure we populate all
-				// different resources we could get during reconciliation
-				client.ListCalls(func(context context.Context, object runtime.Object, _ ...crc.ListOption) error {
-					switch object := object.(type) {
-					case *corev1.SecretList:
-						list := ctl.SecretList(registrySecret)
-						list.DeepCopyInto(object)
-					case *build.ClusterBuildStrategyList:
-						list := ctl.ClusterBuildStrategyList(buildStrategyName)
-						list.DeepCopyInto(object)
-					}
-					return nil
-				})
-
-				// override Build definition with one annotation
-				annotationFinalizer[build.AnnotationBuildRunDeletion] = "true"
-				buildSample = ctl.BuildWithCustomAnnotationAndFinalizer(
-					buildName,
-					namespace,
-					buildStrategyName,
-					annotationFinalizer,
-					[]string{},
-				)
-
-				clientUpdateCalls := ctl.StubBuildUpdateWithFinalizers(build.BuildFinalizer)
-				client.UpdateCalls(clientUpdateCalls)
-
-				result, err := reconciler.Reconcile(request)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(reconcile.Result{}).To(Equal(result))
-			})
-
-			It("removes a finalizer if annotation equals false and finalizer exists", func() {
-				// Fake some client LIST calls and ensure we populate all
-				// different resources we could get during reconciliation
-				client.ListCalls(func(context context.Context, object runtime.Object, _ ...crc.ListOption) error {
-					switch object := object.(type) {
-					case *corev1.SecretList:
-						list := ctl.SecretList(registrySecret)
-						list.DeepCopyInto(object)
-					case *build.ClusterBuildStrategyList:
-						list := ctl.ClusterBuildStrategyList(buildStrategyName)
-						list.DeepCopyInto(object)
-					}
-					return nil
-				})
-
-				// override Build definition with one annotation
-				annotationFinalizer[build.AnnotationBuildRunDeletion] = "false"
-				buildSample = ctl.BuildWithCustomAnnotationAndFinalizer(
-					buildName,
-					namespace,
-					buildStrategyName,
-					annotationFinalizer,
-					[]string{build.BuildFinalizer},
-				)
-				clientUpdateCalls := ctl.StubBuildUpdateWithoutFinalizers()
-				client.UpdateCalls(clientUpdateCalls)
-
-				result, err := reconciler.Reconcile(request)
-				Expect(err).ToNot(HaveOccurred())
 				Expect(reconcile.Result{}).To(Equal(result))
 			})
 		})

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -93,11 +93,7 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 
 			// The CreateFunc is also called when the controller is started and iterates over all objects. For those BuildRuns that have a TaskRun referenced already,
 			// we do not need to do a further reconciliation. BuildRun updates then only happen from the TaskRun.
-			if o.Status.LatestTaskRunRef != nil {
-				return false
-			}
-
-			return true
+			return o.Status.LatestTaskRunRef == nil
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// Ignore updates to CR status in which case metadata.Generation does not change
@@ -187,11 +183,11 @@ func handleError(message string, listOfErrors ...error) error {
 // ValidateBuildRegistration verifies that a referenced Build is properly registered
 func (r *ReconcileBuildRun) ValidateBuildRegistration(ctx context.Context, build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) error {
 	if build.Status.Registered == "" {
-		err := fmt.Errorf("The Build is not yet validated, build: %s", build.Name)
+		err := fmt.Errorf("the Build is not yet validated, build: %s", build.Name)
 		return err
 	}
 	if build.Status.Registered != corev1.ConditionTrue {
-		err := fmt.Errorf("The Build is not registered correctly, build: %s, registered status: %s, reason: %s", build.Name, build.Status.Registered, build.Status.Reason)
+		err := fmt.Errorf("the Build is not registered correctly, build: %s, registered status: %s, reason: %s", build.Name, build.Status.Registered, build.Status.Reason)
 		updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 		return handleError("Build is not ready", err, updateErr)
 	}

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -489,7 +489,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 
 				_, err := reconciler.Reconcile(buildRunRequest)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(" Unsupported BuildStrategy Kind")))
+				Expect(err.Error()).To(ContainSubstring(" Unsupported BuildStrategy Kind"))
 			})
 
 			It("only generates the service account once if the taskRun cannot be created", func() {

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
 	crc "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -437,7 +438,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 
 				_, err := reconciler.Reconcile(buildRunRequest)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("\"default\" not found, msg: Failed to choose a service account to use")))
+				Expect(err.Error()).To(ContainSubstring(`"default" not found, msg: Failed to choose a service account to use`))
 			})
 
 			It("fails on a TaskRun creation due to missing namespaced buildstrategy", func() {
@@ -648,7 +649,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 
 				_, err := reconciler.Reconcile(buildRunRequest)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal(fmt.Sprintf("The Build is not yet validated, build: %s", buildName)))
+				Expect(err.Error()).To(Equal(fmt.Sprintf("the Build is not yet validated, build: %s", buildName)))
 				Expect(client.StatusCallCount()).To(Equal(0))
 			})
 
@@ -683,6 +684,96 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(client.CreateCallCount()).To(Equal(1))
+			})
+
+			It("updates Build with error when BuildRun is already owned", func() {
+
+				fakeOwnerName := "fakeOwner"
+
+				// Set the build spec
+				buildRunSample = ctl.BuildRunWithExistingOwnerReferences(buildRunName, buildName, fakeOwnerName)
+				buildRunSample.Status.BuildSpec = &buildSample.Spec
+
+				// override the Build to use a namespaced BuildStrategy
+				buildSample = ctl.BuildWithBuildRunDeletions(buildName, strategyName, build.NamespacedBuildStrategyKind)
+
+				// Override Stub get calls to include a service account
+				// and BuildStrategies
+				client.GetCalls(ctl.StubBuildRunGetWithSAandStrategies(
+					buildSample,
+					buildRunSample,
+					ctl.DefaultServiceAccount(saName),
+					ctl.DefaultClusterBuildStrategy(),
+					ctl.DefaultNamespacedBuildStrategy()),
+				)
+
+				statusCall := ctl.StubBuildStatusReason(
+					fmt.Sprintf("unexpected error when trying to set the ownerreference: Object /%s is already owned by another %s controller ", buildRunName, fakeOwnerName),
+				)
+				statusWriter.UpdateCalls(statusCall)
+
+				_, err := reconciler.Reconcile(buildRunRequest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(client.CreateCallCount()).To(Equal(1))
+			})
+
+			It("updates Build with error when BuildRun and Build are not in the same ns when setting ownerreferences", func() {
+				// Set the build spec
+				buildRunSample = ctl.BuildRunWithFakeNamespace(buildRunName, buildName)
+				buildRunSample.Status.BuildSpec = &buildSample.Spec
+
+				// override the Build to use a namespaced BuildStrategy
+				buildSample = ctl.BuildWithBuildRunDeletionsAndFakeNS(buildName, strategyName, build.NamespacedBuildStrategyKind)
+
+				// Override Stub get calls to include a service account
+				// and BuildStrategies
+				client.GetCalls(ctl.StubBuildRunGetWithSAandStrategies(
+					buildSample,
+					buildRunSample,
+					ctl.DefaultServiceAccount(saName),
+					ctl.DefaultClusterBuildStrategy(),
+					ctl.DefaultNamespacedBuildStrategy()),
+				)
+
+				statusCall := ctl.StubBuildStatusReason(
+					fmt.Sprintf("unexpected error when trying to set the ownerreference: cross-namespace owner references are disallowed, owner's namespace %s, obj's namespace %s", buildSample.Namespace, buildRunSample.Namespace),
+				)
+				statusWriter.UpdateCalls(statusCall)
+
+				_, err := reconciler.Reconcile(buildRunRequest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(client.CreateCallCount()).To(Equal(1))
+			})
+
+			It("ensure the Build can own a BuildRun when using the proper annotation", func() {
+
+				buildRunSample = ctl.BuildRunWithoutSA(buildRunName, buildName)
+				buildSample = ctl.BuildWithBuildRunDeletions(buildName, strategyName, build.NamespacedBuildStrategyKind)
+
+				// Override Stub get calls to include a service account
+				// and BuildStrategies
+				client.GetCalls(ctl.StubBuildRunGetWithSAandStrategies(
+					buildSample,
+					buildRunSample,
+					ctl.DefaultServiceAccount(saName),
+					ctl.DefaultClusterBuildStrategy(),
+					ctl.DefaultNamespacedBuildStrategy()),
+				)
+
+				// Ensure the BuildRun gets an ownershipReference when
+				// the buildv1alpha1.AnnotationBuildRunDeletion is set to true
+				// in the build
+				clientUpdateCalls := ctl.StubBuildUpdateOwnerReferences("Build",
+					buildName,
+					pointer.BoolPtr(true),
+					pointer.BoolPtr(true),
+				)
+				client.UpdateCalls(clientUpdateCalls)
+
+				_, err := reconciler.Reconcile(buildRunRequest)
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -87,35 +88,6 @@ func (c *Catalog) BuildWithNilBuildStrategyKind(name string, ns string, strategy
 			},
 			StrategyRef: &build.StrategyRef{
 				Name: strategyName,
-			},
-		},
-	}
-}
-
-// BuildWithCustomAnnotationAndFinalizer provides a Build CRD with a customize annotation
-// and optional finalizer
-func (c *Catalog) BuildWithCustomAnnotationAndFinalizer(
-	name string,
-	ns string,
-	strategyName string,
-	a map[string]string,
-	f []string,
-) *build.Build {
-	buildStrategy := build.ClusterBuildStrategyKind
-	return &build.Build{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   ns,
-			Annotations: a,
-			Finalizers:  f,
-		},
-		Spec: build.BuildSpec{
-			Source: build.GitSource{
-				URL: "foobar",
-			},
-			StrategyRef: &build.StrategyRef{
-				Name: strategyName,
-				Kind: &buildStrategy,
 			},
 		},
 	}
@@ -237,31 +209,23 @@ func (c *Catalog) StubFunc(status corev1.ConditionStatus, reason string) func(co
 	}
 }
 
-// StubBuildUpdateWithFinalizers is used to simulate the state of the Build
-// finalizers after a client Update on the Object happened.
-func (c *Catalog) StubBuildUpdateWithFinalizers(finalizer string) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+// StubBuildUpdateOwnerReferences simulates and assert an updated
+// BuildRun object ownerreferences
+func (c *Catalog) StubBuildUpdateOwnerReferences(ownerKind string, ownerName string, isOwnerController *bool, blockOwnerDeletion *bool) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 	return func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 		switch object := object.(type) {
-		case *build.Build:
-			Expect(object.Finalizers).To(ContainElement(finalizer))
+		case *build.BuildRun:
+			Expect(object.OwnerReferences[0].Kind).To(Equal(ownerKind))
+			Expect(object.OwnerReferences[0].Name).To(Equal(ownerName))
+			Expect(object.OwnerReferences[0].Controller).To(Equal(isOwnerController))
+			Expect(object.OwnerReferences[0].BlockOwnerDeletion).To(Equal(blockOwnerDeletion))
+			Expect(len(object.OwnerReferences)).ToNot(Equal(0))
 		}
 		return nil
 	}
 }
 
-// StubBuildUpdateWithoutFinalizers is used to simulate the state of the Build
-// finalizers after a client Update on the Object happened.
-func (c *Catalog) StubBuildUpdateWithoutFinalizers() func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
-	return func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
-		switch object := object.(type) {
-		case *build.Build:
-			Expect(len(object.Finalizers)).To(BeZero())
-		}
-		return nil
-	}
-}
-
-// StubBuildRun is used to simulate the existence of a BuildRun
+// StubBuildRun is used to simulate the existance of a BuildRun
 // only when there is a client GET on this object type
 func (c *Catalog) StubBuildRun(
 	b *build.BuildRun,
@@ -311,6 +275,19 @@ func (c *Catalog) StubBuildAndTaskRun(
 			return nil
 		}
 		return errors.NewNotFound(schema.GroupResource{}, nn.Name)
+	}
+}
+
+// StubBuildStatusReason asserts Status fields on a Build resource
+func (c *Catalog) StubBuildStatusReason(reason string) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+	return func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+		switch object := object.(type) {
+		case *build.Build:
+			if object.Status.Reason != "" {
+				Expect(*&object.Status.Reason).To(Equal(reason))
+			}
+		}
+		return nil
 	}
 }
 
@@ -582,6 +559,47 @@ func (c *Catalog) DefaultBuild(buildName string, strategyName string, strategyKi
 	}
 }
 
+// BuildWithBuildRunDeletions returns a minimal Build object with the
+// build.build.dev/build-run-deletion annotation set to true
+func (c *Catalog) BuildWithBuildRunDeletions(buildName string, strategyName string, strategyKind build.BuildStrategyKind) *build.Build {
+	return &build.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        buildName,
+			Annotations: map[string]string{buildv1alpha1.AnnotationBuildRunDeletion: "true"},
+		},
+		Spec: build.BuildSpec{
+			StrategyRef: &build.StrategyRef{
+				Name: strategyName,
+				Kind: &strategyKind,
+			},
+		},
+		Status: build.BuildStatus{
+			Registered: corev1.ConditionTrue,
+		},
+	}
+}
+
+// BuildWithBuildRunDeletionsAndFakeNS returns a minimal Build object with the
+// build.build.dev/build-run-deletion annotation set to true in a fake namespace
+func (c *Catalog) BuildWithBuildRunDeletionsAndFakeNS(buildName string, strategyName string, strategyKind build.BuildStrategyKind) *build.Build {
+	return &build.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        buildName,
+			Namespace:   "fakens",
+			Annotations: map[string]string{buildv1alpha1.AnnotationBuildRunDeletion: "true"},
+		},
+		Spec: build.BuildSpec{
+			StrategyRef: &build.StrategyRef{
+				Name: strategyName,
+				Kind: &strategyKind,
+			},
+		},
+		Status: build.BuildStatus{
+			Registered: corev1.ConditionTrue,
+		},
+	}
+}
+
 // DefaultBuildWithFalseRegistered returns a minimal Build object with a FALSE Registered
 func (c *Catalog) DefaultBuildWithFalseRegistered(buildName string, strategyName string, strategyKind build.BuildStrategyKind) *build.Build {
 	return &build.Build{
@@ -648,6 +666,48 @@ func (c *Catalog) BuildRunWithBuildSnapshot(buildRunName string, buildName strin
 					Name: "foobar",
 				},
 			},
+		},
+		Spec: build.BuildRunSpec{
+			BuildRef: &build.BuildRef{
+				Name: buildName,
+			},
+		},
+	}
+}
+
+// BuildRunWithExistingOwnerReferences returns a BuildRun object that is
+// already owned by some fake object
+func (c *Catalog) BuildRunWithExistingOwnerReferences(buildRunName string, buildName string, ownerName string) *build.BuildRun {
+
+	managingController := true
+
+	fakeOwnerRef := metav1.OwnerReference{
+		APIVersion: ownerName,
+		Kind:       ownerName,
+		Controller: &managingController,
+	}
+
+	return &build.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            buildRunName,
+			OwnerReferences: []metav1.OwnerReference{fakeOwnerRef},
+		},
+		Spec: build.BuildRunSpec{
+			BuildRef: &build.BuildRef{
+				Name: buildName,
+			},
+		},
+	}
+}
+
+// BuildRunWithFakeNamespace returns a BuildRun object with
+// a namespace that does not exist
+func (c *Catalog) BuildRunWithFakeNamespace(buildRunName string, buildName string) *build.BuildRun {
+
+	return &build.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      buildRunName,
+			Namespace: "foobarns",
 		},
 		Spec: build.BuildRunSpec{
 			BuildRef: &build.BuildRef{

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/onsi/gomega"
 	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -284,7 +283,7 @@ func (c *Catalog) StubBuildStatusReason(reason string) func(context context.Cont
 		switch object := object.(type) {
 		case *build.Build:
 			if object.Status.Reason != "" {
-				Expect(*&object.Status.Reason).To(Equal(reason))
+				Expect(object.Status.Reason).To(Equal(reason))
 			}
 		}
 		return nil
@@ -565,7 +564,7 @@ func (c *Catalog) BuildWithBuildRunDeletions(buildName string, strategyName stri
 	return &build.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        buildName,
-			Annotations: map[string]string{buildv1alpha1.AnnotationBuildRunDeletion: "true"},
+			Annotations: map[string]string{build.AnnotationBuildRunDeletion: "true"},
 		},
 		Spec: build.BuildSpec{
 			StrategyRef: &build.StrategyRef{
@@ -586,7 +585,7 @@ func (c *Catalog) BuildWithBuildRunDeletionsAndFakeNS(buildName string, strategy
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        buildName,
 			Namespace:   "fakens",
-			Annotations: map[string]string{buildv1alpha1.AnnotationBuildRunDeletion: "true"},
+			Annotations: map[string]string{build.AnnotationBuildRunDeletion: "true"},
 		},
 		Spec: build.BuildSpec{
 			StrategyRef: &build.StrategyRef{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -80,7 +80,6 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
-			validateBuildDeletion(namespace, testID, br, false)
 		})
 	})
 
@@ -150,7 +149,6 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
-			validateBuildDeletion(namespace, testID, br, false)
 		})
 	})
 
@@ -282,7 +280,6 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
-			validateBuildDeletion(namespace, testID, br, true)
 		})
 	})
 

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -237,38 +237,6 @@ func validateBuildRunToFail(
 	Expect(testBuildRun.Status.Reason).To(MatchRegexp(expectedReasonRegexp))
 }
 
-// validateBuildDeletion verifies if the BuildRun is deleted after Build is deleted.
-func validateBuildDeletion(
-	namespace string,
-	testBuildName string,
-	testBuildRun *operator.BuildRun,
-	expectedDeletion bool,
-) {
-	f := framework.Global
-
-	// Delete the Build
-	buildNsName := types.NamespacedName{Name: testBuildName, Namespace: namespace}
-	testBuild := &operator.Build{}
-	err := clientGet(buildNsName, testBuild)
-	Expect(err).ToNot(HaveOccurred(), "Build doesn't exist")
-	err = f.Client.Delete(goctx.TODO(), testBuild)
-	Expect(err).ToNot(HaveOccurred(), "Failed to delete build")
-	Logf("Build is deleted!")
-
-	Eventually(func() error {
-		err = clientGet(buildNsName, testBuild)
-		return err
-	}, time.Duration(30*getTimeoutMultiplier())*time.Second, 3*time.Second).ShouldNot(BeNil(), "Build is not deleted yet")
-
-	buildRunNsName := types.NamespacedName{Name: testBuildRun.Name, Namespace: namespace}
-	err = clientGet(buildRunNsName, testBuildRun)
-	if expectedDeletion {
-		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "BuildRun was not deleted together with the Build")
-	} else {
-		Expect(err).ToNot(HaveOccurred(), "BuildRun was deleted together with the Build")
-	}
-}
-
 // validateServiceAccountDeletion validates that a service account is correctly deleted after the end of
 // a build run and depending on the state of the build run
 func validateServiceAccountDeletion(buildRun *operator.BuildRun, namespace string) {

--- a/test/integration/utils/builds.go
+++ b/test/integration/utils/builds.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // This class is intended to host all CRUD calls for testing Build CRDs resources
@@ -30,11 +31,18 @@ func (t *TestBuild) DeleteBuild(name string) error {
 
 // GetBuild returns a Build based on name
 func (t *TestBuild) GetBuild(name string) (*v1alpha1.Build, error) {
-	bInterface := t.BuildClientSet.BuildV1alpha1().Builds(t.Namespace)
+	return t.BuildClientSet.
+		BuildV1alpha1().
+		Builds(t.Namespace).
+		Get(name, metav1.GetOptions{})
+}
 
-	build, err := bInterface.Get(name, metav1.GetOptions{})
+// PatchBuild patches an existing Build
+func (t *TestBuild) PatchBuild(buildName string, data []byte) (*v1alpha1.Build, error) {
+	bInterface := t.BuildClientSet.BuildV1alpha1().Builds(t.Namespace)
+	b, err := bInterface.Patch(buildName, types.MergePatchType, data)
 	if err != nil {
-		return build, err
+		return nil, err
 	}
-	return nil, nil
+	return b, nil
 }


### PR DESCRIPTION
Fixes #324 

This PR is the continuation of https://github.com/shipwright-io/build/pull/371 . I addressed all concerns there into this PR, and preserve @routerhan commits.

This PR replaces the finalizers approach we have in the Build -> BuildRun in favour of OwnerReferences for the same resources, aligning to the same approach as we have between BuildRuns -> TaskRuns. The PR have one commit for fixing go linters I found by using `staticcheck ./...`(I couldn´t avoid fixing this now)


@zhangtbj @HeavyWombat for your information:

_Note_: When dealing with OwnerReferences between the Build(owner) and BuildRun(owned), both controllers `Build` and `BuildRun` plays a role on ensuring that the BuildRun gets the Ownerreference or that the OwnerReference is removed. Following scenarios to consider:

> When the Build have the `build.build.dev/build-run-deletion` annotation set to `true`

For the above case, the Ownerreference is added during the `CREATION` event of a BuildRun, meaning on the `BuildRun` controller side.

> When the Build have the `build.build.dev/build-run-deletion` annotation set to `true`, but the user modifies the annotation and set this back to `false`.

For the above case, the Ownerreference needs to be removed during the `UPDATE` event of a Build, meaning we need logic on the `Build` controller reconciler side.

> When the Build have the `build.build.dev/build-run-deletion` annotation set to `true`, but the user modifies the annotation and set this back to `false`, but then the user changes his mind and modify it one more time, and set it back to the original value, `true`.

For the above case, the Ownerreference needs to be removed or added during the `UPDATE` event of a Build, meaning we need logic on the `Build` controller reconciler side. 


Also please consider that this PR have quite a lot of test cases, both unit-tests and integration-tests. I recommend you to read the integration tests ones.



