### PR TITLE
Add a predefined error code for build CRD as the prefix of error message

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -15,6 +15,7 @@ SPDX-License-Identifier: Apache-2.0
   - [Defining the Output](#defining-the-output)
   - [Runtime-Image](#Runtime-Image)
 - [BuildRun deletion](#BuildRun-deletion)
+- [Build error code](#Build-error-code)
 
 ## Overview
 
@@ -278,3 +279,22 @@ metadata:
   annotations:
     build.build.dev/build-run-deletion: "true"
 ```
+
+## Build error code
+
+---
+|Unique error code|Error name|Error message|
+|---|---|---|
+|`1001`|`ListSecretInNamespaceFailed`|`listing secrets in namespace %s failed`|
+|`1002`|`NoSecretsInNamespace`|`there are no secrets in namespace %s`|
+|`1003`|`SecretsDoNotExist`|`secrets %s do not exist`|
+|`1004`|`SecretDoesNotExist`|`secret %s does not exist`|
+|`1005`|`UnknownStrategy`|`unknown strategy %v`|
+|`1006`|`ListBuildStrategyInNamespaceFailed`|`listing BuildStrategies in ns %s failed`|
+|`1007`|`NoneBuildStrategyFoundInNamespace`|`none BuildStrategies found in namespace %s`|
+|`1008`|`BuildStrategyDoesNotExistInNamespace`|`buildStrategy %s does not exist in namespace %s`|
+|`1009`|`ListClusterBuildStrategyFailed`|`listing ClusterBuildStrategies failed`|
+|`1010`|`NoClusterBuildStrategyFound`|`no ClusterBuildStrategies found`|
+|`1011`|`ClusterBuildStrategyDoesNotExist`|`clusterBuildStrategy %s does not exist`|
+|`1012`|`RuntimePathsCanNotBeEmpty`|`the property 'spec.runtime.paths' must not be empty`|
+|`1013`|`SetOwnerReferenceFailed`|`unexpected error when trying to set the ownerreference: %v`|

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -99,13 +99,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, "secret non-existing does not exist")
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: secret non-existing does not exist", buildController.SecretDoesNotExist))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring("secret non-existing does not exist"))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: secret non-existing does not exist", buildController.SecretDoesNotExist)))
 			})
 
 			It("succeeds when the secret exists", func() {
@@ -162,13 +162,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, "secret non-existing does not exist")
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: secret non-existing does not exist", buildController.SecretDoesNotExist))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring("secret non-existing does not exist"))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: secret non-existing does not exist", buildController.SecretDoesNotExist)))
 			})
 
 			It("succeeds when the secret exists", func() {
@@ -221,13 +221,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("secret %s does not exist", registrySecret))
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: secret %s does not exist", buildController.SecretDoesNotExist, registrySecret))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("secret %s does not exist", registrySecret)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: secret %s does not exist", buildController.SecretDoesNotExist, registrySecret)))
 			})
 			It("succeed when the secret exists", func() {
 
@@ -266,13 +266,13 @@ var _ = Describe("Reconcile Build", func() {
 					}
 					return nil
 				})
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("there are no secrets in namespace %s", namespace))
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: there are no secrets in namespace %s", buildController.NoSecretsInNamespace, namespace))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("there are no secrets in namespace %s", namespace)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: there are no secrets in namespace %s", buildController.NoSecretsInNamespace, namespace)))
 			})
 		})
 
@@ -325,13 +325,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("clusterBuildStrategy %s does not exist", buildStrategyName))
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: clusterBuildStrategy %s does not exist", buildController.ClusterBuildStrategyDoesNotExist, buildStrategyName))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("clusterBuildStrategy %s does not exist", buildStrategyName)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: clusterBuildStrategy %s does not exist", buildController.ClusterBuildStrategyDoesNotExist, buildStrategyName)))
 			})
 			It("succeed when the strategy exists", func() {
 
@@ -373,13 +373,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, "no ClusterBuildStrategies found")
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: no ClusterBuildStrategies found", buildController.NoClusterBuildStrategyFound))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring("no ClusterBuildStrategies found"))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: no ClusterBuildStrategies found", buildController.NoClusterBuildStrategyFound)))
 			})
 		})
 		Context("when spec strategy BuildStrategy is specified", func() {
@@ -406,13 +406,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("buildStrategy %s does not exist in namespace %s", buildStrategyName, namespace))
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: buildStrategy %s does not exist in namespace %s", buildController.BuildStrategyDoesNotExistInNamespace, buildStrategyName, namespace))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("buildStrategy %s does not exist in namespace %s", buildStrategyName, namespace)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: buildStrategy %s does not exist in namespace %s", buildController.BuildStrategyDoesNotExistInNamespace, buildStrategyName, namespace)))
 			})
 			It("succeed when the strategy exists", func() {
 
@@ -454,13 +454,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("none BuildStrategies found in namespace %s", namespace))
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: none BuildStrategies found in namespace %s", buildController.NoneBuildStrategyFoundInNamespace, namespace))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("none BuildStrategies found in namespace %s", namespace)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: none BuildStrategies found in namespace %s", buildController.NoneBuildStrategyFoundInNamespace, namespace)))
 			})
 		})
 		Context("when spec strategy kind is not specified", func() {
@@ -485,13 +485,13 @@ var _ = Describe("Reconcile Build", func() {
 					return nil
 				})
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("buildStrategy %s does not exist in namespace %s", buildStrategyName, namespace))
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, fmt.Sprintf("%v: buildStrategy %s does not exist in namespace %s", buildController.BuildStrategyDoesNotExistInNamespace, buildStrategyName, namespace))
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)
 				Expect(err).To(HaveOccurred())
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("buildStrategy %s does not exist in namespace %s", buildStrategyName, namespace)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("%v: buildStrategy %s does not exist in namespace %s", buildController.BuildStrategyDoesNotExistInNamespace, buildStrategyName, namespace)))
 
 			})
 			It("default to BuildStrategy and succeed if the strategy exists", func() {
@@ -518,5 +518,74 @@ var _ = Describe("Reconcile Build", func() {
 				Expect(reconcile.Result{}).To(Equal(result))
 			})
 		})
+
+		Context("Validate all build error code is correct", func() {
+			It("1001 error code should represent listing secrets in namespace failed", func() {
+				errorName, err := ctl.ValidateError(1001)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("ListSecretInNamespaceFailed"))
+			})
+			It("1002 error code should represent there are no secrets in namespace", func() {
+				errorName, err := ctl.ValidateError(1002)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("NoSecretsInNamespace"))
+			})
+			It("1003 error code should represent secrets do not exist", func() {
+				errorName, err := ctl.ValidateError(1003)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("SecretsDoNotExist"))
+			})
+			It("1004 error code should represent secret does not exist", func() {
+				errorName, err := ctl.ValidateError(1004)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("SecretDoesNotExist"))
+			})
+			It("1005 error code should represent unknown strategy", func() {
+				errorName, err := ctl.ValidateError(1005)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("UnknownStrategy"))
+			})
+			It("1006 error code should represent listing BuildStrategies in ns failed", func() {
+				errorName, err := ctl.ValidateError(1006)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("ListBuildStrategyInNamespaceFailed"))
+			})
+			It("1007 error code should represent none BuildStrategies found in namespace", func() {
+				errorName, err := ctl.ValidateError(1007)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("NoneBuildStrategyFoundInNamespace"))
+			})
+			It("1008 error code should represent buildStrategy does not exist in namespace", func() {
+				errorName, err := ctl.ValidateError(1008)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("BuildStrategyDoesNotExistInNamespace"))
+			})
+			It("1009 error code should represent listing ClusterBuildStrategies failed", func() {
+				errorName, err := ctl.ValidateError(1009)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("ListClusterBuildStrategyFailed"))
+			})
+			It("1010 error code should represent no ClusterBuildStrategies found", func() {
+				errorName, err := ctl.ValidateError(1010)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("NoClusterBuildStrategyFound"))
+			})
+			It("1011 error code should represent clusterBuildStrategy does not exist", func() {
+				errorName, err := ctl.ValidateError(1011)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("ClusterBuildStrategyDoesNotExist"))
+			})
+			It("1012 error code should represent the property 'spec.runtime.paths' must not be empty", func() {
+				errorName, err := ctl.ValidateError(1012)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("RuntimePathsCanNotBeEmpty"))
+			})
+			It("1013 error code should represent unexpected error when trying to set the ownerreference", func() {
+				errorName, err := ctl.ValidateError(1013)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(errorName).To(Equal("SetOwnerReferenceFailed"))
+			})
+		})
+
 	})
 })

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -6,8 +6,10 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
+	errorNew "errors"
 
 	. "github.com/onsi/gomega"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -25,11 +27,14 @@ import (
 	"sigs.k8s.io/yaml"
 
 	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+
+	buildController "github.com/shipwright-io/build/pkg/controller/build"
 	"github.com/shipwright-io/build/pkg/conditions"
 )
 
 // Catalog allows you to access helper functions
 type Catalog struct{}
+type ErrorCodes int
 
 // BuildWithClusterBuildStrategy gives you an specific Build CRD
 func (c *Catalog) BuildWithClusterBuildStrategy(name string, ns string, strategyName string, secretName string) *build.Build {
@@ -923,4 +928,48 @@ func (c *Catalog) LoadCBSWithName(name string, d []byte) (*build.ClusterBuildStr
 	}
 	b.Name = name
 	return b, nil
+}
+
+// validateErrorCode will validate if the errorCode const names are changed
+func (c *Catalog) ValidateErrorCode(e ErrorCodes) (string, error) {
+	switch e {
+	case buildController.ListSecretInNamespaceFailed:
+		return "ListSecretInNamespaceFailed", nil
+	case buildController.NoSecretsInNamespace:
+		return "NoSecretsInNamespace", nil
+	case buildController.SecretsDoNotExist:
+		return "SecretsDoNotExist", nil
+	case buildController.SecretDoesNotExist:
+		return "SecretDoesNotExist", nil
+	case buildController.UnknownStrategy:
+		return "UnknownStrategy", nil
+	case buildController.ListBuildStrategyInNamespaceFailed:
+		return "ListBuildStrategyInNamespaceFailed", nil
+	case buildController.NoneBuildStrategyFoundInNamespace:
+		return "NoneBuildStrategyFoundInNamespace", nil
+	case buildController.BuildStrategyDoesNotExistInNamespace:
+		return "BuildStrategyDoesNotExistInNamespace", nil
+	case buildController.ListClusterBuildStrategyFailed:
+		return "ListClusterBuildStrategyFailed", nil
+	case buildController.NoClusterBuildStrategyFound:
+		return "NoClusterBuildStrategyFound", nil
+	case buildController.ClusterBuildStrategyDoesNotExist:
+		return "ClusterBuildStrategyDoesNotExist", nil
+	case buildController.RuntimePathsCanNotBeEmpty:
+		return "RuntimePathsCanNotBeEmpty", nil
+	case buildController.SetOwnerReferenceFailed:
+		return "SetOwnerReferenceFailed", nil
+	default:
+		return "", errorNew.New("UNKNOWN ERROR CODE")
+	}
+}
+
+// validateError will validate if the error code's error message is correct
+func (c *Catalog) ValidateError(code ErrorCodes) (string, error) {
+	errorCodeName, err := c.ValidateErrorCode(code)
+	if err != nil {
+		fmt.Print("%v", err)
+		return "", err
+	}
+	return errorCodeName, nil
 }

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -6,6 +6,7 @@ package integration_test
 
 import (
 	"fmt"
+	"github.com/shipwright-io/build/pkg/controller/build"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -226,7 +227,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
-			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("the Build is not registered correctly, build: %s, registered status: False, reason: secret fake-secret does not exist", BUILD+tb.Namespace)))
+			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("the Build is not registered correctly, build: %s, registered status: False, reason: %v: secret fake-secret does not exist", BUILD+tb.Namespace, build.SecretDoesNotExist)))
 		})
 	})
 


### PR DESCRIPTION
Fix issue: https://github.com/shipwright-io/build/issues/463

This PR add a predefined error code as the prefix of error message, so that the third party can get the message what they want against this error code. These error codes will never be changed. So And the third party will not be affected by error message's contents.

Now, I use three numbers as the prefix, and begin with `001`. Also I extract all error message and put them at the beginning of codes. In the future, if we want to add more message, then we can append them in order.

I don't add extra functions, so I think add test cases are not necessary.