### PR TITLE
Use single step for all four Buildpacks lifecycle phases

### DIFF
--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -10,51 +10,17 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: ["CHOWN"]
+          add: 
+            - CHOWN
       command:
         - /bin/bash
       args:
         - -c
         - >
-          chown -R "1000:1000" "/workspace/source" &&
-          chown -R "1000:1000" "/tekton/home"
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-    - name: step-detect
-      image: heroku/buildpacks:18
-      securityContext:
-        runAsUser: 1000
-      command:
-        - /cnb/lifecycle/detector
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-restore
-      image: heroku/buildpacks:18
-      securityContext:
-        runAsUser: 1000
-      command:
-        - /cnb/lifecycle/restorer
-      args:
-        - -layers=/layers
-        - -cache-dir=/cache
-        - -group=/layers/group.toml
+          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" /tekton/home &&
+          chown -R "1000:1000" /cache &&
+          chown -R "1000:1000" /layers
       resources:
         limits:
           cpu: 500m
@@ -67,38 +33,17 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-build
+    - name: step-create
       image: heroku/buildpacks:18
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
-        - /cnb/lifecycle/builder
+        - /cnb/lifecycle/creator
       args:
         - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-export
-      image: heroku/buildpacks:18
-      securityContext:
-        runAsUser: 0
-      command:
-        - /cnb/lifecycle/exporter
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
         - -cache-dir=/cache
-        - -group=/layers/group.toml
+        - -layers=/layers
         - $(build.output.image)
       resources:
         limits:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -10,51 +10,17 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: ["CHOWN"]
+          add: 
+            - CHOWN
       command:
         - /bin/bash
       args:
         - -c
         - >
-          chown -R "1000:1000" "/workspace/source" &&
-          chown -R "1000:1000" "/tekton/home"
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-    - name: step-detect
-      image: heroku/buildpacks:18
-      securityContext:
-        runAsUser: 1000
-      command:
-        - /cnb/lifecycle/detector
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-restore
-      image: heroku/buildpacks:18
-      securityContext:
-        runAsUser: 1000
-      command:
-        - /cnb/lifecycle/restorer
-      args:
-        - -layers=/layers
-        - -cache-dir=/cache
-        - -group=/layers/group.toml
+          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" /tekton/home &&
+          chown -R "1000:1000" /cache &&
+          chown -R "1000:1000" /layers
       resources:
         limits:
           cpu: 500m
@@ -67,38 +33,17 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-build
+    - name: step-create
       image: heroku/buildpacks:18
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       command:
-        - /cnb/lifecycle/builder
+        - /cnb/lifecycle/creator
       args:
         - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-export
-      image: heroku/buildpacks:18
-      securityContext:
-        runAsUser: 0
-      command:
-        - /cnb/lifecycle/exporter
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
         - -cache-dir=/cache
-        - -group=/layers/group.toml
+        - -layers=/layers
         - $(build.output.image)
       resources:
         limits:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -10,53 +10,17 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: ["CHOWN"]
+          add: 
+            - CHOWN
       command:
         - /bin/bash
       args:
         - -c
         - >
-          chown -R "1000:1000" "/workspace/source" &&
-          chown -R "1000:1000" "/tekton/home"
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-    - name: step-detect
-      image: docker.io/paketobuildpacks/builder:full
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-      command:
-        - /cnb/lifecycle/detector
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-restore
-      image: docker.io/paketobuildpacks/builder:full
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-      command:
-        - /cnb/lifecycle/restorer
-      args:
-        - -layers=/layers
-        - -cache-dir=/cache
-        - -group=/layers/group.toml
+          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" /tekton/home &&
+          chown -R "1000:1000" /cache &&
+          chown -R "1000:1000" /layers
       resources:
         limits:
           cpu: 500m
@@ -69,40 +33,17 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-build
+    - name: step-create
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
       command:
-        - /cnb/lifecycle/builder
+        - /cnb/lifecycle/creator
       args:
         - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-export
-      image: docker.io/paketobuildpacks/builder:full
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-      command:
-        - /cnb/lifecycle/exporter
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
         - -cache-dir=/cache
-        - -group=/layers/group.toml
+        - -layers=/layers
         - $(build.output.image)
       resources:
         limits:

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -10,53 +10,17 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: ["CHOWN"]
+          add: 
+            - CHOWN
       command:
         - /bin/bash
       args:
         - -c
         - >
-          chown -R "1000:1000" "/workspace/source" &&
-          chown -R "1000:1000" "/tekton/home"
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-    - name: step-detect
-      image: docker.io/paketobuildpacks/builder:full
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-      command:
-        - /cnb/lifecycle/detector
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-restore
-      image: docker.io/paketobuildpacks/builder:full
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-      command:
-        - /cnb/lifecycle/restorer
-      args:
-        - -layers=/layers
-        - -cache-dir=/cache
-        - -group=/layers/group.toml
+          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" /tekton/home &&
+          chown -R "1000:1000" /cache &&
+          chown -R "1000:1000" /layers
       resources:
         limits:
           cpu: 500m
@@ -69,40 +33,17 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-build
+    - name: step-create
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
       command:
-        - /cnb/lifecycle/builder
+        - /cnb/lifecycle/creator
       args:
         - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
-        - -group=/layers/group.toml
-        - -plan=/layers/plan.toml
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: layers-dir
-          mountPath: /layers
-    - name: step-export
-      image: docker.io/paketobuildpacks/builder:full
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-      command:
-        - /cnb/lifecycle/exporter
-      args:
-        - -app=/workspace/source/$(build.source.contextDir)
-        - -layers=/layers
         - -cache-dir=/cache
-        - -group=/layers/group.toml
+        - -layers=/layers
         - $(build.output.image)
       resources:
         limits:


### PR DESCRIPTION
FIxes #455 

The change updates the buildstrategies for Buildpacks, Heroku as well as Paketo, to use a single step for the four lifecycle phases. It is inspired by [the Tekton catalog entry for Buildpacks](https://github.com/tektoncd/catalog/blob/master/task/buildpacks/0.2/buildpacks.yaml). It uses the functionality introduced by [/cnb/lifecycle/creator](https://github.com/buildpacks/rfcs/blob/main/text/0026-lifecycle-all.md).

I am using the resources of one old step now for the merged step.

I did some performance tests. The old build strategy assigns different resources to the different steps: prepare, detect and restore got 0.1 CPU cores and 128 MiB memory; build and export received 0.5 CPU cores and 512 MiB memory. The new build strategy with just one step for the Buildpacks lifecycle continued to assign 0.1 CPU cores and 128 MiB memory to the prepare step while the buildpacks step received 0.5 CPU cores and 512 MiB memory. The source code came from [cf-acceptance-tests](https://github.com/cloudfoundry/cf-acceptance-tests/tree/main/assets). The Buildpacks builder image was [0.1.35-full](https://hub.docker.com/layers/paketobuildpacks/builder/0.1.35-full/images/sha256-cd76a6e4f3f75502a653c134c3ab0e85f16d92e24af91919c902d06028e13fbd?context=explore). I triggered ten buildruns at the same time. Four runtimes were tested:

| Runtime | Old build strategy | New build strategy |
| -- | -- | -- |
| Node | 1m18.5s | 1m14.6s |
| Go | 3m20.7s | 2m56.5s |
| Java | 1m43.1s | 1m33s |
| PHP | 2m17s | 2m12.6s |

To confirm no difference with larger load, a single comparison with 30 parallel builds:

| Runtime | Old build strategy | New build strategy |
| -- | -- | -- |
| Java | 2m57.7s | 2m13.666666666s |