### PR TITLE
Remove step prefix in all buildstrategy steps

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -184,7 +184,7 @@ metadata:
   name: kaniko-small
 spec:
   buildSteps:
-    - name: step-build-and-push
+    - name: build-and-push
       image: gcr.io/kaniko-project/executor:v1.3.0
       workingDir: /workspace/source
       securityContext:
@@ -225,7 +225,7 @@ metadata:
   name: kaniko-medium
 spec:
   buildSteps:
-    - name: step-build-and-push
+    - name: build-and-push
       image: gcr.io/kaniko-project/executor:v1.3.0
       workingDir: /workspace/source
       securityContext:
@@ -373,7 +373,7 @@ If we will apply the following resources:
 - We will use a modified buildah strategy, with the following steps resources:
 
   ```yaml
-    - name: step-buildah-bud
+    - name: buildah-bud
       image: quay.io/buildah/stable:latest
       workingDir: /workspace/source
       securityContext:
@@ -395,7 +395,7 @@ If we will apply the following resources:
       volumeMounts:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
-    - name: step-buildah-push
+    - name: buildah-push
       image: quay.io/buildah/stable:latest
       securityContext:
         privileged: true

--- a/docs/proposals/buildstrategy-steps-resources.md
+++ b/docs/proposals/buildstrategy-steps-resources.md
@@ -158,7 +158,7 @@ metadata:
   name: buildpacks-v3-default
 spec:
   buildSteps:
-    - name: step-prepare
+    - name: prepare
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 0
@@ -178,7 +178,7 @@ spec:
         request:
           cpu: "10m"
           memory: "128Mi"
-    - name: step-detect
+    - name: detect
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
@@ -198,7 +198,7 @@ spec:
         request:
           cpu: "250m"
           memory: "50Mi"
-    - name: step-restore
+    - name: restore
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
@@ -213,7 +213,7 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-build
+    - name: build
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000
@@ -234,7 +234,7 @@ spec:
         request:
           cpu: "500m"
           memory: "1Gi"
-    - name: step-export
+    - name: export
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000

--- a/docs/proposals/runtime-image.md
+++ b/docs/proposals/runtime-image.md
@@ -121,7 +121,7 @@ metadata:
 spec:
   taskSpec:
     steps:
-      - name: step-runtime-dockerfile
+      - name: runtime-dockerfile
         image: $(build.builder.image)
         securityContext:
           runAsUser: 0

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: buildah
 spec:
   buildSteps:
-    - name: step-buildah-bud
+    - name: buildah-bud
       image: quay.io/buildah/stable:latest
       workingDir: /workspace/source
       securityContext:
@@ -27,7 +27,7 @@ spec:
       volumeMounts:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
-    - name: step-buildah-push
+    - name: buildah-push
       image: quay.io/buildah/stable:latest
       securityContext:
         privileged: true

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: buildpacks-v3-heroku
 spec:
   buildSteps:
-    - name: step-prepare
+    - name: prepare
       image: heroku/buildpacks:18
       securityContext:
         runAsUser: 0
@@ -33,7 +33,7 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-create
+    - name: build-and-push
       image: heroku/buildpacks:18
       securityContext:
         runAsUser: 1000

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: buildpacks-v3-heroku
 spec:
   buildSteps:
-    - name: step-prepare
+    - name: prepare
       image: heroku/buildpacks:18
       securityContext:
         runAsUser: 0
@@ -33,7 +33,7 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-create
+    - name: build-and-push
       image: heroku/buildpacks:18
       securityContext:
         runAsUser: 1000

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: buildpacks-v3
 spec:
   buildSteps:
-    - name: step-prepare
+    - name: prepare
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 0
@@ -33,7 +33,7 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-create
+    - name: build-and-push
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: buildpacks-v3
 spec:
   buildSteps:
-    - name: step-prepare
+    - name: prepare
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 0
@@ -33,7 +33,7 @@ spec:
           mountPath: /cache
         - name: layers-dir
           mountPath: /layers
-    - name: step-create
+    - name: build-and-push
       image: docker.io/paketobuildpacks/builder:full
       securityContext:
         runAsUser: 1000

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kaniko
 spec:
   buildSteps:
-    - name: step-build-and-push
+    - name: build-and-push
       image: gcr.io/kaniko-project/executor:v1.3.0
       workingDir: /workspace/source
       securityContext:

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: source-to-image-redhat
 spec:
   buildSteps:
-    - name: step-s2i-generate
+    - name: s2i-generate
       image: registry.redhat.io/ocp-tools-43-tech-preview/source-to-image-rhel8:latest
       workingDir: /workspace/source
       args:
@@ -17,7 +17,7 @@ spec:
       volumeMounts:
         - name: s2i
           mountPath: /s2i
-    - name: step-buildah-bud
+    - name: buildah-bud
       image: quay.io/buildah/stable:latest
       workingDir: /s2i
       securityContext:
@@ -32,7 +32,7 @@ spec:
           mountPath: /s2i
         - name: buildah-images
           mountPath: /var/lib/containers/storage
-    - name: step-buildah-push
+    - name: buildah-push
       image: quay.io/buildah/stable:latest
       securityContext:
         privileged: true

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -30,7 +30,7 @@ spec:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
       image: gcr.io/kaniko-project/executor:v1.3.0
-      name: step-build-and-push
+      name: build-and-push
       securityContext:
         runAsUser: 0
         allowPrivilegeEscalation: false

--- a/test/buildstrategy_samples.go
+++ b/test/buildstrategy_samples.go
@@ -14,7 +14,7 @@ metadata:
   name: buildah
 spec:
   buildSteps:
-    - name: step-buildah-bud
+    - name: buildah-bud
       image: quay.io/buildah/stable:latest
       workingDir: /workspace/source
       securityContext:
@@ -36,7 +36,7 @@ spec:
       volumeMounts:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
-    - name: step-buildah-push
+    - name: buildah-push
       image: quay.io/buildah/stable:latest
       securityContext:
         privileged: true

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -14,7 +14,7 @@ metadata:
   name: buildah
 spec:
   buildSteps:
-    - name: step-buildah-bud
+    - name: buildah-bud
       image: quay.io/buildah/stable:latest
       workingDir: /workspace/source
       securityContext:
@@ -36,7 +36,7 @@ spec:
       volumeMounts:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
-    - name: step-buildah-push
+    - name: buildah-push
       image: quay.io/buildah/stable:latest
       securityContext:
         privileged: true
@@ -68,7 +68,7 @@ metadata:
   name: buildah
 spec:
   buildSteps:
-    - name: step-buildah-bud
+    - name: buildah-bud
       image: quay.io/buildah/stable:latest
       workingDir: /workspace/source
       securityContext:
@@ -90,7 +90,7 @@ spec:
       volumeMounts:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
-    - name: step-buildah-push
+    - name: buildah-push
       image: quay.io/buildah/stable:latest
       securityContext:
         privileged: true


### PR DESCRIPTION
For each Tetkon step, Tekon will add the `step-` prefix automatically. But in our all buildstrategies, we also add `step-` as prefix, so the step name has two duplicate `step-` which make end user confusing and it is hard to remember the correct step name for operation:

```
kubectl logs buildpack-nodejs-buildrun-vj4pr-pod-6h2b8
Error from server (BadRequest): 
a container name must be specified for pod buildpack-nodejs-buildrun-vj4pr-pod-6h2b8, 
choose one of: [
place-tools step-create-dir-image-slc4j 
step-git-source-source-wzfd4 
step-step-prepare 
step-step-detect 
step-step-restore 
step-step-build 
step-step-export 
step-image-digest-exporter-tt7b7
]
```
or
```
  step-step-build-and-push:
    Container ID:  containerd://4ed6198d1d9d776bcd50e5b4e546645c98983e7e7085a2486c24be2fa334bab7
    Image:         icr.io/obs/codeengine/kaniko/executor:v1.2.0-rc1
    Image ID:      icr.io/obs/codeengine/kaniko/executor@sha256:d84611667fc7478f0a210899c39cba2a73fcc5da39165787e12d76eca2c0aba4
    Port:          <none>
    Host Port:     <none>
```

So I did two changes:
- remove `step-` in all buildstrategy step names
- refine the `step-create` step in buildpacks buildstrategy to `step-build-and-push` to make it more clear