### PR TITLE
Bring ruby test sample back

### DIFF
--- a/test/data/build_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/build_buildpacks-v3_ruby_cr.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: buildpack-ruby-build
+spec:
+  source:
+    url: https://github.com/cloudfoundry/cf-acceptance-tests
+    contextDir: assets/dora
+  strategy:
+    name: buildpacks-v3
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/buildrun_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/buildrun_buildpacks-v3_ruby_cr.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: BuildRun
+metadata:
+  name: buildpack-ruby-buildrun
+spec:
+  buildRef:
+    name: buildpack-ruby-build
+  serviceAccount:
+    generate: true

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -198,6 +198,29 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
+	Context("when a Buildpacks v3 build is defined for a ruby runtime", func() {
+
+		BeforeEach(func() {
+			testID = generateTestID("buildpacks-v3-ruby")
+
+			// create the build definition
+			createBuild(ctx,
+				namespace,
+				testID,
+				"test/data/build_buildpacks-v3_ruby_cr.yaml",
+				cleanupTimeout,
+				cleanupRetryInterval,
+			)
+		})
+
+		It("successfully runs a build", func() {
+			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_ruby_cr.yaml")
+			Expect(err).ToNot(HaveOccurred())
+
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
+		})
+	})
+
 	Context("when a Buildpacks v3 build is defined for a golang runtime", func() {
 
 		BeforeEach(func() {


### PR DESCRIPTION
Fix issue: https://github.com/shipwright-io/build/issues/458

The latest Paketo builder image has supported ruby buildpack, so we need to bring this test sample back.

This is [ruby buildpack repo](https://github.com/paketo-buildpacks/ruby), it has been moved to paketo-buildpack org from paketo-community org. 

Also in the website, they has announced supports ruby buildpack: https://paketo.io/docs/buildpacks/language-family-buildpacks/ruby/

Besides, in the slack channel, they also announced ruby buildpack has been added into paketo builder image: https://paketobuildpacks.slack.com/archives/CURGNPSTE/p1604001381008700