### PR TITLE
Update Kaniko builder image to v1.3.0

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -185,7 +185,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.2.0
+      image: gcr.io/kaniko-project/executor:v1.3.0
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -226,7 +226,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.2.0
+      image: gcr.io/kaniko-project/executor:v1.3.0
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ const (
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
 	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
-	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.2.0"
+	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.3.0"
 	kanikoImageEnvVar  = "KANIKO_CONTAINER_IMAGE"
 
 	// environment variable to override the buckets

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.2.0
+      image: gcr.io/kaniko-project/executor:v1.3.0
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -29,7 +29,7 @@ spec:
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
-      image: gcr.io/kaniko-project/executor:v1.2.0
+      image: gcr.io/kaniko-project/executor:v1.3.0
       name: step-build-and-push
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
Update Kaniko builder image to the latest release `v1.3.0`: 
https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.3.0