### PR TITLE
Try to fix Travis timeout during e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ TEKTON_VERSION ?= v0.17.1
 SDK_VERSION ?= v0.17.0
 
 # E2E test flags
-TEST_E2E_FLAGS ?= -failFast -flakeAttempts=2 -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=20m -trace -v
+TEST_E2E_FLAGS ?= -failFast -flakeAttempts=2 -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=30m -progress -stream -trace -v
 
 # E2E test operator behavior, can be start_local or managed_outside
 TEST_E2E_OPERATOR ?= start_local


### PR DESCRIPTION
We often faced a failing travis build here which ended with:

```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

The build has been terminated
```

I am addressing this by two changes:

1. Adding a `Logf` to the `Eventually` blocks in the e2e tests to tell that something is still going on.
2. Adding the `travis_wait` for this long running command.

With that, I am getting a green build here. Unfortunately, `travis_wait` means that the log is only printed once the process is finished or times out.