### PR TITLE
Add buildrunname label for custom metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,11 +14,11 @@ Following build metrics are exposed at service `build-operator-metrics` on port 
 | ---- | ---- | ----------- | ------ | ------ |
 | `build_builds_registered_total` | Counter | Number of total registered Builds. | buildstrategy=<build_buildstrategy_name> | experimental |
 | `build_buildruns_completed_total` | Counter | Number of total completed BuildRuns. | buildstrategy=<build_buildstrategy_name> | experimental |
-| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
 
 <sup>1</sup> Labels for histograms are disabled by default. See [Configuration of histogram labels](#configuration-of-histogram-labels) to enable them.
 
@@ -57,7 +57,7 @@ As the amount of buckets and labels has a direct impact on the number of Prometh
 
 * buildstrategy
 * namespace
-* buildrunname
+* buildrun
 
 Use a comma-separated value to enable multiple labels. For example:
 
@@ -69,7 +69,7 @@ make local
 or
 
 ```bash
-export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=buildstrategy,namespace,buildrunname
+export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=buildstrategy,namespace,buildrun
 make local
 ```
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,11 +14,11 @@ Following build metrics are exposed at service `build-operator-metrics` on port 
 | ---- | ---- | ----------- | ------ | ------ |
 | `build_builds_registered_total` | Counter | Number of total registered Builds. | buildstrategy=<build_buildstrategy_name> | experimental |
 | `build_buildruns_completed_total` | Counter | Number of total completed BuildRuns. | buildstrategy=<build_buildstrategy_name> | experimental |
-| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
-| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
-| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup> | experimental |
+| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrunname=<buildrun_name> <sup>1</sup> | experimental |
 
 <sup>1</sup> Labels for histograms are disabled by default. See [Configuration of histogram labels](#configuration-of-histogram-labels) to enable them.
 
@@ -57,6 +57,7 @@ As the amount of buckets and labels has a direct impact on the number of Prometh
 
 * buildstrategy
 * namespace
+* buildrunname
 
 Use a comma-separated value to enable multiple labels. For example:
 
@@ -68,7 +69,7 @@ make local
 or
 
 ```bash
-export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=buildstrategy,namespace
+export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=buildstrategy,namespace,buildrunname
 make local
 ```
 

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -345,6 +345,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			buildmetrics.BuildRunRampUpDurationObserve(
 				buildRun.Status.BuildSpec.StrategyRef.Name,
 				buildRun.Namespace,
+				buildRun.Name,
 				generatedTaskRun.CreationTimestamp.Time.Sub(buildRun.CreationTimestamp.Time),
 			)
 		} else {
@@ -401,6 +402,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 				buildmetrics.BuildRunEstablishObserve(
 					buildRun.Status.BuildSpec.StrategyRef.Name,
 					buildRun.Namespace,
+					buildRun.Name,
 					buildRun.Status.StartTime.Time.Sub(buildRun.CreationTimestamp.Time),
 				)
 			}
@@ -413,6 +415,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 					buildmetrics.BuildRunCompletionObserve(
 						buildRun.Status.BuildSpec.StrategyRef.Name,
 						buildRun.Namespace,
+						buildRun.Name,
 						buildRun.Status.CompletionTime.Time.Sub(buildRun.CreationTimestamp.Time),
 					)
 
@@ -429,6 +432,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 								buildmetrics.TaskRunPodRampUpDurationObserve(
 									buildRun.Status.BuildSpec.StrategyRef.Name,
 									buildRun.Namespace,
+									buildRun.Name,
 									lastInitPod.State.Terminated.FinishedAt.Sub(pod.CreationTimestamp.Time),
 								)
 							}
@@ -438,6 +442,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 						buildmetrics.TaskRunRampUpDurationObserve(
 							buildRun.Status.BuildSpec.StrategyRef.Name,
 							buildRun.Namespace,
+							buildRun.Name,
 							pod.CreationTimestamp.Time.Sub(lastTaskRun.CreationTimestamp.Time),
 						)
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,7 +17,7 @@ import (
 const (
 	BuildStrategyLabel string = "buildstrategy"
 	NamespaceLabel     string = "namespace"
-	BuildRunNameLabel  string = "buildrunname"
+	BuildRunLabel      string = "buildrun"
 )
 
 var (
@@ -44,7 +44,7 @@ var (
 
 	histogramBuildStrategyLabelEnabled = false
 	histogramNamespaceLabelEnabled     = false
-	histogramBuildRunNameLabelEnabled  = false
+	histogramBuildRunLabelEnabled      = false
 
 	initialized = false
 )
@@ -66,9 +66,9 @@ func InitPrometheus(config *config.Config) {
 		histogramLabels = append(histogramLabels, NamespaceLabel)
 		histogramNamespaceLabelEnabled = true
 	}
-	if contains(config.Prometheus.HistogramEnabledLabels, BuildRunNameLabel) {
-		histogramLabels = append(histogramLabels, BuildRunNameLabel)
-		histogramBuildRunNameLabelEnabled = true
+	if contains(config.Prometheus.HistogramEnabledLabels, BuildRunLabel) {
+		histogramLabels = append(histogramLabels, BuildRunLabel)
+		histogramBuildRunLabelEnabled = true
 	}
 
 	buildRunEstablishDuration = prometheus.NewHistogramVec(
@@ -132,7 +132,7 @@ func contains(slice []string, element string) bool {
 	return false
 }
 
-func createHistogramLabels(buildStrategy string, namespace string, buildRunName string) prometheus.Labels {
+func createHistogramLabels(buildStrategy string, namespace string, buildRun string) prometheus.Labels {
 	labels := prometheus.Labels{}
 
 	if histogramBuildStrategyLabelEnabled {
@@ -141,8 +141,8 @@ func createHistogramLabels(buildStrategy string, namespace string, buildRunName 
 	if histogramNamespaceLabelEnabled {
 		labels[NamespaceLabel] = namespace
 	}
-	if histogramBuildRunNameLabelEnabled {
-		labels[BuildRunNameLabel] = buildRunName
+	if histogramBuildRunLabelEnabled {
+		labels[BuildRunLabel] = buildRun
 	}
 
 	return labels
@@ -161,36 +161,36 @@ func BuildRunCountInc(buildStrategy string) {
 }
 
 // BuildRunEstablishObserve sets the build run establish time
-func BuildRunEstablishObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
+func BuildRunEstablishObserve(buildStrategy string, namespace string, buildRun string, duration time.Duration) {
 	if buildRunEstablishDuration != nil {
-		buildRunEstablishDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
+		buildRunEstablishDuration.With(createHistogramLabels(buildStrategy, namespace, buildRun)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunCompletionObserve sets the build run completion time
-func BuildRunCompletionObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
+func BuildRunCompletionObserve(buildStrategy string, namespace string, buildRun string, duration time.Duration) {
 	if buildRunCompletionDuration != nil {
-		buildRunCompletionDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
+		buildRunCompletionDuration.With(createHistogramLabels(buildStrategy, namespace, buildRun)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunRampUpDurationObserve processes the observation of a new buildrun ramp-up duration
-func BuildRunRampUpDurationObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
+func BuildRunRampUpDurationObserve(buildStrategy string, namespace string, buildRun string, duration time.Duration) {
 	if buildRunRampUpDuration != nil {
-		buildRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
+		buildRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRun)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunRampUpDurationObserve processes the observation of a new taskrun ramp-up duration
-func TaskRunRampUpDurationObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
+func TaskRunRampUpDurationObserve(buildStrategy string, namespace string, buildRun string, duration time.Duration) {
 	if taskRunRampUpDuration != nil {
-		taskRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
+		taskRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRun)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunPodRampUpDurationObserve processes the observation of a new taskrun pod ramp-up duration
-func TaskRunPodRampUpDurationObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
+func TaskRunPodRampUpDurationObserve(buildStrategy string, namespace string, buildRun string, duration time.Duration) {
 	if taskRunPodRampUpDuration != nil {
-		taskRunPodRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
+		taskRunPodRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRun)).Observe(duration.Seconds())
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	buildStrategyLabel string = "buildstrategy"
-	namespaceLabel     string = "namespace"
+	BuildStrategyLabel string = "buildstrategy"
+	NamespaceLabel     string = "namespace"
+	BuildRunNameLabel  string = "buildrunname"
 )
 
 var (
@@ -25,14 +26,14 @@ var (
 			Name: "build_builds_registered_total",
 			Help: "Number of total registered Builds.",
 		},
-		[]string{buildStrategyLabel})
+		[]string{BuildStrategyLabel})
 
 	buildRunCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "build_buildruns_completed_total",
 			Help: "Number of total completed BuildRuns.",
 		},
-		[]string{buildStrategyLabel})
+		[]string{BuildStrategyLabel})
 
 	buildRunEstablishDuration  *prometheus.HistogramVec
 	buildRunCompletionDuration *prometheus.HistogramVec
@@ -43,6 +44,7 @@ var (
 
 	histogramBuildStrategyLabelEnabled = false
 	histogramNamespaceLabelEnabled     = false
+	histogramBuildRunNameLabelEnabled  = false
 
 	initialized = false
 )
@@ -56,13 +58,17 @@ func InitPrometheus(config *config.Config) {
 	initialized = true
 
 	var histogramLabels []string
-	if contains(config.Prometheus.HistogramEnabledLabels, buildStrategyLabel) {
-		histogramLabels = append(histogramLabels, buildStrategyLabel)
+	if contains(config.Prometheus.HistogramEnabledLabels, BuildStrategyLabel) {
+		histogramLabels = append(histogramLabels, BuildStrategyLabel)
 		histogramBuildStrategyLabelEnabled = true
 	}
-	if contains(config.Prometheus.HistogramEnabledLabels, namespaceLabel) {
-		histogramLabels = append(histogramLabels, namespaceLabel)
+	if contains(config.Prometheus.HistogramEnabledLabels, NamespaceLabel) {
+		histogramLabels = append(histogramLabels, NamespaceLabel)
 		histogramNamespaceLabelEnabled = true
+	}
+	if contains(config.Prometheus.HistogramEnabledLabels, BuildRunNameLabel) {
+		histogramLabels = append(histogramLabels, BuildRunNameLabel)
+		histogramBuildRunNameLabelEnabled = true
 	}
 
 	buildRunEstablishDuration = prometheus.NewHistogramVec(
@@ -126,14 +132,17 @@ func contains(slice []string, element string) bool {
 	return false
 }
 
-func createHistogramLabels(buildStrategy string, namespace string) prometheus.Labels {
+func createHistogramLabels(buildStrategy string, namespace string, buildRunName string) prometheus.Labels {
 	labels := prometheus.Labels{}
 
 	if histogramBuildStrategyLabelEnabled {
-		labels[buildStrategyLabel] = buildStrategy
+		labels[BuildStrategyLabel] = buildStrategy
 	}
 	if histogramNamespaceLabelEnabled {
-		labels[namespaceLabel] = namespace
+		labels[NamespaceLabel] = namespace
+	}
+	if histogramBuildRunNameLabelEnabled {
+		labels[BuildRunNameLabel] = buildRunName
 	}
 
 	return labels
@@ -152,36 +161,36 @@ func BuildRunCountInc(buildStrategy string) {
 }
 
 // BuildRunEstablishObserve sets the build run establish time
-func BuildRunEstablishObserve(buildStrategy string, namespace string, duration time.Duration) {
+func BuildRunEstablishObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
 	if buildRunEstablishDuration != nil {
-		buildRunEstablishDuration.With(createHistogramLabels(buildStrategy, namespace)).Observe(duration.Seconds())
+		buildRunEstablishDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunCompletionObserve sets the build run completion time
-func BuildRunCompletionObserve(buildStrategy string, namespace string, duration time.Duration) {
+func BuildRunCompletionObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
 	if buildRunCompletionDuration != nil {
-		buildRunCompletionDuration.With(createHistogramLabels(buildStrategy, namespace)).Observe(duration.Seconds())
+		buildRunCompletionDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunRampUpDurationObserve processes the observation of a new buildrun ramp-up duration
-func BuildRunRampUpDurationObserve(buildStrategy string, namespace string, duration time.Duration) {
+func BuildRunRampUpDurationObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
 	if buildRunRampUpDuration != nil {
-		buildRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace)).Observe(duration.Seconds())
+		buildRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunRampUpDurationObserve processes the observation of a new taskrun ramp-up duration
-func TaskRunRampUpDurationObserve(buildStrategy string, namespace string, duration time.Duration) {
+func TaskRunRampUpDurationObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
 	if taskRunRampUpDuration != nil {
-		taskRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace)).Observe(duration.Seconds())
+		taskRunRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunPodRampUpDurationObserve processes the observation of a new taskrun pod ramp-up duration
-func TaskRunPodRampUpDurationObserve(buildStrategy string, namespace string, duration time.Duration) {
+func TaskRunPodRampUpDurationObserve(buildStrategy string, namespace string, buildRunName string, duration time.Duration) {
 	if taskRunPodRampUpDuration != nil {
-		taskRunPodRampUpDuration.With(createHistogramLabels(buildStrategy, namespace)).Observe(duration.Seconds())
+		taskRunPodRampUpDuration.With(createHistogramLabels(buildStrategy, namespace, buildRunName)).Observe(duration.Seconds())
 	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Custom Metrics", func() {
 	type buildRunLabels struct {
 		buildStrategy string
 		namespace     string
-		buildRunName  string
+		buildRun      string
 	}
 
 	var (
@@ -35,8 +35,8 @@ var _ = Describe("Custom Metrics", func() {
 					result.buildStrategy = *label.Value
 				case NamespaceLabel:
 					result.namespace = *label.Value
-				case BuildRunNameLabel:
-					result.buildRunName = *label.Value
+				case BuildRunLabel:
+					result.buildRun = *label.Value
 				}
 			}
 
@@ -47,8 +47,8 @@ var _ = Describe("Custom Metrics", func() {
 	BeforeSuite(func() {
 		var (
 			testLabels = []buildRunLabels{
-				{buildStrategy: "kaniko", namespace: "default", buildRunName: "kaniko-buildrun"},
-				{buildStrategy: "buildpacks", namespace: "default", buildRunName: "buildpacks-buildrun"},
+				{buildStrategy: "kaniko", namespace: "default", buildRun: "kaniko-buildrun"},
+				{buildStrategy: "buildpacks", namespace: "default", buildRun: "buildpacks-buildrun"},
 			}
 
 			knownCounterMetrics = []string{
@@ -77,22 +77,22 @@ var _ = Describe("Custom Metrics", func() {
 
 		// initialize prometheus (second init should be no-op)
 		config := config.NewDefaultConfig()
-		config.Prometheus.HistogramEnabledLabels = []string{BuildStrategyLabel, NamespaceLabel, BuildRunNameLabel}
+		config.Prometheus.HistogramEnabledLabels = []string{BuildStrategyLabel, NamespaceLabel, BuildRunLabel}
 		InitPrometheus(config)
 		InitPrometheus(config)
 
 		// and fire some examples
 		for _, entry := range testLabels {
-			buildStrategy, namespace, buildRunName := entry.buildStrategy, entry.namespace, entry.buildRunName
+			buildStrategy, namespace, buildRun := entry.buildStrategy, entry.namespace, entry.buildRun
 
 			// tell prometheus some things have happened
 			BuildCountInc(buildStrategy)
 			BuildRunCountInc(buildStrategy)
-			BuildRunEstablishObserve(buildStrategy, namespace, buildRunName, time.Duration(1)*time.Second)
-			BuildRunCompletionObserve(buildStrategy, namespace, buildRunName, time.Duration(200)*time.Second)
-			BuildRunRampUpDurationObserve(buildStrategy, namespace, buildRunName, time.Duration(1)*time.Second)
-			TaskRunRampUpDurationObserve(buildStrategy, namespace, buildRunName, time.Duration(2)*time.Second)
-			TaskRunPodRampUpDurationObserve(buildStrategy, namespace, buildRunName, time.Duration(3)*time.Second)
+			BuildRunEstablishObserve(buildStrategy, namespace, buildRun, time.Duration(1)*time.Second)
+			BuildRunCompletionObserve(buildStrategy, namespace, buildRun, time.Duration(200)*time.Second)
+			BuildRunRampUpDurationObserve(buildStrategy, namespace, buildRun, time.Duration(1)*time.Second)
+			TaskRunRampUpDurationObserve(buildStrategy, namespace, buildRun, time.Duration(2)*time.Second)
+			TaskRunPodRampUpDurationObserve(buildStrategy, namespace, buildRun, time.Duration(3)*time.Second)
 		}
 
 		// gather metrics from prometheus and fill the result maps


### PR DESCRIPTION
For the current custom metric, we have two labels: `buildStrategy` and `namespace` and we can configure to the controller deployment choose which label we want to collect.

At the beginning, we just have two labels: `buildStrategy` and `namespace` because the metric limitation in Sysdig system, but it is not the limitation for other monitoring system and the `buildrunname` label is also important so that the end user can know more detail about each buildrun status.

By default the default label is still `buildStrategy`, but after this PR, the end user can have the capability to choose one more label in custom metric to show more detail.