### PR TITLE
Refactor config environment variable override code

### DIFF
--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -1,0 +1,17 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,91 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/shipwright-io/build/pkg/config"
+)
+
+var _ = Describe("Config", func() {
+	Context("obtaining the configuration for build", func() {
+		It("should create a default configuration with reasonable values", func() {
+			config := NewDefaultConfig()
+			Expect(config).ToNot(BeNil())
+		})
+
+		It("should allow for an override of the context timeout using an environment variable", func() {
+			var overrides = map[string]string{"CTX_TIMEOUT": "600"}
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(config.CtxTimeOut).To(Equal(600 * time.Second))
+			})
+		})
+
+		It("should allow for an override of the default Kaniko project image using an environment variable", func() {
+			var overrides = map[string]string{"KANIKO_CONTAINER_IMAGE": "gcr.io/kaniko-project/executor:v1.0.1"}
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(config.KanikoContainerImage).To(Equal("gcr.io/kaniko-project/executor:v1.0.1"))
+			})
+		})
+
+		It("should allow for an override of the Prometheus buckets settings using an environment variable", func() {
+			var overrides = map[string]string{
+				"PROMETHEUS_BR_COMP_DUR_BUCKETS":   "1,2,3,4",
+				"PROMETHEUS_BR_EST_DUR_BUCKETS":    "10,20,30,40",
+				"PROMETHEUS_BR_RAMPUP_DUR_BUCKETS": "1,2,3,5,8,12,20",
+			}
+
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(config.Prometheus.BuildRunCompletionDurationBuckets).To(Equal([]float64{1, 2, 3, 4}))
+				Expect(config.Prometheus.BuildRunEstablishDurationBuckets).To(Equal([]float64{10, 20, 30, 40}))
+				Expect(config.Prometheus.BuildRunRampUpDurationBuckets).To(Equal([]float64{1, 2, 3, 5, 8, 12, 20}))
+			})
+		})
+
+		It("should allow for an override of the Prometheus enabled labels using an environment variable", func() {
+			var overrides = map[string]string{"PROMETHEUS_HISTOGRAM_ENABLED_LABELS": "namespace,strategy"}
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(config.Prometheus.HistogramEnabledLabels).To(Equal([]string{"namespace", "strategy"}))
+			})
+		})
+	})
+})
+
+func configWithEnvVariableOverrides(settings map[string]string, f func(config *Config)) {
+	var backup = make(map[string]*string, len(settings))
+	for k, v := range settings {
+		value, ok := os.LookupEnv(k)
+		switch ok {
+		case true:
+			backup[k] = &value
+
+		case false:
+			backup[k] = nil
+		}
+
+		os.Setenv(k, v)
+	}
+
+	config := NewDefaultConfig()
+	Expect(config).ToNot(BeNil())
+
+	err := config.SetConfigFromEnv()
+	Expect(err).ToNot(HaveOccurred())
+
+	f(config)
+
+	for k, v := range backup {
+		if v != nil {
+			os.Setenv(k, *v)
+		} else {
+			os.Unsetenv(k)
+		}
+	}
+}


### PR DESCRIPTION
Over time, there was some code duplication accumulated for overriding
configuration settings using an environment variable.

Introduce one common function to do the float slice override.

Combine `os.Getenv` and `if` case into one line, where possible.

Introduce basic Ginkgo test suite.

Add test cases for the currently possible environment overrides.