### PR TITLE
tests: Get BuildRun before parent Build is deleted

### DIFF
--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -435,12 +435,12 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 			Expect(patchedBuild.Annotations[v1alpha1.AnnotationBuildRunDeletion]).To(Equal("true"))
 
-			err = tb.DeleteBuild(BUILD + tb.Namespace)
-			Expect(err).To(BeNil())
-
 			br, err := tb.GetBR(BUILDRUN + tb.Namespace)
 			Expect(err).To(BeNil())
 			Expect(ownerReferenceNames(br.OwnerReferences)).Should(ContainElement(buildObject.Name))
+
+			err = tb.DeleteBuild(BUILD + tb.Namespace)
+			Expect(err).To(BeNil())
 
 			buildIsDeleted, err := tb.GetBRTillDeletion(BUILDRUN + tb.Namespace)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
When testing if a BuildRun is cleaned up by k8s garbage collection, we
need to get the BuildRun object before we delete the parent Build
object. Our test cluster in Travis probably didn't catch this because of
weak resource constraints. This test fails when run against a
production-grade cluster.