### PR TITLE
Temporarily use develop branch for dora

### DIFF
--- a/test/data/build_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/build_buildpacks-v3_ruby_cr.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     url: https://github.com/cloudfoundry/cf-acceptance-tests
     contextDir: assets/dora
-    revision: main
+    revision: develop
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy


### PR DESCRIPTION
To workaround the ruby buildpack failure, I am changing to use the develop branch instead of main, as explained [here](https://github.com/shipwright-io/build/issues/532#issuecomment-758500156).