### PR TITLE
Enhance GetTRTillDesiredReason func

### DIFF
--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -75,14 +75,14 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 			_, err = tb.GetBRTillStartTime(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
-			err = tb.GetTRTillDesiredReason(buildRunObject.Name, "Pending")
-			Expect(err).To(BeNil())
+			actualReason, err := tb.GetTRTillDesiredReason(buildRunObject.Name, "Pending")
+			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", "Pending", actualReason))
 
 			err = tb.GetBRTillDesiredReason(buildRunObject.Name, "Pending")
 			Expect(err).To(BeNil())
 
-			err = tb.GetTRTillDesiredReason(buildRunObject.Name, "Running")
-			Expect(err).To(BeNil())
+			actualReason, err = tb.GetTRTillDesiredReason(buildRunObject.Name, "Running")
+			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", "Running", actualReason))
 
 			err = tb.GetBRTillDesiredReason(buildRunObject.Name, "Running")
 			Expect(err).To(BeNil())
@@ -106,8 +106,8 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 			_, err = tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
-			err = tb.GetTRTillDesiredReason(buildRunObject.Name, "TaskRunTimeout")
-			Expect(err).To(BeNil())
+			actualReason, err := tb.GetTRTillDesiredReason(buildRunObject.Name, "TaskRunTimeout")
+			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", "TaskRunTimeout", actualReason))
 
 			tr, err := tb.GetTaskRunFromBuildRun(buildRunObject.Name)
 			Expect(err).To(BeNil())
@@ -138,8 +138,8 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 			_, err = tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
-			err = tb.GetTRTillDesiredReason(buildRunObject.Name, "Failed")
-			Expect(err).To(BeNil())
+			actualReason, err := tb.GetTRTillDesiredReason(buildRunObject.Name, "Failed")
+			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", "Failed", actualReason))
 
 			tr, err := tb.GetTaskRunFromBuildRun(buildRunObject.Name)
 			Expect(err).To(BeNil())
@@ -180,8 +180,8 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 
 			err = tb.GetBRTillDesiredReason(buildRunObject.Name, fmt.Sprintf("TaskRun \"%s\" was cancelled", tr.Name))
 
-			err = tb.GetTRTillDesiredReason(buildRunObject.Name, "TaskRunCancelled")
-			Expect(err).To(BeNil())
+			actualReason, err := tb.GetTRTillDesiredReason(buildRunObject.Name, "TaskRunCancelled")
+			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", "TaskRunCancelled", actualReason))
 
 		})
 	})

--- a/test/integration/utils/taskruns.go
+++ b/test/integration/utils/taskruns.go
@@ -62,12 +62,14 @@ func (t *TestBuild) GetTRReason(buildRunName string) (string, error) {
 
 // GetTRTillDesiredReason polls until a TaskRun matches a desired Reason
 // or it exits if an error happen or a timeout is reach.
-func (t *TestBuild) GetTRTillDesiredReason(buildRunName string, reason string) error {
+func (t *TestBuild) GetTRTillDesiredReason(buildRunName string, reason string) (string, error) {
+	var trReason string
+	var err error
 
 	var (
 		pollTRTillCompletion = func() (bool, error) {
 
-			trReason, err := t.GetTRReason(buildRunName)
+			trReason, err = t.GetTRReason(buildRunName)
 			if err != nil {
 				return false, err
 			}
@@ -80,10 +82,10 @@ func (t *TestBuild) GetTRTillDesiredReason(buildRunName string, reason string) e
 		}
 	)
 
-	err := wait.PollImmediate(t.Interval, t.TimeOut, pollTRTillCompletion)
-	if err != nil {
-		return err
+	pollError := wait.PollImmediate(t.Interval, t.TimeOut, pollTRTillCompletion)
+	if pollError != nil {
+		return trReason, pollError
 	}
 
-	return nil
+	return trReason, nil
 }


### PR DESCRIPTION
Return the actual reason and then enhance the ginkgo assertions to display the actual reason in case of an error when calling this function. This is related with https://github.com/shipwright-io/build/pull/481

The above will provide users with the following insights in case of a failed assertion in ginkgo:

![Screenshot 2020-11-13 at 16 01 52](https://user-images.githubusercontent.com/4812480/99087785-75361700-25cb-11eb-8502-f36cf021ef64.png)
