### PR TITLE
Increase integration test timeouts

### DIFF
--- a/test/integration/utils/environment.go
+++ b/test/integration/utils/environment.go
@@ -71,7 +71,7 @@ func NewTestBuild() (*TestBuild, error) {
 	return &TestBuild{
 		// TODO: interval and timeout can be configured via ENV vars
 		Interval:          time.Second * 3,
-		TimeOut:           time.Second * 120,
+		TimeOut:           time.Second * 180,
 		KubeConfig:        restConfig,
 		Clientset:         kubeConfig,
 		Namespace:         testNamespace,


### PR DESCRIPTION
To help travis to get more time for polling for resources states. We are moving from 120s to 180s.