### PR TITLE
Add SETFCAP Linux capability for Kaniko buildstrategy

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -195,6 +195,7 @@ spec:
             - FOWNER
             - SETGID
             - SETUID
+            - SETFCAP
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
@@ -235,6 +236,7 @@ spec:
             - FOWNER
             - SETGID
             - SETUID
+            - SETFCAP
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker

--- a/pkg/controller/buildrun/runtime_image.go
+++ b/pkg/controller/buildrun/runtime_image.go
@@ -200,6 +200,7 @@ func runtimeBuildAndPushStep(b *buildv1alpha1.Build, kanikoImage string) *v1beta
 					v1.Capability("FOWNER"),
 					v1.Capability("SETGID"),
 					v1.Capability("SETUID"),
+					v1.Capability("SETFCAP"),
 				},
 			},
 		},

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -17,6 +17,7 @@ spec:
             - FOWNER
             - SETGID
             - SETUID
+            - SETFCAP
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -39,6 +39,7 @@ spec:
             - FOWNER
             - SETGID
             - SETUID
+            - SETFCAP
       volumeMounts:
         - mountPath: /gen-source
           name: gen-source


### PR DESCRIPTION
We had a customer problem when build a source code repo from: https://github.com/nheidloff/code-with-quarkus/blob/master/src/main/docker/Dockerfile.multistage

This build fail at the step `microdnf update`:

It will fail at step-step-build-and-push step, and the final error is:
```
...
Cleanup: libgcc;8.3.1-4.5.el8;x86_64;installed
Updating: (null)
Updating: (null)
error: Error -1 running transaction
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
```

Finally, I found the root cause. We didn't enable a Linux Capability `setfcap` in the Kaniko build strategy, without this permission, some system installations cannot work. I added it and test, the build works for me:
```
jordanzt@bogon:~/Works/workspaces/gopath/src/github.com/zhangtbj/code-with-quarkus$ kubectl get buildrun
NAME                 SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
microdnf-run-l7bpt   True        Succeeded   14m         12m
```

And the deployment which is based on this image also works fine, You can see my application screenshot below:
<img width="853" alt="b91fc780-027c-11eb-85b8-5553deca70ec" src="https://user-images.githubusercontent.com/18108042/94652255-4b32d900-032c-11eb-8ad8-3105c080a705.png">


Here is the introduction about this  setfcap Linux Capability:
```
       CAP_SETFCAP (since Linux 2.6.24)
              Set arbitrary capabilities on a file.
```
- In: https://man7.org/linux/man-pages/man7/capabilities.7.html

```
setfcap
Finally, the setfcap capability allows you to set file capabilities on a file system. Might be needed for doing installs during builds, but in production it should probably be dropped.
```
- In: https://www.redhat.com/en/blog/secure-your-containers-one-weird-trick

From the info, it is not very risky for us to enable this permission, it is just used to set file capabilities on a file system. And we also see some of the user cases are install something by using microdnf or apt-get, so it should be a **valid** scenario.

