### PR TITLE
Move to Paketo `full` tag builder image

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -69,7 +69,8 @@ The [buildpacks-v3][buildpacks] BuildStrategy/ClusterBuildStrategy uses a Cloud 
 
 - [`heroku/buildpacks:18`][hubheroku]
 - [`cloudfoundry/cnb:bionic`][hubcloudfoundry]
-- [`docker.io/paketobuildpacks/builder:latest`](https://hub.docker.com/r/paketobuildpacks/builder/tags)
+- [`docker.io/paketobuildpacks/builder:full`](https://hub.docker.com/r/paketobuildpacks/builder/tags)
+
 
 ### Installing Buildpacks v3 Strategy
 

--- a/docs/proposals/buildstrategy-steps-resources.md
+++ b/docs/proposals/buildstrategy-steps-resources.md
@@ -159,7 +159,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-prepare
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 0
         capabilities:
@@ -179,7 +179,7 @@ spec:
           cpu: "10m"
           memory: "128Mi"
     - name: step-detect
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -199,7 +199,7 @@ spec:
           cpu: "250m"
           memory: "50Mi"
     - name: step-restore
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -214,7 +214,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-build
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -235,7 +235,7 @@ spec:
           cpu: "500m"
           memory: "1Gi"
     - name: step-export
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-prepare
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 0
         capabilities:
@@ -26,7 +26,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: step-detect
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -46,7 +46,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-restore
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -68,7 +68,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-build
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -89,7 +89,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-export
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-prepare
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 0
         capabilities:
@@ -26,7 +26,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: step-detect
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -46,7 +46,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-restore
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -68,7 +68,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-build
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:
@@ -89,7 +89,7 @@ spec:
         - name: layers-dir
           mountPath: /layers
     - name: step-export
-      image: docker.io/paketobuildpacks/builder:latest
+      image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
       command:


### PR DESCRIPTION
This is a follow up from https://github.com/shipwright-io/build/pull/406

I tested if the container images that we build with Paketo can be deployed
with the bionic stack via [test branch](https://github.com/qu1queee/build/commit/6ff4ece927e9d030fa57bcacff5a437c0aea14e5).

Moving from `builder:latest` to `builder:full` means that we are gonna stop
running on top of a cflinuxfs3 stack in favor of a bionic stack.

Paketo community mentioned that the bionic stack have parity with cflinuxfs3,
therefore this is a safe change, plus the deployment validations I did.