### PR TITLE
Add user group ID for each buildpack step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ generate:
 verify-codegen: generate
 	# TODO: Fix travis issue with ginkgo install updating go.mod and go.sum
 	# TODO: Verify vendor tree is accurate
-	# git diff --quiet -- ':(exclude)go.mod' ':(exclude)go.sum' ':(exclude)vendor/*'
+	git diff --quiet -- ':(exclude)go.mod' ':(exclude)go.sum' ':(exclude)vendor/*'
 
 install-ginkgo:
 	go get -u github.com/onsi/ginkgo/ginkgo

--- a/pkg/controller/fakes/client.go
+++ b/pkg/controller/fakes/client.go
@@ -128,15 +128,16 @@ func (fake *FakeClient) Create(arg1 context.Context, arg2 runtime.Object, arg3 .
 		arg2 runtime.Object
 		arg3 []client.CreateOption
 	}{arg1, arg2, arg3})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1
 }
 
@@ -190,15 +191,16 @@ func (fake *FakeClient) Delete(arg1 context.Context, arg2 runtime.Object, arg3 .
 		arg2 runtime.Object
 		arg3 []client.DeleteOption
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1, arg2, arg3})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 
@@ -252,15 +254,16 @@ func (fake *FakeClient) DeleteAllOf(arg1 context.Context, arg2 runtime.Object, a
 		arg2 runtime.Object
 		arg3 []client.DeleteAllOfOption
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteAllOfStub
+	fakeReturns := fake.deleteAllOfReturns
 	fake.recordInvocation("DeleteAllOf", []interface{}{arg1, arg2, arg3})
 	fake.deleteAllOfMutex.Unlock()
-	if fake.DeleteAllOfStub != nil {
-		return fake.DeleteAllOfStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteAllOfReturns
 	return fakeReturns.result1
 }
 
@@ -314,15 +317,16 @@ func (fake *FakeClient) Get(arg1 context.Context, arg2 types.NamespacedName, arg
 		arg2 types.NamespacedName
 		arg3 runtime.Object
 	}{arg1, arg2, arg3})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1
 }
 
@@ -376,15 +380,16 @@ func (fake *FakeClient) List(arg1 context.Context, arg2 runtime.Object, arg3 ...
 		arg2 runtime.Object
 		arg3 []client.ListOption
 	}{arg1, arg2, arg3})
+	stub := fake.ListStub
+	fakeReturns := fake.listReturns
 	fake.recordInvocation("List", []interface{}{arg1, arg2, arg3})
 	fake.listMutex.Unlock()
-	if fake.ListStub != nil {
-		return fake.ListStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.listReturns
 	return fakeReturns.result1
 }
 
@@ -439,15 +444,16 @@ func (fake *FakeClient) Patch(arg1 context.Context, arg2 runtime.Object, arg3 cl
 		arg3 client.Patch
 		arg4 []client.PatchOption
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchStub
+	fakeReturns := fake.patchReturns
 	fake.recordInvocation("Patch", []interface{}{arg1, arg2, arg3, arg4})
 	fake.patchMutex.Unlock()
-	if fake.PatchStub != nil {
-		return fake.PatchStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchReturns
 	return fakeReturns.result1
 }
 
@@ -498,15 +504,16 @@ func (fake *FakeClient) Status() client.StatusWriter {
 	ret, specificReturn := fake.statusReturnsOnCall[len(fake.statusArgsForCall)]
 	fake.statusArgsForCall = append(fake.statusArgsForCall, struct {
 	}{})
+	stub := fake.StatusStub
+	fakeReturns := fake.statusReturns
 	fake.recordInvocation("Status", []interface{}{})
 	fake.statusMutex.Unlock()
-	if fake.StatusStub != nil {
-		return fake.StatusStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.statusReturns
 	return fakeReturns.result1
 }
 
@@ -553,15 +560,16 @@ func (fake *FakeClient) Update(arg1 context.Context, arg2 runtime.Object, arg3 .
 		arg2 runtime.Object
 		arg3 []client.UpdateOption
 	}{arg1, arg2, arg3})
+	stub := fake.UpdateStub
+	fakeReturns := fake.updateReturns
 	fake.recordInvocation("Update", []interface{}{arg1, arg2, arg3})
 	fake.updateMutex.Unlock()
-	if fake.UpdateStub != nil {
-		return fake.UpdateStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateReturns
 	return fakeReturns.result1
 }
 

--- a/pkg/controller/fakes/manager.go
+++ b/pkg/controller/fakes/manager.go
@@ -177,15 +177,16 @@ func (fake *FakeManager) Add(arg1 manager.Runnable) error {
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
 		arg1 manager.Runnable
 	}{arg1})
+	stub := fake.AddStub
+	fakeReturns := fake.addReturns
 	fake.recordInvocation("Add", []interface{}{arg1})
 	fake.addMutex.Unlock()
-	if fake.AddStub != nil {
-		return fake.AddStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addReturns
 	return fakeReturns.result1
 }
 
@@ -238,15 +239,16 @@ func (fake *FakeManager) AddHealthzCheck(arg1 string, arg2 healthz.Checker) erro
 		arg1 string
 		arg2 healthz.Checker
 	}{arg1, arg2})
+	stub := fake.AddHealthzCheckStub
+	fakeReturns := fake.addHealthzCheckReturns
 	fake.recordInvocation("AddHealthzCheck", []interface{}{arg1, arg2})
 	fake.addHealthzCheckMutex.Unlock()
-	if fake.AddHealthzCheckStub != nil {
-		return fake.AddHealthzCheckStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addHealthzCheckReturns
 	return fakeReturns.result1
 }
 
@@ -299,15 +301,16 @@ func (fake *FakeManager) AddReadyzCheck(arg1 string, arg2 healthz.Checker) error
 		arg1 string
 		arg2 healthz.Checker
 	}{arg1, arg2})
+	stub := fake.AddReadyzCheckStub
+	fakeReturns := fake.addReadyzCheckReturns
 	fake.recordInvocation("AddReadyzCheck", []interface{}{arg1, arg2})
 	fake.addReadyzCheckMutex.Unlock()
-	if fake.AddReadyzCheckStub != nil {
-		return fake.AddReadyzCheckStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addReadyzCheckReturns
 	return fakeReturns.result1
 }
 
@@ -358,15 +361,16 @@ func (fake *FakeManager) GetAPIReader() client.Reader {
 	ret, specificReturn := fake.getAPIReaderReturnsOnCall[len(fake.getAPIReaderArgsForCall)]
 	fake.getAPIReaderArgsForCall = append(fake.getAPIReaderArgsForCall, struct {
 	}{})
+	stub := fake.GetAPIReaderStub
+	fakeReturns := fake.getAPIReaderReturns
 	fake.recordInvocation("GetAPIReader", []interface{}{})
 	fake.getAPIReaderMutex.Unlock()
-	if fake.GetAPIReaderStub != nil {
-		return fake.GetAPIReaderStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getAPIReaderReturns
 	return fakeReturns.result1
 }
 
@@ -410,15 +414,16 @@ func (fake *FakeManager) GetCache() cache.Cache {
 	ret, specificReturn := fake.getCacheReturnsOnCall[len(fake.getCacheArgsForCall)]
 	fake.getCacheArgsForCall = append(fake.getCacheArgsForCall, struct {
 	}{})
+	stub := fake.GetCacheStub
+	fakeReturns := fake.getCacheReturns
 	fake.recordInvocation("GetCache", []interface{}{})
 	fake.getCacheMutex.Unlock()
-	if fake.GetCacheStub != nil {
-		return fake.GetCacheStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getCacheReturns
 	return fakeReturns.result1
 }
 
@@ -462,15 +467,16 @@ func (fake *FakeManager) GetClient() client.Client {
 	ret, specificReturn := fake.getClientReturnsOnCall[len(fake.getClientArgsForCall)]
 	fake.getClientArgsForCall = append(fake.getClientArgsForCall, struct {
 	}{})
+	stub := fake.GetClientStub
+	fakeReturns := fake.getClientReturns
 	fake.recordInvocation("GetClient", []interface{}{})
 	fake.getClientMutex.Unlock()
-	if fake.GetClientStub != nil {
-		return fake.GetClientStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getClientReturns
 	return fakeReturns.result1
 }
 
@@ -514,15 +520,16 @@ func (fake *FakeManager) GetConfig() *rest.Config {
 	ret, specificReturn := fake.getConfigReturnsOnCall[len(fake.getConfigArgsForCall)]
 	fake.getConfigArgsForCall = append(fake.getConfigArgsForCall, struct {
 	}{})
+	stub := fake.GetConfigStub
+	fakeReturns := fake.getConfigReturns
 	fake.recordInvocation("GetConfig", []interface{}{})
 	fake.getConfigMutex.Unlock()
-	if fake.GetConfigStub != nil {
-		return fake.GetConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getConfigReturns
 	return fakeReturns.result1
 }
 
@@ -567,15 +574,16 @@ func (fake *FakeManager) GetEventRecorderFor(arg1 string) record.EventRecorder {
 	fake.getEventRecorderForArgsForCall = append(fake.getEventRecorderForArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetEventRecorderForStub
+	fakeReturns := fake.getEventRecorderForReturns
 	fake.recordInvocation("GetEventRecorderFor", []interface{}{arg1})
 	fake.getEventRecorderForMutex.Unlock()
-	if fake.GetEventRecorderForStub != nil {
-		return fake.GetEventRecorderForStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getEventRecorderForReturns
 	return fakeReturns.result1
 }
 
@@ -626,15 +634,16 @@ func (fake *FakeManager) GetFieldIndexer() client.FieldIndexer {
 	ret, specificReturn := fake.getFieldIndexerReturnsOnCall[len(fake.getFieldIndexerArgsForCall)]
 	fake.getFieldIndexerArgsForCall = append(fake.getFieldIndexerArgsForCall, struct {
 	}{})
+	stub := fake.GetFieldIndexerStub
+	fakeReturns := fake.getFieldIndexerReturns
 	fake.recordInvocation("GetFieldIndexer", []interface{}{})
 	fake.getFieldIndexerMutex.Unlock()
-	if fake.GetFieldIndexerStub != nil {
-		return fake.GetFieldIndexerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getFieldIndexerReturns
 	return fakeReturns.result1
 }
 
@@ -678,15 +687,16 @@ func (fake *FakeManager) GetRESTMapper() meta.RESTMapper {
 	ret, specificReturn := fake.getRESTMapperReturnsOnCall[len(fake.getRESTMapperArgsForCall)]
 	fake.getRESTMapperArgsForCall = append(fake.getRESTMapperArgsForCall, struct {
 	}{})
+	stub := fake.GetRESTMapperStub
+	fakeReturns := fake.getRESTMapperReturns
 	fake.recordInvocation("GetRESTMapper", []interface{}{})
 	fake.getRESTMapperMutex.Unlock()
-	if fake.GetRESTMapperStub != nil {
-		return fake.GetRESTMapperStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getRESTMapperReturns
 	return fakeReturns.result1
 }
 
@@ -730,15 +740,16 @@ func (fake *FakeManager) GetScheme() *runtime.Scheme {
 	ret, specificReturn := fake.getSchemeReturnsOnCall[len(fake.getSchemeArgsForCall)]
 	fake.getSchemeArgsForCall = append(fake.getSchemeArgsForCall, struct {
 	}{})
+	stub := fake.GetSchemeStub
+	fakeReturns := fake.getSchemeReturns
 	fake.recordInvocation("GetScheme", []interface{}{})
 	fake.getSchemeMutex.Unlock()
-	if fake.GetSchemeStub != nil {
-		return fake.GetSchemeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getSchemeReturns
 	return fakeReturns.result1
 }
 
@@ -782,15 +793,16 @@ func (fake *FakeManager) GetWebhookServer() *webhook.Server {
 	ret, specificReturn := fake.getWebhookServerReturnsOnCall[len(fake.getWebhookServerArgsForCall)]
 	fake.getWebhookServerArgsForCall = append(fake.getWebhookServerArgsForCall, struct {
 	}{})
+	stub := fake.GetWebhookServerStub
+	fakeReturns := fake.getWebhookServerReturns
 	fake.recordInvocation("GetWebhookServer", []interface{}{})
 	fake.getWebhookServerMutex.Unlock()
-	if fake.GetWebhookServerStub != nil {
-		return fake.GetWebhookServerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getWebhookServerReturns
 	return fakeReturns.result1
 }
 
@@ -835,15 +847,16 @@ func (fake *FakeManager) SetFields(arg1 interface{}) error {
 	fake.setFieldsArgsForCall = append(fake.setFieldsArgsForCall, struct {
 		arg1 interface{}
 	}{arg1})
+	stub := fake.SetFieldsStub
+	fakeReturns := fake.setFieldsReturns
 	fake.recordInvocation("SetFields", []interface{}{arg1})
 	fake.setFieldsMutex.Unlock()
-	if fake.SetFieldsStub != nil {
-		return fake.SetFieldsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setFieldsReturns
 	return fakeReturns.result1
 }
 
@@ -895,15 +908,16 @@ func (fake *FakeManager) Start(arg1 <-chan struct{}) error {
 	fake.startArgsForCall = append(fake.startArgsForCall, struct {
 		arg1 <-chan struct{}
 	}{arg1})
+	stub := fake.StartStub
+	fakeReturns := fake.startReturns
 	fake.recordInvocation("Start", []interface{}{arg1})
 	fake.startMutex.Unlock()
-	if fake.StartStub != nil {
-		return fake.StartStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.startReturns
 	return fakeReturns.result1
 }
 

--- a/pkg/controller/fakes/status_writer.go
+++ b/pkg/controller/fakes/status_writer.go
@@ -53,15 +53,16 @@ func (fake *FakeStatusWriter) Patch(arg1 context.Context, arg2 runtime.Object, a
 		arg3 client.Patch
 		arg4 []client.PatchOption
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchStub
+	fakeReturns := fake.patchReturns
 	fake.recordInvocation("Patch", []interface{}{arg1, arg2, arg3, arg4})
 	fake.patchMutex.Unlock()
-	if fake.PatchStub != nil {
-		return fake.PatchStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchReturns
 	return fakeReturns.result1
 }
 
@@ -115,15 +116,16 @@ func (fake *FakeStatusWriter) Update(arg1 context.Context, arg2 runtime.Object, 
 		arg2 runtime.Object
 		arg3 []client.UpdateOption
 	}{arg1, arg2, arg3})
+	stub := fake.UpdateStub
+	fakeReturns := fake.updateReturns
 	fake.recordInvocation("Update", []interface{}{arg1, arg2, arg3})
 	fake.updateMutex.Unlock()
-	if fake.UpdateStub != nil {
-		return fake.UpdateStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateReturns
 	return fakeReturns.result1
 }
 

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -29,6 +29,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/detector
       args:
@@ -49,6 +50,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/restorer
       args:
@@ -71,6 +73,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/builder
       args:
@@ -92,6 +95,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/exporter
       args:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -29,6 +29,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/detector
       args:
@@ -49,6 +50,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/restorer
       args:
@@ -71,6 +73,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/builder
       args:
@@ -92,6 +95,7 @@ spec:
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
         - /cnb/lifecycle/exporter
       args:


### PR DESCRIPTION
Fix issue: https://github.com/shipwright-io/build/issues/450

Now, paketo builder image is consuming lifecycle `0.9.2` version. When switch to 0.9.2, restore step failed because exec as user 1000:1000: operation not permitted.

About this issue, I discuss with community and go through changes between lifecycle `0.9.1` and `0.9.2`. Role error has been [bubbled up](https://github.com/buildpacks/lifecycle/compare/v0.9.1...v0.9.2#diff-73763e61f2242eb741045f9665ef775d854ec4f0ed00d18d6ad6518d0833f6b3R45). Before this error indeed exists, but just doesn't been thrown out. So we should specify the group ID, otherwise, each step will fail because exec as user 1000:1000: operation not permitted.

I have verified and this solution works.

Besides, below change just a revert operation for this [pr](https://github.com/shipwright-io/build/pull/447) :
```
git diff --quiet -- ':(exclude)go.mod' ':(exclude)go.sum' ':(exclude)vendor/*'
```