### PR TITLE
Fix buildah ClusterBuildStrategy

### DIFF
--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -36,6 +36,7 @@ spec:
       args:
         - push
         - --tls-verify=false
+        - $(build.output.image)
         - docker://$(build.output.image)
       resources:
         limits:


### PR DESCRIPTION
For quay.io/buildah/stable:latest, the push cmd changed the arguments
behaviour. It now requires an IMAGE and a DESTINATION. The DESTINATION
can be ommited, and buildah would add that based on the IMAGE, by adding
a docker transport prefix (`docker://`).

Add IMAGE name to command explicitely and keep DESTINATION as-is.

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>