### PR TITLE
Add detailed error message for e2e test

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -127,7 +127,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		for _, clusterBuildStrategy := range clusterBuildStrategies {
 			Logf("Creating cluster build strategy %s", clusterBuildStrategy)
 			cbs, err := clusterBuildStrategyTestData(clusterBuildStrategy)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving cluster buildstrategy test data")
 			cbs.SetNamespace(namespace)
 
 			createClusterBuildStrategy(globalCtx, f, cbs, cleanupTimeout, cleanupRetryInterval)
@@ -138,7 +138,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		for _, namespaceBuildStrategy := range namespaceBuildStrategies {
 			Logf("Creating namespace build strategy %s", namespaceBuildStrategy)
 			nbs, err := buildStrategyTestData(namespace, namespaceBuildStrategy)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving build strategy test data")
 
 			createNamespacedBuildStrategy(globalCtx, f, nbs, cleanupTimeout, cleanupRetryInterval)
 		}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -26,7 +26,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		br = nil
 
 		namespace, err = ctx.GetWatchNamespace()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "Error retrieving namespace")
 	})
 
 	AfterEach(func() {
@@ -54,7 +54,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -77,7 +77,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -100,7 +100,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -146,7 +146,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -169,7 +169,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -192,7 +192,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_php_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -238,7 +238,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -283,7 +283,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_buildpacks-v3_nodejs_runtime-image_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -323,7 +323,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -363,7 +363,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("fails the build run", func() {
 			br, err = buildRunTestData(namespace, testID, "test/data/buildrun_timeout.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToFail(ctx,
 				namespace,
@@ -392,7 +392,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 		It("successfully runs a build", func() {
 			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_source-to-image_cr.yaml")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 		})
@@ -423,7 +423,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})
@@ -469,7 +469,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_kaniko_cr.yaml")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})
@@ -514,7 +514,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 			It("successfully runs a build", func() {
 				br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_source-to-image_cr.yaml")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 				validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
 			})

--- a/test/e2e/samples.go
+++ b/test/e2e/samples.go
@@ -86,10 +86,10 @@ func createBuild(ctx *framework.Context, namespace string, identifier string, fi
 	Logf("Creating build %s", identifier)
 
 	rootDir, err := getRootDir()
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "Unable to get root dir")
 
 	b, err := buildTestData(namespace, identifier, rootDir+"/"+filePath)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
 
 	amendBuild(identifier, b)
 

--- a/test/e2e/validators.go
+++ b/test/e2e/validators.go
@@ -154,7 +154,7 @@ func createNamespacedBuildStrategy(
 ) {
 	err := f.Client.Create(goctx.TODO(), testBuildStrategy, cleanupOptions(ctx, timeout, retry))
 	if err != nil {
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "on creating namespace build strategy")
 	}
 }
 
@@ -168,7 +168,7 @@ func createClusterBuildStrategy(
 ) {
 	err := f.Client.Create(goctx.TODO(), testBuildStrategy, cleanupOptions(ctx, timeout, retry))
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to create cluster build strategy")
 	}
 }
 
@@ -201,7 +201,7 @@ func validateBuildRunToSucceed(
 			return corev1.ConditionUnknown
 		}
 
-		Expect(testBuildRun.Status.GetCondition(operator.Succeeded).Status).ToNot(Equal(falseCondition))
+		Expect(testBuildRun.Status.GetCondition(operator.Succeeded).Status).ToNot(Equal(falseCondition), "BuildRun status doesn't move to Succeeded")
 
 		now := time.Now()
 		if now.After(nextStatusLog) {
@@ -214,7 +214,7 @@ func validateBuildRunToSucceed(
 	}, time.Duration(1100*getTimeoutMultiplier())*time.Second, 5*time.Second).Should(Equal(trueCondition), "BuildRun did not succeed")
 
 	// Verify that the BuildSpec is still available in the status
-	Expect(testBuildRun.Status.BuildSpec).ToNot(BeNil())
+	Expect(testBuildRun.Status.BuildSpec).ToNot(BeNil(), "BuildSpec is not available in the status")
 
 	Logf("Test build '%s' is completed after %v !", testBuildRun.GetName(), testBuildRun.Status.CompletionTime.Time.Sub(testBuildRun.Status.StartTime.Time))
 }
@@ -249,7 +249,7 @@ func validateBuildRunToFail(
 			return corev1.ConditionUnknown
 		}
 
-		Expect(testBuildRun.Status.GetCondition(operator.Succeeded).Status).ToNot(Equal(trueCondition))
+		Expect(testBuildRun.Status.GetCondition(operator.Succeeded).Status).ToNot(Equal(trueCondition), "BuildRun status doesn't move to fail status")
 
 		now := time.Now()
 		if now.After(nextStatusLog) {
@@ -414,6 +414,6 @@ func getTimeoutMultiplier() int64 {
 	}
 
 	intValue, err := strconv.ParseInt(value, 10, 64)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "Failed to parse EnvVarTimeoutMultiplier to integer")
 	return intValue
 }


### PR DESCRIPTION
When running end to end test, in some failures, the error message clearly described what's wrong in the test case in expect clause, such as in https://github.com/shipwright-io/build/blob/master/test/e2e/validators.go#L109, but sometimes there is no error message description in expect clause, such as in https://github.com/shipwright-io/build/blob/master/test/e2e/e2e_test.go#L29. 
This PR is to fill in all missing error message description in expect clause in end to end test. Test result with this PR shows this line `BuildRun status doesn't move to Succeeded`. Without this PR, it only showed the below `Expect... ` lines.
![image](https://user-images.githubusercontent.com/7133130/103864579-d37c0380-50fd-11eb-854d-d1e2a23ffd37.png)
