### PR TITLE
Fixes for CRDs and fakes generator

### DIFF
--- a/deploy/crds/build.dev_buildstrategies_crd.yaml
+++ b/deploy/crds/build.dev_buildstrategies_crd.yaml
@@ -845,15 +845,11 @@ spec:
                               description: GMSACredentialSpec is where the GMSA admission
                                 webhook (https://github.com/kubernetes-sigs/windows-gmsa)
                                 inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field. This field is
-                                alpha-level and is only honored by servers that enable
-                                the WindowsGMSA feature flag.
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
                               description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use. This field is alpha-level
-                                and is only honored by servers that enable the WindowsGMSA
-                                feature flag.
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
                               description: The UserName in Windows to run the entrypoint
@@ -861,9 +857,7 @@ spec:
                                 in image metadata if unspecified. May also be set
                                 in PodSecurityContext. If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence. This field is beta-level and may
-                                be disabled with the WindowsRunAsUserName feature
-                                flag.
+                                takes precedence.
                               type: string
                           type: object
                       type: object
@@ -875,7 +869,7 @@ spec:
                         can be used to provide different probe parameters at the beginning
                         of a Pod''s lifecycle, when it might take a long time to load
                         data or warm a cache, than during steady-state operation.
-                        This cannot be updated. This is an alpha feature enabled by
+                        This cannot be updated. This is a beta feature enabled by
                         the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
@@ -1033,7 +1027,7 @@ spec:
                       type: boolean
                     volumeDevices:
                       description: volumeDevices is the list of block devices to be
-                        used by the container. This is a beta feature.
+                        used by the container.
                       items:
                         description: volumeDevice describes a mapping of a raw block
                           device within a container.

--- a/deploy/crds/build.dev_clusterbuildstrategies_crd.yaml
+++ b/deploy/crds/build.dev_clusterbuildstrategies_crd.yaml
@@ -845,15 +845,11 @@ spec:
                               description: GMSACredentialSpec is where the GMSA admission
                                 webhook (https://github.com/kubernetes-sigs/windows-gmsa)
                                 inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field. This field is
-                                alpha-level and is only honored by servers that enable
-                                the WindowsGMSA feature flag.
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
                               description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use. This field is alpha-level
-                                and is only honored by servers that enable the WindowsGMSA
-                                feature flag.
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
                               description: The UserName in Windows to run the entrypoint
@@ -861,9 +857,7 @@ spec:
                                 in image metadata if unspecified. May also be set
                                 in PodSecurityContext. If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence. This field is beta-level and may
-                                be disabled with the WindowsRunAsUserName feature
-                                flag.
+                                takes precedence.
                               type: string
                           type: object
                       type: object
@@ -875,7 +869,7 @@ spec:
                         can be used to provide different probe parameters at the beginning
                         of a Pod''s lifecycle, when it might take a long time to load
                         data or warm a cache, than during steady-state operation.
-                        This cannot be updated. This is an alpha feature enabled by
+                        This cannot be updated. This is a beta feature enabled by
                         the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
@@ -1033,7 +1027,7 @@ spec:
                       type: boolean
                     volumeDevices:
                       description: volumeDevices is the list of block devices to be
-                        used by the container. This is a beta feature.
+                        used by the container.
                       items:
                         description: volumeDevice describes a mapping of a raw block
                           device within a container.

--- a/hack/generate-fakes.sh
+++ b/hack/generate-fakes.sh
@@ -12,6 +12,6 @@ set -euo pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 BIN=$(go env GOPATH)/bin
 
-"${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/manager.go vendor/sigs.k8s.io/controller-runtime/pkg/manager Manager
-"${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/client.go vendor/sigs.k8s.io/controller-runtime/pkg/client Client
-"${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/status_writer.go vendor/sigs.k8s.io/controller-runtime/pkg/client StatusWriter
+GO111MODULE=off "${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/manager.go vendor/sigs.k8s.io/controller-runtime/pkg/manager Manager
+GO111MODULE=off "${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/client.go vendor/sigs.k8s.io/controller-runtime/pkg/client Client
+GO111MODULE=off "${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/status_writer.go vendor/sigs.k8s.io/controller-runtime/pkg/client StatusWriter


### PR DESCRIPTION
This is coming from me trying to cook a new PR around conditions, where I would need to update the BuildRun CRDs.

In a nutshell this PR:

- Align CRDs to be compliant with operator-sdk v0.17.0, there were some messages missing and also this PR avoids the removal of the "default: TCP" field, as requested in #299. The cmd to generate this was `$ operator-sdk generate crds --crd-version v1` . I opened https://github.com/shipwright-io/build/issues/472 as a follow up for this.


- Add fixes for fakes generation script. Ensure GO111MODULE is set to off

