### PR TITLE
Refactor Build Status fields

### DIFF
--- a/deploy/crds/build.dev_builds_crd.yaml
+++ b/deploy/crds/build.dev_builds_crd.yaml
@@ -251,9 +251,13 @@ spec:
           status:
             description: BuildStatus defines the observed state of Build
             properties:
+              message:
+                description: The message of the registered Build, either an error
+                  or succeed message
+                type: string
               reason:
-                description: The reason of the registered Build, either an error or
-                  succeed message
+                description: The reason of the registered Build, it's an one-word
+                  camelcase
                 type: string
               registered:
                 description: The Register status of the Build

--- a/docs/build.md
+++ b/docs/build.md
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 
 - [Overview](#overview)
 - [Build Controller](#build-controller)
+- [Build Validations](#build-validations)
 - [Configuring a Build](#configuring-a-build)
   - [Defining the Source](#defining-the-source)
   - [Defining the Strategy](#defining-the-strategy)
@@ -39,6 +40,22 @@ When the controller reconciles it:
 - Validates if the referenced `StrategyRef` exists.
 - Validates if the container `registry` output secret exists.
 - Validates if the referenced `spec.source.url` endpoint exists.
+
+## Build Validations
+
+In order to prevent users from triggering `BuildRuns` (_execution of a Build_) that will eventually fail because of wrong or missing dependencies or configuration settings, the Build controller will validate them in advance. If all validations are successful, users can expect a `Succeeded` `Status.Reason`, however if any of the validations failed, users can rely on the `Status.Reason` and `Status.Message` fields, in order to understand the root cause.
+
+| Status.Reason | Description |
+| --- | --- |
+| BuildStrategyNotFound   | The referenced namespace-scope strategy doesn´t exist. |
+| ClusterBuildStrategyNotFound   | The referenced cluster-scope strategy doesn´t exist. |
+| SetOwnerReferenceFailed   | Setting ownerreferences between a Build and a BuildRun failed. This is triggered when making use of the `build.build.dev/build-run-deletion` annotation in a Build. |
+| SpecSourceSecretNotFound | The secret used to authenticate to git doesn´t exist. |
+| SpecOutputSecretRefNotFound | The secret used to authenticate to the container registry doesn´t exist. |
+| SpecRuntimeSecretRefNotFound | The secret used to authenticate to the container registry doesn´t exist.|
+| MultipleSecretRefNotFound | More than one secret is missing. At the moment, only three paths on a Build can specify a secret. |
+| RuntimePathsCanNotBeEmpty | The Runtime feature is used, but the runtime path was not defined. This is mandatory. |
+| RemoteRepositoryUnreachable | The defined `spec.source.url` was not found. This validation only take place for http/https protocols. |
 
 ## Configuring a Build
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/operator-framework/operator-sdk v0.18.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/spf13/pflag v1.0.5

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -9,6 +9,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// BuildReason is a type used for populating the
+// Build Status.Reason field
+type BuildReason string
+
+const (
+	// SucceedStatus indicates that all validations Succeeded
+	SucceedStatus BuildReason = "Succeeded"
+	// BuildStrategyNotFound indicates that a namespaced-scope strategy was not found in the namespace
+	BuildStrategyNotFound BuildReason = "BuildStrategyNotFound"
+	// ClusterBuildStrategyNotFound indicates that a cluster-scope strategy was not found
+	ClusterBuildStrategyNotFound BuildReason = "ClusterBuildStrategyNotFound"
+	// SetOwnerReferenceFailed indicates that setting ownerReferences between a Build and a BuildRun failed
+	SetOwnerReferenceFailed BuildReason = "SetOwnerReferenceFailed"
+	// SpecSourceSecretRefNotFound indicates the referenced secret in source is missing
+	SpecSourceSecretRefNotFound BuildReason = "SpecSourceSecretRefNotFound"
+	// SpecOutputSecretRefNotFound indicates the referenced secret in output is missing
+	SpecOutputSecretRefNotFound BuildReason = "SpecOutputSecretRefNotFound"
+	// SpecRuntimeSecretRefNotFound indicates the referenced secret in runtime is missing
+	SpecRuntimeSecretRefNotFound BuildReason = "SpecRuntimeSecretRefNotFound"
+	// MultipleSecretRefNotFound indicates that multiple secrets are missing
+	MultipleSecretRefNotFound BuildReason = "MultipleSecretRefNotFound"
+	// RuntimePathsCanNotBeEmpty indicates that the spec.runtime feature is used but the paths were not specified
+	RuntimePathsCanNotBeEmpty BuildReason = "RuntimePathsCanNotBeEmpty"
+	// RemoteRepositoryUnreachable indicates the referenced repository is unreachable
+	RemoteRepositoryUnreachable BuildReason = "RemoteRepositoryUnreachable"
+	// AllValidationsSucceeded indicates a Build was successfully validated
+	AllValidationsSucceeded = "all validations succeeded"
+)
+
 const (
 	// BuildDomain is the domain used for all labels and annotations for this resource
 	BuildDomain = "build.build.dev"

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -164,9 +164,13 @@ type BuildStatus struct {
 	// +optional
 	Registered corev1.ConditionStatus `json:"registered,omitempty"`
 
-	// The reason of the registered Build, either an error or succeed message
+	// The reason of the registered Build, it's an one-word camelcase
 	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason BuildReason `json:"reason,omitempty"`
+
+	// The message of the registered Build, either an error or succeed message
+	// +optional
+	Message string `json:"message,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -285,7 +285,8 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			// Set OwnerReference for Build and BuildRun only when build.build.dev/build-run-deletion is set "true"
 			if build.GetAnnotations()[buildv1alpha1.AnnotationBuildRunDeletion] == "true" && !isOwnedByBuild(build, buildRun.OwnerReferences) {
 				if err := r.setOwnerReferenceFunc(build, buildRun, r.scheme); err != nil {
-					build.Status.Reason = fmt.Sprintf("unexpected error when trying to set the ownerreference: %v", err)
+					build.Status.Reason = buildv1alpha1.SetOwnerReferenceFailed
+					build.Status.Message = fmt.Sprintf("unexpected error when trying to set the ownerreference: %v", err)
 					if err := r.client.Status().Update(ctx, build); err != nil {
 						return reconcile.Result{}, err
 					}

--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -711,7 +711,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					ctl.DefaultNamespacedBuildStrategy()),
 				)
 
-				statusCall := ctl.StubBuildStatusReason(
+				statusCall := ctl.StubBuildStatusReason(build.SetOwnerReferenceFailed,
 					fmt.Sprintf("unexpected error when trying to set the ownerreference: Object /%s is already owned by another %s controller ", buildRunName, fakeOwnerName),
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -740,7 +740,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					ctl.DefaultNamespacedBuildStrategy()),
 				)
 
-				statusCall := ctl.StubBuildStatusReason(
+				statusCall := ctl.StubBuildStatusReason(build.SetOwnerReferenceFailed,
 					fmt.Sprintf("unexpected error when trying to set the ownerreference: cross-namespace owner references are disallowed, owner's namespace %s, obj's namespace %s", buildSample.Namespace, buildRunSample.Namespace),
 				)
 				statusWriter.UpdateCalls(statusCall)

--- a/pkg/validate/ownerreferences.go
+++ b/pkg/validate/ownerreferences.go
@@ -1,0 +1,98 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/ctxlog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// OwnerRef contains all required fields
+// to validate a Build OwnerReference definition
+type OwnerRef struct {
+	Build  *build.Build
+	Client client.Client
+	Scheme *runtime.Scheme
+}
+
+// ValidatePath implements BuildPath interface and validates
+// setting the ownershipReference between a Build and a BuildRun
+func (o OwnerRef) ValidatePath(ctx context.Context) error {
+
+	buildRunList, err := o.retrieveBuildRunsfromBuild(ctx)
+	if err != nil {
+		return err
+	}
+
+	switch o.Build.GetAnnotations()[build.AnnotationBuildRunDeletion] {
+	case "true":
+		// if the buildRun does not have an ownerreference to the Build, lets add it.
+		for _, buildRun := range buildRunList.Items {
+			if index := o.validateBuildOwnerReference(buildRun.OwnerReferences); index == -1 {
+				if err := controllerutil.SetControllerReference(o.Build, &buildRun, o.Scheme); err != nil {
+					o.Build.Status.Reason = build.SetOwnerReferenceFailed
+					o.Build.Status.Message = fmt.Sprintf("unexpected error when trying to set the ownerreference: %v", err)
+				}
+				if err = o.Client.Update(ctx, &buildRun); err != nil {
+					return err
+				}
+				ctxlog.Info(ctx, fmt.Sprintf("successfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
+			}
+		}
+	case "", "false":
+		// if the buildRun have an ownerreference to the Build, lets remove it
+		for _, buildRun := range buildRunList.Items {
+			if index := o.validateBuildOwnerReference(buildRun.OwnerReferences); index != -1 {
+				buildRun.OwnerReferences = removeOwnerReferenceByIndex(buildRun.OwnerReferences, index)
+				if err := o.Client.Update(ctx, &buildRun); err != nil {
+					return err
+				}
+				ctxlog.Info(ctx, fmt.Sprintf("successfully updated BuildRun %s", buildRun.Name), namespace, buildRun.Namespace, name, buildRun.Name)
+			}
+		}
+
+	default:
+		ctxlog.Info(ctx, fmt.Sprintf("the annotation %s was not properly defined, supported values are true or false", build.AnnotationBuildRunDeletion), namespace, o.Build.Namespace, name, o.Build.Name)
+		return fmt.Errorf("the annotation %s was not properly defined, supported values are true or false", build.AnnotationBuildRunDeletion)
+	}
+
+	return nil
+}
+
+// retrieveBuildRunsfromBuild returns a list of BuildRuns that are owned by a Build in the same namespace
+func (o OwnerRef) retrieveBuildRunsfromBuild(ctx context.Context) (*build.BuildRunList, error) {
+	buildRunList := &build.BuildRunList{}
+
+	lbls := map[string]string{
+		build.LabelBuild: o.Build.Name,
+	}
+	opts := client.ListOptions{
+		Namespace:     o.Build.Namespace,
+		LabelSelector: labels.SelectorFromSet(lbls),
+	}
+
+	err := o.Client.List(ctx, buildRunList, &opts)
+	return buildRunList, err
+}
+
+// validateOwnerReferences returns an index value if a Build is owning a reference or -1 if this is not the case
+func (o OwnerRef) validateBuildOwnerReference(references []metav1.OwnerReference) int {
+	for i, ownerRef := range references {
+		if ownerRef.Kind == o.Build.Kind && ownerRef.Name == o.Build.Name {
+			return i
+		}
+	}
+	return -1
+}
+
+// removeOwnerReferenceByIndex removes the entry by index, this will not keep the same
+// order in the slice
+func removeOwnerReferenceByIndex(references []metav1.OwnerReference, i int) []metav1.OwnerReference {
+	return append(references[:i], references[i+1:]...)
+}

--- a/pkg/validate/runtime.go
+++ b/pkg/validate/runtime.go
@@ -1,0 +1,30 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/controller/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RuntimeRef contains all required fields
+// to validate a Build spec runtime definition
+type RuntimeRef struct {
+	Build  *build.Build
+	Client client.Client
+}
+
+// ValidatePath implements BuildPath interface and validates
+// that the Build spec runtime definition is properly populated
+func (r RuntimeRef) ValidatePath(ctx context.Context) error {
+	if utils.IsRuntimeDefined(r.Build) {
+		if len(r.Build.Spec.Runtime.Paths) == 0 {
+			r.Build.Status.Reason = build.RuntimePathsCanNotBeEmpty
+			r.Build.Status.Message = "the property 'spec.runtime.paths' must not be empty"
+			return fmt.Errorf("missing some") // TODO
+		}
+	}
+	return nil
+}

--- a/pkg/validate/secrets.go
+++ b/pkg/validate/secrets.go
@@ -1,0 +1,60 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SecretRef contains all required fields
+// to validate a Build spec secrets definitions
+type SecretRef struct {
+	Build  *build.Build
+	Client client.Client
+}
+
+// ValidatePath implements BuildPath interface and validates
+// that all referenced secrets under spec exists
+func (s SecretRef) ValidatePath(ctx context.Context) error {
+	var missingSecrets []string
+	secret := &corev1.Secret{}
+
+	secretNames := s.buildSecretReferences()
+
+	for refSecret, secretType := range secretNames {
+		if err := s.Client.Get(ctx, types.NamespacedName{Name: refSecret, Namespace: s.Build.Namespace}, secret); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		} else if apierrors.IsNotFound(err) {
+			s.Build.Status.Reason = secretType
+			s.Build.Status.Message = fmt.Sprintf("referenced secret %s not found", refSecret)
+			missingSecrets = append(missingSecrets, refSecret)
+		}
+	}
+
+	if len(missingSecrets) > 1 {
+		s.Build.Status.Reason = build.MultipleSecretRefNotFound
+		s.Build.Status.Message = fmt.Sprintf("missing secrets are %s", strings.Join(missingSecrets, ","))
+	}
+	return nil
+}
+
+func (s SecretRef) buildSecretReferences() map[string]build.BuildReason {
+	// Validate if the referenced secrets exist in the namespace
+	secretRefMap := map[string]build.BuildReason{}
+	if s.Build.Spec.Output.SecretRef != nil && s.Build.Spec.Output.SecretRef.Name != "" {
+		secretRefMap[s.Build.Spec.Output.SecretRef.Name] = build.SpecOutputSecretRefNotFound
+	}
+	if s.Build.Spec.Source.SecretRef != nil && s.Build.Spec.Source.SecretRef.Name != "" {
+		secretRefMap[s.Build.Spec.Source.SecretRef.Name] = build.SpecSourceSecretRefNotFound
+	}
+	if s.Build.Spec.BuilderImage != nil && s.Build.Spec.BuilderImage.SecretRef != nil && s.Build.Spec.BuilderImage.SecretRef.Name != "" {
+		secretRefMap[s.Build.Spec.BuilderImage.SecretRef.Name] = build.SpecRuntimeSecretRefNotFound
+	}
+	return secretRefMap
+}

--- a/pkg/validate/sourceurl.go
+++ b/pkg/validate/sourceurl.go
@@ -1,0 +1,49 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/ctxlog"
+	"github.com/shipwright-io/build/pkg/git"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SourceURLRef contains all required fields
+// to validate a Build spec source definition
+type SourceURLRef struct {
+	Build  *build.Build
+	Client client.Client
+}
+
+// ValidatePath implements BuildPath interface and validates
+// that the spec.source.url exists. This validation only applies
+// to endpoints that do not require authentication.
+func (s SourceURLRef) ValidatePath(ctx context.Context) error {
+	if s.Build.Spec.Source.SecretRef == nil {
+		switch s.Build.GetAnnotations()[build.AnnotationBuildVerifyRepository] {
+		case "", "true":
+			err := git.ValidateGitURLExists(s.Build.Spec.Source.URL)
+			if err != nil {
+				s.MarkBuildStatus(s.Build, build.RemoteRepositoryUnreachable, err.Error())
+			}
+			return err
+		case "false":
+			ctxlog.Info(ctx, fmt.Sprintf("the annotation %s is set to %s, nothing to do", build.AnnotationBuildVerifyRepository, s.Build.GetAnnotations()[build.AnnotationBuildVerifyRepository]))
+			return nil
+		default:
+			var annoErr = fmt.Errorf("the annotation %s was not properly defined, supported values are true or false", build.AnnotationBuildVerifyRepository)
+			ctxlog.Error(ctx, annoErr, namespace, s.Build.Namespace, name, s.Build.Name)
+			s.MarkBuildStatus(s.Build, build.RemoteRepositoryUnreachable, annoErr.Error())
+			return annoErr
+		}
+	}
+	return nil
+}
+
+// MarkBuildStatus updates a Build Status fields
+func (s SourceURLRef) MarkBuildStatus(build *build.Build, reason build.BuildReason, msg string) {
+	build.Status.Reason = reason
+	build.Status.Message = msg
+}

--- a/pkg/validate/strategies.go
+++ b/pkg/validate/strategies.go
@@ -1,0 +1,70 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/ctxlog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// StrategyRef contains all required fields
+// to validate a Build spec strategy definition
+type StrategyRef struct {
+	Build  *build.Build
+	Client client.Client
+}
+
+// ValidatePath implements BuildPath interface and validates
+// that the referenced strategy exists. This applies to both
+// namespaced or cluster scoped strategies
+func (s StrategyRef) ValidatePath(ctx context.Context) error {
+	if s.Build.Spec.StrategyRef != nil {
+		if s.Build.Spec.StrategyRef.Kind != nil {
+			switch *s.Build.Spec.StrategyRef.Kind {
+			case build.NamespacedBuildStrategyKind:
+				if err := s.validateBuildStrategy(ctx, s.Build.Spec.StrategyRef.Name, s.Build); err != nil {
+					return err
+				}
+			case build.ClusterBuildStrategyKind:
+				if err := s.validateClusterBuildStrategy(ctx, s.Build.Spec.StrategyRef.Name, s.Build); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unknown strategy kind: %v", *s.Build.Spec.StrategyRef.Kind)
+			}
+		} else {
+			ctxlog.Info(ctx, "buildStrategy kind is nil, use default NamespacedBuildStrategyKind")
+			if err := s.validateBuildStrategy(ctx, s.Build.Spec.StrategyRef.Name, s.Build); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s StrategyRef) validateBuildStrategy(ctx context.Context, strategyName string, b *build.Build) error {
+	buildStrategy := &build.BuildStrategy{}
+	if err := s.Client.Get(ctx, types.NamespacedName{Name: strategyName, Namespace: b.Namespace}, buildStrategy); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	} else if apierrors.IsNotFound(err) {
+		b.Status.Reason = build.BuildStrategyNotFound
+		b.Status.Message = fmt.Sprintf("buildStrategy %s does not exist in namespace %s", b.Spec.StrategyRef.Name, b.Namespace)
+	}
+
+	return nil
+}
+
+func (s StrategyRef) validateClusterBuildStrategy(ctx context.Context, strategyName string, b *build.Build) error {
+	clusterBuildStrategy := &build.ClusterBuildStrategy{}
+	if err := s.Client.Get(ctx, types.NamespacedName{Name: strategyName}, clusterBuildStrategy); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	} else if apierrors.IsNotFound(err) {
+		b.Status.Reason = build.ClusterBuildStrategyNotFound
+		b.Status.Message = fmt.Sprintf("clusterBuildStrategy %s does not exist", b.Spec.StrategyRef.Name)
+	}
+	return nil
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -1,0 +1,77 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// Secrets for validating secret references in Build objects
+	Secrets = "secrets"
+	// Strategies for validating strategy references in Build objects
+	Strategies = "strategy"
+	// SourceURL for validating the source URL in Build objects
+	SourceURL = "sourceurl"
+	// Runtime for validating the runtime definition in Build objects
+	Runtime = "runtime"
+	// OwnerReferences for validating the ownerreferences between a Build
+	// and BuildRun objects
+	OwnerReferences = "ownerreferences"
+	namespace       = "namespace"
+	name            = "name"
+)
+
+// BuildPath is an interface that holds a ValidaPath() function
+// for validating different Build spec paths
+type BuildPath interface {
+	ValidatePath(ctx context.Context) error
+}
+
+// NewValidation returns an specific Structure that implements
+// BuildPath interface
+func NewValidation(
+	validationType string,
+	build *build.Build,
+	client client.Client,
+	scheme *runtime.Scheme,
+) (BuildPath, error) {
+	secretRef := SecretRef{
+		Build:  build,
+		Client: client,
+	}
+	strategyRef := StrategyRef{
+		Build:  build,
+		Client: client,
+	}
+	sourceURLRef := SourceURLRef{
+		Build:  build,
+		Client: client,
+	}
+	runtimeSpecRef := RuntimeRef{
+		Build:  build,
+		Client: client,
+	}
+	ownerRef := OwnerRef{
+		Build:  build,
+		Client: client,
+		Scheme: scheme,
+	}
+	switch validationType {
+	case Secrets:
+		return secretRef, nil
+	case Strategies:
+		return strategyRef, nil
+	case SourceURL:
+		return sourceURLRef, nil
+	case Runtime:
+		return runtimeSpecRef, nil
+	case OwnerReferences:
+		return ownerRef, nil
+	default:
+		return nil, fmt.Errorf("unknown validation type")
+	}
+}

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
-			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("the Build is not registered correctly, build: %s, registered status: False, reason: secret fake-secret does not exist", BUILD+tb.Namespace)))
+			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("the Build is not registered correctly, build: %s, registered status: False, reason: SpecOutputSecretRefNotFound", BUILD+tb.Namespace)))
 		})
 	})
 

--- a/test/integration/build_to_git_test.go
+++ b/test/integration/build_to_git_test.go
@@ -54,7 +54,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -77,7 +78,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("remote repository unreachable"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("remote repository unreachable"))
 		})
 	})
 
@@ -102,7 +104,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -125,7 +128,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("remote repository unreachable"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("remote repository unreachable"))
 		})
 	})
 
@@ -151,7 +155,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(err).To(BeNil())
 			// this one is validating file protocol
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("invalid source url"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("invalid source url"))
 		})
 	})
 
@@ -176,7 +181,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(err).To(BeNil())
 			// skip validation due to false annotation
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -203,7 +209,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
 			// Because github enterprise always require authentication, this validation will fail while
 			// the repository could not be found.
-			Expect(buildObject.Status.Reason).To(ContainSubstring("no such host"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(ContainSubstring("no such host"))
 		})
 
 		It("should not validate sourceURL because a referenced secret exists", func() {
@@ -232,7 +239,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 
 			// Because this build references a source secret, Build controller will skip this validation.
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -259,7 +267,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			// Because sourceURL with git@ format implies that authentication is required,
 			// this validation will be skipped and build will be successful.
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("the source url requires authentication"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("the source url requires authentication"))
 		})
 	})
 
@@ -286,7 +295,8 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			// Because sourceURL with ssh format implies that authentication is required,
 			// this validation will be skipped and build will be successful.
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal("the source url requires authentication"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(buildObject.Status.Message).To(Equal("the source url requires authentication"))
 		})
 	})
 })

--- a/test/integration/build_to_secrets_test.go
+++ b/test/integration/build_to_secrets_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 
 			// delete a secret
 			Expect(tb.DeleteSecret(buildObject.Spec.Output.SecretRef.Name)).To(BeNil())
@@ -66,8 +66,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", buildObject.Spec.Output.SecretRef.Name)))
-
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecOutputSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.Output.SecretRef.Name)))
 		})
 
 		It("should validate when a missing secret is recreated", func() {
@@ -86,7 +86,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", buildObject.Spec.Output.SecretRef.Name)))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecOutputSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.Output.SecretRef.Name)))
 
 			sampleSecret := tb.Catalog.SecretWithAnnotation(buildObject.Spec.Output.SecretRef.Name, buildObject.Namespace)
 
@@ -97,7 +98,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 		})
 	})
 
@@ -123,7 +124,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 
 			// delete a secret
 			Expect(tb.DeleteSecret(buildObject.Spec.Output.SecretRef.Name)).To(BeNil())
@@ -150,7 +151,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", buildObject.Spec.Output.SecretRef.Name)))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecOutputSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.Output.SecretRef.Name)))
 
 			sampleSecret := tb.Catalog.SecretWithoutAnnotation(buildObject.Spec.Output.SecretRef.Name, buildObject.Namespace)
 
@@ -161,8 +163,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", buildObject.Spec.Output.SecretRef.Name)))
-
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecOutputSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.Output.SecretRef.Name)))
 		})
 
 		It("should validate when a missing secret is recreated with annotation", func() {
@@ -181,7 +183,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", "fake-secret")))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecOutputSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", "fake-secret")))
 
 			sampleSecret := tb.Catalog.SecretWithoutAnnotation(buildObject.Spec.Output.SecretRef.Name, buildObject.Namespace)
 
@@ -189,7 +192,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			Expect(tb.CreateSecret(sampleSecret)).To(BeNil())
 			// validate build status again
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", "fake-secret")))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecOutputSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", "fake-secret")))
 
 			// we modify the annotation so automatic delete does not take place
 			data := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%s":"true"}}}`, v1alpha1.AnnotationBuildRefSecret))
@@ -201,8 +205,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
-
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal("all validations succeeded"))
 		})
 	})
 
@@ -228,7 +232,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal("all validations succeeded"))
 
 			// delete a secret
 			Expect(tb.DeleteSecret(buildObject.Spec.Source.SecretRef.Name)).To(BeNil())
@@ -237,8 +242,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", buildObject.Spec.Source.SecretRef.Name)))
-
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecSourceSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.Source.SecretRef.Name)))
 		})
 
 		It("should validate when a missing secret is recreated", func() {
@@ -269,7 +274,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 		})
 	})
 
@@ -295,7 +300,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 
 			// delete a secret
 			Expect(tb.DeleteSecret(buildObject.Spec.BuilderImage.SecretRef.Name)).To(BeNil())
@@ -304,7 +309,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", buildObject.Spec.BuilderImage.SecretRef.Name)))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecRuntimeSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.BuilderImage.SecretRef.Name)))
 
 		})
 
@@ -324,7 +330,8 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", buildObject.Spec.BuilderImage.SecretRef.Name)))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecRuntimeSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.BuilderImage.SecretRef.Name)))
 
 			sampleSecret := tb.Catalog.SecretWithAnnotation(buildObject.Spec.BuilderImage.SecretRef.Name, buildObject.Namespace)
 
@@ -335,7 +342,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 		})
 	})
 
@@ -363,17 +370,18 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 
 			// delete a secret
 			Expect(tb.DeleteSecret(specSourceSecret.Name)).To(BeNil())
 			Expect(tb.DeleteSecret(specBuilderSecret.Name)).To(BeNil())
 
-			buildObject, err = tb.GetBuildTillReasonContainsSubstring(buildName, "do not exist")
+			buildObject, err = tb.GetBuildTillMessageContainsSubstring(buildName, "missing secrets are")
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(ContainSubstring(specSourceSecret.Name))
-			Expect(buildObject.Status.Reason).To(ContainSubstring(specBuilderSecret.Name))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.MultipleSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(ContainSubstring(specSourceSecret.Name))
+			Expect(buildObject.Status.Message).To(ContainSubstring(specBuilderSecret.Name))
 
 		})
 
@@ -393,9 +401,10 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(ContainSubstring("do not exist"))
-			Expect(buildObject.Status.Reason).To(ContainSubstring(buildObject.Spec.Source.SecretRef.Name))
-			Expect(buildObject.Status.Reason).To(ContainSubstring(buildObject.Spec.BuilderImage.SecretRef.Name))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.MultipleSecretRefNotFound))
+			Expect(buildObject.Status.Message).To(ContainSubstring("missing secrets are"))
+			Expect(buildObject.Status.Message).To(ContainSubstring(buildObject.Spec.Source.SecretRef.Name))
+			Expect(buildObject.Status.Message).To(ContainSubstring(buildObject.Spec.BuilderImage.SecretRef.Name))
 
 			specSourceSecret := tb.Catalog.SecretWithAnnotation(buildObject.Spec.Source.SecretRef.Name, buildObject.Namespace)
 			specBuilderSecret := tb.Catalog.SecretWithAnnotation(buildObject.Spec.BuilderImage.SecretRef.Name, buildObject.Namespace)
@@ -408,7 +417,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(buildObject.Status.Reason).To(Equal("Succeeded"))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 		})
 	})
 	Context("when multiple builds reference a secret with annotations for the spec.source", func() {
@@ -443,12 +452,12 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			o, err := tb.GetBuildTillValidation(firstBuildName)
 			Expect(err).To(BeNil())
 			Expect(o.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(o.Status.Reason).To(Equal("Succeeded"))
+			Expect(o.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 
 			o, err = tb.GetBuildTillValidation(secondBuildName)
 			Expect(err).To(BeNil())
 			Expect(o.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(o.Status.Reason).To(Equal("Succeeded"))
+			Expect(o.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 
 			// delete a secret
 			Expect(tb.DeleteSecret(specSourceSecret.Name)).To(BeNil())
@@ -457,13 +466,15 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			o, err = tb.GetBuildTillRegistration(firstBuildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(o.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(o.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", firstBuildObject.Spec.Source.SecretRef.Name)))
+			Expect(o.Status.Reason).To(Equal(v1alpha1.SpecSourceSecretRefNotFound))
+			Expect(o.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", firstBuildObject.Spec.Source.SecretRef.Name)))
 
 			// assert that the validation happened one more time
 			o, err = tb.GetBuildTillRegistration(secondBuildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(o.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(o.Status.Reason).To(Equal(fmt.Sprintf("secret %s does not exist", secondBuildObject.Spec.Source.SecretRef.Name)))
+			Expect(o.Status.Reason).To(Equal(v1alpha1.SpecSourceSecretRefNotFound))
+			Expect(o.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", secondBuildObject.Spec.Source.SecretRef.Name)))
 		})
 		It("should validate the Builds when a missing secret is recreated", func() {
 			// populate Build related vars
@@ -505,12 +516,12 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			o, err := tb.GetBuildTillRegistration(firstBuildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(o.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(o.Status.Reason).To(Equal("Succeeded"))
+			Expect(o.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 
 			o, err = tb.GetBuildTillRegistration(secondBuildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
 			Expect(o.Status.Registered).To(Equal(corev1.ConditionTrue))
-			Expect(o.Status.Reason).To(Equal("Succeeded"))
+			Expect(o.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
 		})
 	})
 })

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -317,7 +317,8 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 			b, err := tb.GetBuildTillRegistration(buildObject.Name, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(b.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(b.Status.Reason).To(ContainSubstring("no such host"))
+			Expect(b.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
+			Expect(b.Status.Message).To(ContainSubstring("no such host"))
 
 			_, err = tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())

--- a/test/integration/utils/builds.go
+++ b/test/integration/utils/builds.go
@@ -123,13 +123,13 @@ func (t *TestBuild) GetBuildTillRegistration(name string, condition corev1.Condi
 	return brInterface.Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-// GetBuildTillReasonContainsSubstring polls until a Build reason contains the desired
+// GetBuildTillMessageContainsSubstring polls until a Build message contains the desired
 // substring value and updates it´s registered field. If timeout is reached or an error is found,
 // it will return with an error
-func (t *TestBuild) GetBuildTillReasonContainsSubstring(name string, partOfReason string) (*v1alpha1.Build, error) {
+func (t *TestBuild) GetBuildTillMessageContainsSubstring(name string, partOfMessage string) (*v1alpha1.Build, error) {
 
 	var (
-		pollBuildTillReasonContainsSubString = func() (bool, error) {
+		pollBuildTillMessageContainsSubString = func() (bool, error) {
 
 			bInterface := t.BuildClientSet.BuildV1alpha1().Builds(t.Namespace)
 
@@ -138,7 +138,7 @@ func (t *TestBuild) GetBuildTillReasonContainsSubstring(name string, partOfReaso
 				return false, err
 			}
 
-			if strings.Contains(buildRun.Status.Reason, partOfReason) {
+			if strings.Contains(buildRun.Status.Message, partOfMessage) {
 				return true, nil
 			}
 
@@ -148,7 +148,7 @@ func (t *TestBuild) GetBuildTillReasonContainsSubstring(name string, partOfReaso
 
 	brInterface := t.BuildClientSet.BuildV1alpha1().Builds(t.Namespace)
 
-	if err := wait.PollImmediate(t.Interval, t.TimeOut, pollBuildTillReasonContainsSubString); err != nil {
+	if err := wait.PollImmediate(t.Interval, t.TimeOut, pollBuildTillMessageContainsSubString); err != nil {
 		return nil, err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,7 +254,6 @@ github.com/operator-framework/operator-sdk/version
 # github.com/pborman/uuid v1.2.0
 github.com/pborman/uuid
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.8.0
 ## explicit


### PR DESCRIPTION
This fixes #463 and #494

_Note_: this a follow-up based on the discussions in #463 , we are not longer introducing error codes, but rather an enhancement in the Build Status fields based on the feedback on that issue.

This should conclude a set of enhancements we have been doing in both Build/BuildRun Status fields. This PR proposes an enhancement on the Build Status fields. This will provide more clarity for users on why a validation happened and will also standardize the `Status.Reason` via the usage of a one-word camelCase constant. We also introduce a distinction on which type of referenced secret is missing, previously we were only highlighting if one or multiple secrets were missing, but we didn´t make any references to where in the Build definition was this secret used.

The following are examples of some of the validation scenarios on how the new fields will be populated.

### All validations succeeded

![image](https://user-images.githubusercontent.com/4812480/105023646-824c0800-5a4b-11eb-8c03-a900e749e921.png)

### spec.source secret is missing

![image](https://user-images.githubusercontent.com/4812480/105023941-d5be5600-5a4b-11eb-83dc-20f327a0d553.png)
![image](https://user-images.githubusercontent.com/4812480/105023983-df47be00-5a4b-11eb-80ce-6539fe97997d.png)

### spec.output secret is missing

![image](https://user-images.githubusercontent.com/4812480/105023815-b7f0f100-5a4b-11eb-90fd-42f3e854fc21.png)
![image](https://user-images.githubusercontent.com/4812480/105023790-b0c9e300-5a4b-11eb-85ea-a6b6c60e3724.png)

### multiple secrets are missing

![image](https://user-images.githubusercontent.com/4812480/105024151-0acaa880-5a4c-11eb-8fc8-e93a2118418b.png)
![image](https://user-images.githubusercontent.com/4812480/105024184-128a4d00-5a4c-11eb-978e-d75b5a0a5dd0.png)

### ClusterBuildStrategy is missing

![image](https://user-images.githubusercontent.com/4812480/105024253-2afa6780-5a4c-11eb-9c3d-c29969c3b335.png)
![image](https://user-images.githubusercontent.com/4812480/105024286-3188df00-5a4c-11eb-8c39-c33cf136d20b.png)
