### PR TITLE
Handle non-existing annotation

### DIFF
--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -339,10 +339,10 @@ func (r *ReconcileBuild) validateBuildRunOwnerReferences(ctx context.Context, b 
 				if err = r.client.Update(ctx, &buildRun); err != nil {
 					return err
 				}
-				ctxlog.Info(ctx, fmt.Sprintf("succesfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
+				ctxlog.Info(ctx, fmt.Sprintf("successfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
 			}
 		}
-	case "false":
+	case "", "false":
 		// if the buildRun have an ownerreference to the Build, lets remove it
 		for _, buildRun := range buildRunList.Items {
 			if index := r.validateBuildOwnerReference(buildRun.OwnerReferences, b); index != -1 {
@@ -350,7 +350,7 @@ func (r *ReconcileBuild) validateBuildRunOwnerReferences(ctx context.Context, b 
 				if err := r.client.Update(ctx, &buildRun); err != nil {
 					return err
 				}
-				ctxlog.Info(ctx, fmt.Sprintf("succesfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
+				ctxlog.Info(ctx, fmt.Sprintf("successfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
 			}
 		}
 

--- a/test/integration/utils/builds.go
+++ b/test/integration/utils/builds.go
@@ -38,10 +38,15 @@ func (t *TestBuild) GetBuild(name string) (*v1alpha1.Build, error) {
 		Get(name, metav1.GetOptions{})
 }
 
-// PatchBuild patches an existing Build
+// PatchBuild patches an existing Build using the merge patch type
 func (t *TestBuild) PatchBuild(buildName string, data []byte) (*v1alpha1.Build, error) {
+	return t.PatchBuildWithPatchType(buildName, data, types.MergePatchType)
+}
+
+// PatchBuildWithPatchType patches an existing Build and allows specifying the patch type
+func (t *TestBuild) PatchBuildWithPatchType(buildName string, data []byte, pt types.PatchType) (*v1alpha1.Build, error) {
 	bInterface := t.BuildClientSet.BuildV1alpha1().Builds(t.Namespace)
-	b, err := bInterface.Patch(buildName, types.MergePatchType, data)
+	b, err := bInterface.Patch(buildName, pt, data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I just noticed these output in the operator logs in a travis build https://travis-ci.org/github/shipwright-io/build/builds/740734332:

```
{"level":"info","ts":1604290243.6176696,"logger":"build.build-controller","msg":"the annotation build.build.dev/build-run-deletion was not properly defined, supported values are true or false","namespace":"default","name":"buildpacks-v3-ruby-x42q8"}
{"level":"info","ts":1604290243.617835,"logger":"build.build-controller","msg":"unexpected error during ownership reference validation","namespace":"default","name":"buildpacks-v3-ruby-x42q8","error":"the annotation build.build.dev/build-run-deletion was not properly defined, supported values are true or false"}
```

We forgot to handle the non-existing annotation in the same was as one with value `false`. I am correcting this.