### PR TITLE
Bring Kaniko version and arguments in sync

### DIFF
--- a/pkg/controller/buildrun/runtime_image.go
+++ b/pkg/controller/buildrun/runtime_image.go
@@ -216,6 +216,7 @@ func runtimeBuildAndPushStep(b *buildv1alpha1.Build, kanikoImage string) *v1beta
 			fmt.Sprintf("--context=%x", path.Join(workspaceDir, contextDir)),
 			fmt.Sprintf("--destination=%s", b.Spec.Output.ImageURL),
 			"--snapshotMode=redo",
+			"--oci-layout-path=/workspace/output/image",
 		},
 	}
 	return &v1beta1.Step{Container: container}

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -22,12 +22,14 @@ spec:
         - '--dockerfile=/gen-source/Dockerfile.gen'
         - '--context=/gen-source'
         - '--destination=$(build.output.image)'
+        - '--oci-layout-path=/workspace/output/image'
+        - '--snapshotMode=redo'
       command:
         - /kaniko/executor
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
-      image: 'gcr.io/kaniko-project/executor:v0.19.0'
+      image: gcr.io/kaniko-project/executor:v1.0.0
       name: step-build-and-push
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
In my recent [Kaniko-related PR](https://github.com/shipwright-io/build/pull/401) where I upleveled it to v1.0.0, I forgot the s2i build strategy and also missed to add the `--oci-layout-path` argument to the runtime image support. Correcting this with this PR.