### PR TITLE
Add build strategy labels to task run

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
+const (
 	// LabelBuild is a label key for defining the build name
 	LabelBuild = "build.build.dev/name"
 

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
+const (
 	// LabelBuildRun is a label key for BuildRuns to define the name of the BuildRun
 	LabelBuildRun = "buildrun.build.dev/name"
 

--- a/pkg/apis/build/v1alpha1/buildstrategy.go
+++ b/pkg/apis/build/v1alpha1/buildstrategy.go
@@ -47,3 +47,11 @@ type StrategyRef struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 }
+
+// BuilderStrategy defines the common elements of build strategies
+type BuilderStrategy interface {
+	GetName() string
+	GetGeneration() int64
+	GetResourceLabels() map[string]string
+	GetBuildSteps() []BuildStep
+}

--- a/pkg/apis/build/v1alpha1/buildstrategy.go
+++ b/pkg/apis/build/v1alpha1/buildstrategy.go
@@ -1,0 +1,49 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// NamespacedBuildStrategyKind indicates that the buildstrategy type has a namespaced scope.
+	NamespacedBuildStrategyKind BuildStrategyKind = "BuildStrategy"
+
+	// ClusterBuildStrategyKind indicates that buildstrategy type has a cluster scope.
+	ClusterBuildStrategyKind BuildStrategyKind = "ClusterBuildStrategy"
+)
+
+// BuildStrategySpec defines the desired state of BuildStrategy
+type BuildStrategySpec struct {
+	BuildSteps []BuildStep `json:"buildSteps,omitempty"`
+}
+
+// BuildStep defines a partial step that needs to run in container for
+// building the image.
+type BuildStep struct {
+	corev1.Container `json:",inline"`
+}
+
+// BuildStrategyStatus defines the observed state of BuildStrategy
+type BuildStrategyStatus struct {
+}
+
+// BuildStrategyKind defines the type of BuildStrategy used by the build.
+type BuildStrategyKind string
+
+// StrategyRef can be used to refer to a specific instance of a buildstrategy.
+// Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64
+type StrategyRef struct {
+	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+	Name string `json:"name"`
+
+	// BuildStrategyKind indicates the kind of the buildstrategy, namespaced or cluster scoped.
+	Kind *BuildStrategyKind `json:"kind,omitempty"`
+
+	// API version of the referent
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+}

--- a/pkg/apis/build/v1alpha1/buildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/buildstrategy_types.go
@@ -5,24 +5,18 @@
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"strconv"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BuildStrategySpec defines the desired state of BuildStrategy
-type BuildStrategySpec struct {
-	BuildSteps []BuildStep `json:"buildSteps,omitempty"`
-}
+const (
+	// LabelBuildStrategyName is a label key for defining the build strategy name
+	LabelBuildStrategyName = "buildstrategy.build.dev/name"
 
-// BuildStep defines a partial step that needs to run in container for
-// building the image.
-type BuildStep struct {
-	corev1.Container `json:",inline"`
-}
-
-// BuildStrategyStatus defines the observed state of BuildStrategy
-type BuildStrategyStatus struct {
-}
+	// LabelBuildStrategyGeneration is a label key for defining the build strategy generation
+	LabelBuildStrategyGeneration = "buildstrategy.build.dev/generation"
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -50,25 +44,3 @@ type BuildStrategyList struct {
 func init() {
 	SchemeBuilder.Register(&BuildStrategy{}, &BuildStrategyList{})
 }
-
-// StrategyRef can be used to refer to a specific instance of a buildstrategy.
-// Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64
-type StrategyRef struct {
-	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name"`
-	// BuildStrategyKind indicates the kind of the buildstrategy, namespaced or cluster scoped.
-	Kind *BuildStrategyKind `json:"kind,omitempty"`
-	// API version of the referent
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
-}
-
-// BuildStrategyKind defines the type of BuildStrategy used by the build.
-type BuildStrategyKind string
-
-const (
-	// NamespacedBuildStrategyKind indicates that the buildstrategy type has a namespaced scope.
-	NamespacedBuildStrategyKind BuildStrategyKind = "BuildStrategy"
-	// ClusterBuildStrategyKind indicates that buildstrategy type has a cluster scope.
-	ClusterBuildStrategyKind BuildStrategyKind = "ClusterBuildStrategy"
-)

--- a/pkg/apis/build/v1alpha1/buildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/buildstrategy_types.go
@@ -41,6 +41,31 @@ type BuildStrategyList struct {
 	Items           []BuildStrategy `json:"items"`
 }
 
+// GetName returns the name of the build strategy
+func (s BuildStrategy) GetName() string {
+	return s.Name
+}
+
+// GetGeneration returns the current generation sequence number of the build
+// strategy resource
+func (s BuildStrategy) GetGeneration() int64 {
+	return s.Generation
+}
+
+// GetResourceLabels returns labels that define the build strategy name and
+// generation to be used in labels map of a resource
+func (s BuildStrategy) GetResourceLabels() map[string]string {
+	return map[string]string{
+		LabelBuildStrategyName:       s.Name,
+		LabelBuildStrategyGeneration: strconv.FormatInt(s.Generation, 10),
+	}
+}
+
+// GetBuildSteps returns the spec build steps of the build strategy
+func (s BuildStrategy) GetBuildSteps() []BuildStep {
+	return s.Spec.BuildSteps
+}
+
 func init() {
 	SchemeBuilder.Register(&BuildStrategy{}, &BuildStrategyList{})
 }

--- a/pkg/apis/build/v1alpha1/clusterbuildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/clusterbuildstrategy_types.go
@@ -5,7 +5,17 @@
 package v1alpha1
 
 import (
+	"strconv"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// LabelClusterBuildStrategyName is a label key for defining the cluster build strategy name
+	LabelClusterBuildStrategyName = "clusterbuildstrategy.build.dev/name"
+
+	// LabelClusterBuildStrategyGeneration is a label key for defining the cluster build strategy generation
+	LabelClusterBuildStrategyGeneration = "clusterbuildstrategy.build.dev/generation"
 )
 
 // +genclient
@@ -30,6 +40,31 @@ type ClusterBuildStrategyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ClusterBuildStrategy `json:"items"`
+}
+
+// GetName returns the name of the build strategy
+func (s ClusterBuildStrategy) GetName() string {
+	return s.Name
+}
+
+// GetGeneration returns the current generation sequence number of the build
+// strategy resource
+func (s ClusterBuildStrategy) GetGeneration() int64 {
+	return s.Generation
+}
+
+// GetResourceLabels returns labels that define the build strategy name and
+// generation to be used in labels map of a resource
+func (s ClusterBuildStrategy) GetResourceLabels() map[string]string {
+	return map[string]string{
+		LabelClusterBuildStrategyName:       s.Name,
+		LabelClusterBuildStrategyGeneration: strconv.FormatInt(s.Generation, 10),
+	}
+}
+
+// GetBuildSteps returns the spec build steps of the build strategy
+func (s ClusterBuildStrategy) GetBuildSteps() []BuildStep {
+	return s.Spec.BuildSteps
 }
 
 func init() {

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -554,7 +554,7 @@ func (r *ReconcileBuildRun) createTaskRun(ctx context.Context, build *buildv1alp
 			return nil, err
 		}
 		if buildStrategy != nil {
-			generatedTaskRun, err = GenerateTaskRun(r.config, build, buildRun, serviceAccount.Name, buildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = GenerateTaskRun(r.config, build, buildRun, serviceAccount.Name, buildStrategy)
 			if err != nil {
 				updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 				return nil, handleError("Failed to generate the taskrun with buildStrategy", err, updateErr)
@@ -566,7 +566,7 @@ func (r *ReconcileBuildRun) createTaskRun(ctx context.Context, build *buildv1alp
 			return nil, err
 		}
 		if clusterBuildStrategy != nil {
-			generatedTaskRun, err = GenerateTaskRun(r.config, build, buildRun, serviceAccount.Name, clusterBuildStrategy.Spec.BuildSteps)
+			generatedTaskRun, err = GenerateTaskRun(r.config, build, buildRun, serviceAccount.Name, clusterBuildStrategy)
 			if err != nil {
 				updateErr := r.updateBuildRunErrorStatus(ctx, buildRun, err.Error())
 				return nil, handleError("Failed to generate the taskrun with clusterBuildStrategy", err, updateErr)

--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -178,7 +178,7 @@ func GenerateTaskRun(
 	build *buildv1alpha1.Build,
 	buildRun *buildv1alpha1.BuildRun,
 	serviceAccountName string,
-	buildSteps []buildv1alpha1.BuildStep,
+	strategy buildv1alpha1.BuilderStrategy,
 ) (*v1beta1.TaskRun, error) {
 
 	revision := "master"

--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -254,6 +254,10 @@ func GenerateTaskRun(
 		},
 	}
 
+	for label, value := range strategy.GetResourceLabels() {
+		expectedTaskRun.Labels[label] = value
+	}
+
 	// assign the timeout
 	if buildRun.Spec.Timeout != nil {
 		expectedTaskRun.Spec.Timeout = buildRun.Spec.Timeout

--- a/pkg/controller/buildrun/generate_taskrun.go
+++ b/pkg/controller/buildrun/generate_taskrun.go
@@ -194,7 +194,7 @@ func GenerateTaskRun(
 		ImageURL = build.Spec.Output.ImageURL
 	}
 
-	taskSpec, err := GenerateTaskSpec(cfg, build, buildRun, buildSteps)
+	taskSpec, err := GenerateTaskSpec(cfg, build, buildRun, strategy.GetBuildSteps())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/buildrun/generate_taskrun_test.go
+++ b/pkg/controller/buildrun/generate_taskrun_test.go
@@ -144,7 +144,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			JustBeforeEach(func() {
-				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy.Spec.BuildSteps)
+				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy)
 				Expect(err).To(BeNil())
 			})
 
@@ -215,7 +215,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			JustBeforeEach(func() {
-				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy.Spec.BuildSteps)
+				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy)
 				Expect(err).To(BeNil())
 			})
 
@@ -274,7 +274,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			JustBeforeEach(func() {
-				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy.Spec.BuildSteps)
+				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy)
 				Expect(err).To(BeNil())
 			})
 
@@ -297,7 +297,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			JustBeforeEach(func() {
-				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy.Spec.BuildSteps)
+				got, err = buildrunCtl.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy)
 				Expect(err).To(BeNil())
 			})
 

--- a/pkg/controller/buildrun/generate_taskrun_test.go
+++ b/pkg/controller/buildrun/generate_taskrun_test.go
@@ -154,6 +154,8 @@ var _ = Describe("GenerateTaskrun", func() {
 				Expect(got.Spec.ServiceAccountName).To(Equal(buildpacks + "-serviceaccount"))
 				Expect(got.Labels[buildv1alpha1.LabelBuild]).To(Equal(build.Name))
 				Expect(got.Labels[buildv1alpha1.LabelBuildRun]).To(Equal(buildRun.Name))
+				Expect(got.Labels[buildv1alpha1.LabelBuildStrategyName]).To(Equal(build.Spec.StrategyRef.Name))
+				Expect(got.Labels[buildv1alpha1.LabelBuildStrategyGeneration]).To(Equal("0"))
 			})
 
 			It("should ensure generated TaskRun's input and output resources are correct", func() {


### PR DESCRIPTION
When monitoring a system that uses https://github.com/shipwright-io/build, it would be helpful to make that the build work load can be identified very easy and correctly. At the moment, there is no direct way to differentiate between a buildrun that uses Kaniko or Buildpacks from a purely Kubernetes point of view by just looking at the actual task run pod.

Suggestion: Add more labels to the task run and therefore the task run pod to help to identify the respective work load.
```yaml
---
apiVersion: v1
kind: Pod
metadata:
 annotations:
   pipeline.tekton.dev/release: v0.17.1
 creationTimestamp: "2020-11-03T15:23:07Z"
 labels:
   app.kubernetes.io/managed-by: tekton-pipelines
   build.build.dev/generation: "1"
   build.build.dev/name: test-kaniko-0
   buildrun.build.dev/generation: "1"
   buildrun.build.dev/name: test-kaniko-0
   clusterbuildstrategy.build.dev/name: kaniko
   clusterbuildstrategy.build.dev/generation: "1"
```

In order to keep the symmetry with `build`, and `buildrun`, the new labels would come as the same type of pair with a name and the generation.

To achieve this in code while not introducing additional code duplication, I decided to introduce an interface to encapsulate the common elements of both BuildStrategy and ClusterBuildStrategy. In theory, this could later help to reduce some code duplication that are in the code to date.