### PR TITLE
WIP: Add support for buildkit daemonless strategy

### DIFF
--- a/samples/build/build_buildkit_cr.yaml
+++ b/samples/build/build_buildkit_cr.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: buildkit-build
+  annotations:
+    build.build.dev/build-run-deletion: "true"
+spec:
+  dockerfile: "Dockerfile"
+  source:
+    url: https://github.com/sbose78/taxi
+  strategy:
+    name: buildkit
+    kind: ClusterBuildStrategy
+  dockerfile: Dockerfile
+  output:
+    image: us.icr.io/source-to-image-build/buildkit
+    credentials:
+      name: icr-knbuild

--- a/samples/buildrun/buildrun_buildkit_cr.yaml
+++ b/samples/buildrun/buildrun_buildkit_cr.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: BuildRun
+metadata:
+  name: buildkit-buildrun
+spec:
+  buildRef:
+    name: buildkit-build
+  serviceAccount:
+    generate: true

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: ClusterBuildStrategy
+metadata:
+  name: buildkit
+spec:
+  buildSteps:
+    - name: build-and-push
+      image: docker.io/moby/buildkit:v0.6.2@sha256:db234cf7362aef489e4273a6937794cb19c09ba15c7ee0ec6f85044086ea4f6a
+      workingDir: /workspace/source/
+      securityContext:
+        privileged: true
+      env:
+        - name: DOCKER_CONFIG
+          value: /tekton/home/.docker
+      command: ["buildctl-daemonless.sh", "--debug",
+                    "build",
+                    "--progress=plain",
+                    "--frontend=dockerfile.v0",
+                    "--opt", "filename=$(build.dockerfile)",
+                    "--local", "context=.", "--local", "dockerfile=.",
+                    "--output", "type=image,name=$(build.output.image),push=true",
+                    "--export-cache", "type=inline",
+                    "--import-cache", "type=registry,ref=$(build.output.image)"]


### PR DESCRIPTION
Fixes https://github.com/shipwright-io/build/issues/407

This is a daemonless flavour.
Keep in mind this requires `privileged` mode.
Verify this by pushing the image with the new strategy and pulling the
generated container image and running it, ending up with the taxi app.

Based on https://github.com/tektoncd/catalog/tree/master/task/buildkit-daemonless/0.1