### PR TITLE
Refactor metrics observe calls to report metrics as soon as possible

### DIFF
--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -211,7 +211,9 @@ var _ = Describe("Reconcile BuildRun", func() {
 			It("deletes a generated service account when the task run ends", func() {
 
 				// setup a buildrun to use a generated service account
+				buildSample = ctl.DefaultBuild(buildName, "foobar-strategy", build.ClusterBuildStrategyKind)
 				buildRunSample = ctl.BuildRunWithSAGenerate(buildRunSample.Name, buildName)
+				buildRunSample.Status.BuildSpec = &buildSample.Spec
 				buildRunSample.Labels = make(map[string]string)
 				buildRunSample.Labels[build.LabelBuild] = buildName
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -9,12 +9,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	io_prometheus_client "github.com/prometheus/client_model/go"
-
-	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
-
-	"github.com/shipwright-io/build/pkg/config"
 	. "github.com/shipwright-io/build/pkg/metrics"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/shipwright-io/build/pkg/config"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var _ = Describe("Custom Metrics", func() {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Custom Metrics", func() {
 				"build_builds_registered_total",
 			}
 
-			knownHistrogramMetrics = []string{
+			knownHistogramMetrics = []string{
 				"build_buildrun_establish_duration_seconds",
 				"build_buildrun_completion_duration_seconds",
 				"build_buildrun_rampup_duration_seconds",
@@ -63,17 +63,17 @@ var _ = Describe("Custom Metrics", func() {
 			}
 		)
 
-		// initialise the counter metrics result map with empty maps
+		// initialize the counter metrics result map with empty maps
 		for _, name := range knownCounterMetrics {
 			counterMetrics[name] = map[string]float64{}
 		}
 
-		// initialise the histrogram metrics result map with empty maps
-		for _, name := range knownHistrogramMetrics {
+		// initialize the histogram metrics result map with empty maps
+		for _, name := range knownHistogramMetrics {
 			histogramMetrics[name] = map[buildRunLabels]float64{}
 		}
 
-		// initialise prometheus (second init should be no-op)
+		// initialize prometheus (second init should be no-op)
 		config := config.NewDefaultConfig()
 		config.Prometheus.HistogramEnabledLabels = []string{"buildstrategy", "namespace"}
 		InitPrometheus(config)

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -480,6 +480,11 @@ func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, n
 					},
 				},
 			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				StartTime: &metav1.Time{
+					Time: time.Now(),
+				},
+			},
 		},
 	}
 }
@@ -536,6 +541,11 @@ func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName stri
 						Status:  corev1.ConditionFalse,
 						Message: "some message",
 					},
+				},
+			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				StartTime: &metav1.Time{
+					Time: time.Now(),
 				},
 			},
 		},
@@ -622,6 +632,7 @@ func (c *Catalog) DefaultBuildWithFalseRegistered(buildName string, strategyName
 
 // DefaultBuildRun returns a minimal BuildRun object
 func (c *Catalog) DefaultBuildRun(buildRunName string, buildName string) *build.BuildRun {
+	var defaultBuild = c.DefaultBuild(buildName, "foobar-strategy", build.ClusterBuildStrategyKind)
 	return &build.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: buildRunName,
@@ -630,6 +641,9 @@ func (c *Catalog) DefaultBuildRun(buildRunName string, buildName string) *build.
 			BuildRef: &build.BuildRef{
 				Name: buildName,
 			},
+		},
+		Status: build.BuildRunStatus{
+			BuildSpec: &defaultBuild.Spec,
 		},
 	}
 }
@@ -704,7 +718,6 @@ func (c *Catalog) BuildRunWithExistingOwnerReferences(buildRunName string, build
 // BuildRunWithFakeNamespace returns a BuildRun object with
 // a namespace that does not exist
 func (c *Catalog) BuildRunWithFakeNamespace(buildRunName string, buildName string) *build.BuildRun {
-
 	return &build.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildRunName,


### PR DESCRIPTION
Based on the suggestion by @SaschaSchwarze0, there is a gap in the metrics reporting. At the moment, the metrics are observed when the BuildRun is done. However, a metric like the BuildRun Establised Duration could be reported as soon as the BuildRun is available in the system. Furthermore, in case the BuildRun fails, the metrics for this execution are not reported at all.

_Idea for refactoring:_ Move metrics for `build-run-count`, `build-run-established`, and `build-run-rampup` to a section in `Reconcile` where the details are already available and where in theory the metrics should only be reported once.