### PR TITLE
Wire test variables through e2e lib code

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -86,7 +86,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	// initialize cluster resources
 	Logf("Initializing cluster resources")
-	err = globalCtx.InitializeClusterResources(cleanupOptions(globalCtx))
+	err = globalCtx.InitializeClusterResources(cleanupOptions(globalCtx, cleanupTimeout, cleanupRetryInterval))
 	Expect(err).ToNot(HaveOccurred(), "unable to initialize cluster resources")
 
 	// get the namespace
@@ -116,11 +116,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	// create the pipeline service account
 	Logf("Creating the pipeline service account")
-	createPipelineServiceAccount(globalCtx, f, namespace)
+	createPipelineServiceAccount(globalCtx, f, namespace, cleanupTimeout, cleanupRetryInterval)
 
 	// create the container registry secret
 	Logf("Creating the container registry secret")
-	createContainerRegistrySecret(globalCtx, f, namespace)
+	createContainerRegistrySecret(globalCtx, f, namespace, cleanupTimeout, cleanupRetryInterval)
 
 	if os.Getenv(EnvVarCreateGlobalObjects) == "true" {
 		// create cluster build strategies
@@ -131,7 +131,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			Expect(err).ToNot(HaveOccurred())
 			cbs.SetNamespace(namespace)
 
-			createClusterBuildStrategy(globalCtx, f, cbs)
+			createClusterBuildStrategy(globalCtx, f, cbs, cleanupTimeout, cleanupRetryInterval)
 		}
 
 		// create namespace build strategies
@@ -141,7 +141,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			nbs, err := buildStrategyTestData(namespace, namespaceBuildStrategy)
 			Expect(err).ToNot(HaveOccurred())
 
-			createNamespacedBuildStrategy(globalCtx, f, nbs)
+			createNamespacedBuildStrategy(globalCtx, f, nbs, cleanupTimeout, cleanupRetryInterval)
 		}
 	} else {
 		Logf("Build strategy creation skipped.")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -43,14 +43,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildah")
 
 			// create the build definition
-			createBuild(namespace, testID, "samples/build/build_buildah_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"samples/build/build_buildah_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -60,14 +66,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildah-custom-context-dockerfile")
 
 			// create the build definition
-			createBuild(namespace, testID, "test/data/build_buildah_cr_custom_context+dockerfile.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_buildah_cr_custom_context+dockerfile.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			validateBuildDeletion(namespace, testID, br, false)
 		})
 	})
@@ -78,14 +90,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildpacks-v3-heroku")
 
 			// create the build definition
-			createBuild(namespace, testID, "samples/build/build_buildpacks-v3-heroku_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"samples/build/build_buildpacks-v3-heroku_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -95,14 +113,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildpacks-v3-heroku-namespaced")
 
 			// create the build definition
-			createBuild(namespace, testID, "samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -112,14 +136,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildpacks-v3")
 
 			// create the build definition
-			createBuild(namespace, testID, "samples/build/build_buildpacks-v3_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"samples/build/build_buildpacks-v3_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			validateBuildDeletion(namespace, testID, br, false)
 		})
 	})
@@ -130,14 +160,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildpacks-v3-namespaced")
 
 			// create the build definition
-			createBuild(namespace, testID, "samples/build/build_buildpacks-v3_namespaced_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"samples/build/build_buildpacks-v3_namespaced_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -147,14 +183,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildpacks-v3-php")
 
 			// create the build definition
-			createBuild(namespace, testID, "test/data/build_buildpacks-v3_php_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_buildpacks-v3_php_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_php_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -164,14 +206,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildpacks-v3-golang")
 
 			// create the build definition
-			createBuild(namespace, testID, "test/data/build_buildpacks-v3_golang_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_buildpacks-v3_golang_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -181,14 +229,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("buildpacks-v3-java")
 
 			// create the build definition
-			createBuild(namespace, testID, "test/data/build_buildpacks-v3_java_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_buildpacks-v3_java_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_java_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -197,14 +251,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-nodejs-ex-runtime")
 
-			createBuild(namespace, testID, "test/data/build_buildpacks-v3_nodejs_runtime-image_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_buildpacks-v3_nodejs_runtime-image_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_nodejs_runtime-image_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -214,14 +274,14 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("kaniko")
 
 			// create the build definition
-			createBuild(namespace, testID, "samples/build/build_kaniko_cr.yaml")
+			createBuild(ctx, namespace, testID, "samples/build/build_kaniko_cr.yaml", cleanupTimeout, cleanupRetryInterval)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_kaniko_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			validateBuildDeletion(namespace, testID, br, true)
 		})
 	})
@@ -232,14 +292,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("kaniko-advanced-dockerfile")
 
 			// create the build definition
-			createBuild(namespace, testID, "test/data/build_kaniko_cr_advanced_dockerfile.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_kaniko_cr_advanced_dockerfile.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -249,14 +315,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("kaniko-custom-context-dockerfile")
 
 			// create the build definition
-			createBuild(namespace, testID, "test/data/build_kaniko_cr_custom_context+dockerfile.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_kaniko_cr_custom_context+dockerfile.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -266,14 +338,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("kaniko-timeout")
 
 			// create the build definition
-			createBuild(namespace, testID, "test/data/build_timeout.yaml")
+			createBuild(ctx, namespace, testID, "test/data/build_timeout.yaml", cleanupTimeout, cleanupRetryInterval)
 		})
 
 		It("fails the build run", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_timeout.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToFail(namespace, br, "kaniko-timeout.*failed to finish within \"15s\"")
+			validateBuildRunToFail(ctx,
+				namespace,
+				br,
+				"kaniko-timeout.*failed to finish within \"15s\"",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 	})
 
@@ -283,14 +361,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			testID = generateTestID("s2i")
 
 			// create the build definition
-			createBuild(namespace, testID, "samples/build/build_source-to-image_cr.yaml")
+			createBuild(ctx,
+				namespace,
+				testID,
+				"samples/build/build_source-to-image_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
 		})
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_source-to-image_cr.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
-			validateBuildRunToSucceed(namespace, br)
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
 	})
 
@@ -308,14 +392,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				testID = generateTestID("private-github-buildah")
 
 				// create the build definition
-				createBuild(namespace, testID, "test/data/build_buildah_cr_private_github.yaml")
+				createBuild(ctx,
+					namespace,
+					testID,
+					"test/data/build_buildah_cr_private_github.yaml",
+					cleanupTimeout,
+					cleanupRetryInterval,
+				)
 			})
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
-				validateBuildRunToSucceed(namespace, br)
+				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})
 		})
 
@@ -325,14 +415,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				testID = generateTestID("private-gitlab-buildah")
 
 				// create the build definition
-				createBuild(namespace, testID, "test/data/build_buildah_cr_private_gitlab.yaml")
+				createBuild(ctx,
+					namespace,
+					testID,
+					"test/data/build_buildah_cr_private_gitlab.yaml",
+					cleanupTimeout,
+					cleanupRetryInterval,
+				)
 			})
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
-				validateBuildRunToSucceed(namespace, br)
+				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})
 		})
 
@@ -342,14 +438,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				testID = generateTestID("private-github-kaniko")
 
 				// create the build definition
-				createBuild(namespace, testID, "test/data/build_kaniko_cr_private_github.yaml")
+				createBuild(ctx,
+					namespace,
+					testID,
+					"test/data/build_kaniko_cr_private_github.yaml",
+					cleanupTimeout,
+					cleanupRetryInterval,
+				)
 			})
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
-				validateBuildRunToSucceed(namespace, br)
+				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})
 		})
 
@@ -359,14 +461,19 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				testID = generateTestID("private-gitlab-kaniko")
 
 				// create the build definition
-				createBuild(namespace, testID, "test/data/build_kaniko_cr_private_gitlab.yaml")
+				createBuild(ctx,
+					namespace,
+					testID,
+					"test/data/build_kaniko_cr_private_gitlab.yaml",
+					cleanupTimeout,
+					cleanupRetryInterval)
 			})
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_kaniko_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
-				validateBuildRunToSucceed(namespace, br)
+				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})
 		})
 
@@ -376,14 +483,20 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				testID = generateTestID("private-github-s2i")
 
 				// create the build definition
-				createBuild(namespace, testID, "test/data/build_source-to-image_cr_private_github.yaml")
+				createBuild(ctx,
+					namespace,
+					testID,
+					"test/data/build_source-to-image_cr_private_github.yaml",
+					cleanupTimeout,
+					cleanupRetryInterval,
+				)
 			})
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_source-to-image_cr.yaml")
 				Expect(err).ToNot(HaveOccurred())
 
-				validateBuildRunToSucceed(namespace, br)
+				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})
 		})
 	})

--- a/test/e2e/samples.go
+++ b/test/e2e/samples.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"knative.dev/pkg/apis"
 
@@ -82,7 +83,7 @@ func amendBuild(identifier string, b *operator.Build) {
 
 // CreateBuild loads the builds definition from the file path, unifies the output image based on
 // the identifier and creates it in a namespace
-func createBuild(namespace string, identifier string, filePath string) {
+func createBuild(ctx *framework.Context, namespace string, identifier string, filePath string, timeout time.Duration, retry time.Duration) {
 	Logf("Creating build %s", identifier)
 
 	rootDir, err := getRootDir()
@@ -94,7 +95,7 @@ func createBuild(namespace string, identifier string, filePath string) {
 	amendBuild(identifier, b)
 
 	f := framework.Global
-	err = f.Client.Create(context.TODO(), b, cleanupOptions(ctx))
+	err = f.Client.Create(context.TODO(), b, cleanupOptions(ctx, timeout, retry))
 	Expect(err).ToNot(HaveOccurred(), "Unable to create build %s", identifier)
 
 	Logf("Build %s created", identifier)


### PR DESCRIPTION
Files without the `_test.go` suffix are compiled as "normal" go code in
IDEs like VSCode. This can lead to spurious compile errors if the normal
code references variables in test code.

Updating the library code in `samples.go` and `validators.go` to accept
test variables as arguments in function calls. Wired test arguments
through to library functions.