### PR TITLE
Partial fix for issue 486

### DIFF
--- a/test/data/build_buildpacks-v3_golang_cr.yaml
+++ b/test/data/build_buildpacks-v3_golang_cr.yaml
@@ -7,6 +7,7 @@ spec:
   source:
     url: https://github.com/cloudfoundry/cf-acceptance-tests
     contextDir: assets/catnip
+    revision: main
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy

--- a/test/data/build_buildpacks-v3_java_cr.yaml
+++ b/test/data/build_buildpacks-v3_java_cr.yaml
@@ -7,6 +7,7 @@ spec:
   source:
     url: https://github.com/cloudfoundry/cf-acceptance-tests
     contextDir: assets/java
+    revision: main
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy

--- a/test/data/build_buildpacks-v3_php_cr.yaml
+++ b/test/data/build_buildpacks-v3_php_cr.yaml
@@ -7,6 +7,7 @@ spec:
   source:
     url: https://github.com/cloudfoundry/cf-acceptance-tests
     contextDir: assets/php
+    revision: main
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy

--- a/test/data/build_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/build_buildpacks-v3_ruby_cr.yaml
@@ -7,6 +7,7 @@ spec:
   source:
     url: https://github.com/cloudfoundry/cf-acceptance-tests
     contextDir: assets/dora
+    revision: main
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy


### PR DESCRIPTION
This forces our samples to use the `main` branch from
https://github.com/cloudfoundry/cf-acceptance-tests , the master
branch was deprecated. Thanks @zhangtbj for reporting this.