### PR TITLE
Remove unused builder image

### DIFF
--- a/test/data/build_buildpacks-v3_nodejs_runtime-image_cr.yaml
+++ b/test/data/build_buildpacks-v3_nodejs_runtime-image_cr.yaml
@@ -9,8 +9,6 @@ spec:
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy
-  builder:
-    image: heroku/buildpacks:18
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/nodejs-ex:runtime
   runtime:


### PR DESCRIPTION
In buildpacks build strategy, we have removed the support for the builder image. I am removing the builder image from one test build definition where we forgot to remove it.