### PR TITLE
Upgrade Kaniko builder image to v1.2.0

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -185,7 +185,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v0.23.0
+      image: gcr.io/kaniko-project/executor:v1.2.0
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -226,7 +226,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v0.23.0
+      image: gcr.io/kaniko-project/executor:v1.2.0
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,9 +19,7 @@ const (
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
 	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
-	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.0.0"
-	// kanikoImageEnvVar environment variable for Kaniko container image, for instance:
-	// KANIKO_CONTAINER_IMAGE="gcr.io/kaniko-project/executor:v0.24.0"
+	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.2.0"
 	kanikoImageEnvVar = "KANIKO_CONTAINER_IMAGE"
 
 	// environment variable to override the buckets

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.0.0
+      image: gcr.io/kaniko-project/executor:v1.2.0
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -29,7 +29,7 @@ spec:
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
-      image: gcr.io/kaniko-project/executor:v1.0.0
+      image: gcr.io/kaniko-project/executor:v1.2.0
       name: step-build-and-push
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
Upgrade Kaniko builder image to v1.2.0 in all build strategies and document.