### PR TITLE
Make build operator leader durations configurable 

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -109,7 +109,10 @@ func main() {
 	mgr, err := controller.NewManager(ctx, c, cfg, manager.Options{
 		LeaderElection:          true,
 		LeaderElectionID:        "build-operator-lock",
-		LeaderElectionNamespace: "default",
+		LeaderElectionNamespace: c.ManagerOptions.LeaderElectionNamespace,
+		LeaseDuration:           c.ManagerOptions.LeaseDuration,
+		RenewDeadline:           c.ManagerOptions.RenewDeadline,
+		RetryPeriod:             c.ManagerOptions.RetryPeriod,
 		Namespace:               "",
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -100,19 +100,19 @@ func main() {
 	}
 	defer r.Unset()
 
-	c := buildconfig.NewDefaultConfig()
-	if err := c.SetConfigFromEnv(); err != nil {
+	buildCfg := buildconfig.NewDefaultConfig()
+	if err := buildCfg.SetConfigFromEnv(); err != nil {
 		ctxlog.Error(ctx, err, "")
 		os.Exit(1)
 	}
 
-	mgr, err := controller.NewManager(ctx, c, cfg, manager.Options{
+	mgr, err := controller.NewManager(ctx, buildCfg, cfg, manager.Options{
 		LeaderElection:          true,
 		LeaderElectionID:        "build-operator-lock",
-		LeaderElectionNamespace: c.ManagerOptions.LeaderElectionNamespace,
-		LeaseDuration:           c.ManagerOptions.LeaseDuration,
-		RenewDeadline:           c.ManagerOptions.RenewDeadline,
-		RetryPeriod:             c.ManagerOptions.RetryPeriod,
+		LeaderElectionNamespace: buildCfg.ManagerOptions.LeaderElectionNamespace,
+		LeaseDuration:           buildCfg.ManagerOptions.LeaseDuration,
+		RenewDeadline:           buildCfg.ManagerOptions.RenewDeadline,
+		RetryPeriod:             buildCfg.ManagerOptions.RetryPeriod,
 		Namespace:               "",
 		MetricsBindAddress:      fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
@@ -123,7 +123,7 @@ func main() {
 
 	// Add the Metrics Service
 	addMetrics(ctx, cfg, namespace)
-	buildMetrics.InitPrometheus(c)
+	buildMetrics.InitPrometheus(buildCfg)
 
 	ctxlog.Info(ctx, "Starting the Cmd.")
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,6 +25,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: BUILD_OPERATOR_LEADER_ELECTION_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,20 @@
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Configuration
+
+The `build-operator` is installed into Kubernetes with reasonable defaults. However, there are some settings that can be overridden using environment variables in [`operator.yaml`](../deploy/operator.yaml).
+
+The following environment variables are available:
+
+| Environment Variable | Description |
+| --- | --- |
+| `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. |
+| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used instead of the default, for example `gcr.io/kaniko-project/executor:v1.0.1`. |
+| `BUILD_OPERATOR_LEADER_ELECTION_NAMESPACE` |  Set the namespace to be used to store the `build-operator` lock, by default it is in the same namespace as the operator itself. |
+| `BUILD_OPERATOR_LEASE_DURATION` |  Override the `LeaseDuration`, which is the duration that non-leader candidates will wait to force acquire leadership. |
+| `BUILD_OPERATOR_RENEW_DEADLINE` |  Override the `RenewDeadline`, which is the duration that the acting master will retry refreshing leadership before giving up. |
+| `BUILD_OPERATOR_RETRY_PERIOD` |  Override the `RetryPeriod`, which is the duration the LeaderElector clients should wait between tries of actions. |

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -55,6 +55,27 @@ var _ = Describe("Config", func() {
 				Expect(config.Prometheus.HistogramEnabledLabels).To(Equal([]string{"namespace", "strategy"}))
 			})
 		})
+
+		It("should allow for an override of the operator leader election namespace using an environment variable", func() {
+			var overrides = map[string]string{"BUILD_OPERATOR_LEADER_ELECTION_NAMESPACE": "build-operator"}
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(config.ManagerOptions.LeaderElectionNamespace).To(Equal("build-operator"))
+			})
+		})
+
+		It("should allow for an override of the operator leader election times using environment variables", func() {
+			var overrides = map[string]string{
+				"BUILD_OPERATOR_LEASE_DURATION": "42s",
+				"BUILD_OPERATOR_RENEW_DEADLINE": "32s",
+				"BUILD_OPERATOR_RETRY_PERIOD":   "10s",
+			}
+
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(*config.ManagerOptions.LeaseDuration).To(Equal(time.Duration(42 * time.Second)))
+				Expect(*config.ManagerOptions.RenewDeadline).To(Equal(time.Duration(32 * time.Second)))
+				Expect(*config.ManagerOptions.RetryPeriod).To(Equal(time.Duration(10 * time.Second)))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
In case the build operator needs to be started with very specific leader
lease duration configuration, there is currently no way to configure it.

Introduce new section in build configuration that contains some of the
manager options to be configurable and passed through to the manager.

Pass new section values as-is into the manager options for the build
operator setup. Any `nil` value will result in the default value.

Add four new environment variables to override these settings:
- `BUILD_OPERATOR_LEADER_ELECTION_NAMESPACE`
- `BUILD_OPERATOR_LEASE_DURATION`
- `BUILD_OPERATOR_RENEW_DEADLINE`
- `BUILD_OPERATOR_RETRY_PERIOD`

_Please note:_ All duration based environment variables use the time duration
parse function, so they expect an input like `42s`.

This should fix #414.