### PR TITLE
Print operator log for failed integration test case

### DIFF
--- a/pkg/ctxlog/log.go
+++ b/pkg/ctxlog/log.go
@@ -6,6 +6,7 @@ package ctxlog
 
 import (
 	"context"
+	"io"
 
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -18,6 +19,18 @@ import (
 // implementation
 func NewLogger(name string) logr.Logger {
 	l := zap.Logger()
+
+	logf.SetLogger(l)
+
+	l = l.WithName(name)
+
+	return l
+}
+
+// NewLoggerTo returns a new Logger which logs
+// to a given destination.
+func NewLoggerTo(destWriter io.Writer, name string) logr.Logger {
+	l := zap.LoggerTo(destWriter)
 
 	logf.SetLogger(l)
 

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -55,6 +55,12 @@ var _ = AfterEach(func() {
 	if tb.StopBuildOperator != nil {
 		close(tb.StopBuildOperator)
 	}
+
+	if CurrentGinkgoTestDescription().Failed && tb.BuildOperatorLogBuffer != nil {
+		// print operator logs
+		fmt.Println("\nLogs of the operator:")
+		fmt.Printf("%v\n", tb.BuildOperatorLogBuffer)
+	}
 })
 
 var _ = AfterSuite(func() {

--- a/test/integration/utils/operator.go
+++ b/test/integration/utils/operator.go
@@ -5,8 +5,6 @@
 package utils
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	buildconfig "github.com/shipwright-io/build/pkg/config"
@@ -19,7 +17,7 @@ import (
 func (t *TestBuild) StartBuildOperator() (chan struct{}, error) {
 	c := buildconfig.NewDefaultConfig()
 
-	mgr, err := controller.NewManager(context.Background(), c, t.KubeConfig, manager.Options{
+	mgr, err := controller.NewManager(t.Context, c, t.KubeConfig, manager.Options{
 		Namespace:          t.Namespace,
 		LeaderElection:     false,
 		MetricsBindAddress: "0",


### PR DESCRIPTION
I was just fighting with a failing integration test and needed access to the logs of the operator. Had to do a quick hack. Proposing here a solution that dumps the logs in case a test case fails. Here is an example:

```bash
$ make test-integration
installing apis
customresourcedefinition.apiextensions.k8s.io/buildstrategies.build.dev unchanged
customresourcedefinition.apiextensions.k8s.io/clusterbuildstrategies.build.dev unchanged
customresourcedefinition.apiextensions.k8s.io/builds.build.dev unchanged
customresourcedefinition.apiextensions.k8s.io/buildruns.build.dev unchanged
GO111MODULE=on ginkgo \
        -randomizeAllSpecs \
        -randomizeSuites \
        -failOnPending \
        -slowSpecThreshold=240 \
        -trace \
        -focus=SASCHA \
        test/integration/...
Running Suite: Integration Suite
================================
Random Seed: 1611069618 - Will randomize all specs
Will run 1 of 39 specs

SSSSSS
Logs of the operator:
{"level":"info","ts":1611069626.5348132,"logger":"test-build-201","msg":"Registering Components."}
{"level":"info","ts":1611069626.5391345,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"build-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1611069626.54015,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildrun-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1611069626.5417032,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildstrategy-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1611069626.5427108,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"clusterbuildstrategy-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1611069626.643647,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"build-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1611069626.6446395,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"buildstrategy-controller"}
{"level":"info","ts":1611069626.6584384,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"clusterbuildstrategy-controller"}
{"level":"info","ts":1611069626.6609323,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"buildrun-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1611069626.744976,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"build-controller"}
{"level":"info","ts":1611069626.7450142,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"build-controller","worker count":1}
{"level":"info","ts":1611069626.7451818,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"buildstrategy-controller","worker count":1}
{"level":"info","ts":1611069626.7459912,"logger":"test-build-201.buildstrategy-controller","msg":"reconciling BuildStrategy","namespace":"test-build-201","name":"buildah"}
{"level":"info","ts":1611069626.7588978,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"clusterbuildstrategy-controller","worker count":1}
{"level":"error","ts":1611069626.7605817,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"info","ts":1611069626.7623847,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"buildrun-controller"}
{"level":"info","ts":1611069626.762401,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"buildrun-controller","worker count":1}
{"level":"error","ts":1611069626.783543,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069627.7780914,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069627.802235,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069628.9264355,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069628.9264355,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069630.1422846,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069630.1425176,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069631.3531342,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069631.3537345,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069632.3693857,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069632.3737822,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069633.3999321,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069633.4068966,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069634.4249017,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069634.7025445,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069635.441569,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069635.717029,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069636.7349608,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069637.012958,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069639.3134098,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069639.588261,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069644.4488194,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069644.7230148,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069654.7055032,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069654.9757738,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069675.199538,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069675.469568,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069716.1723518,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069716.4426327,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069798.1085942,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"buildrun-controller","name":"buildrun-test-build-201","namespace":"test-build-201","error":"errors: the Build is not registered correctly, build: build-test-build-201, registered status: False, reason: buildStrategy buildahWRONG does not exist in namespace test-build-201, msg: Build is not ready","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}
{"level":"error","ts":1611069798.3758738,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"build-controller","name":"build-test-build-201","namespace":"test-build-201","error":"errors: buildStrategy buildahWRONG does not exist in namespace test-build-201 <nil>","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/home/sascha/go/src/github.com/shipwright-io/build/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90"}


------------------------------
• Failure [180.352 seconds]
SASCHA Integration tests BuildStrategies and TaskRuns
/home/sascha/go/src/github.com/shipwright-io/build/test/integration/buildstrategy_to_taskruns_test.go:15
  when a buildrun is created
  /home/sascha/go/src/github.com/shipwright-io/build/test/integration/buildstrategy_to_taskruns_test.go:59
    should create a taskrun with the correct annotations [It]
    /home/sascha/go/src/github.com/shipwright-io/build/test/integration/buildstrategy_to_taskruns_test.go:66

    Expected
        <*errors.errorString | 0xc00044f5a0>: {
            s: "timed out waiting for the condition",
        }
    to be nil

    /home/sascha/go/src/github.com/shipwright-io/build/test/integration/buildstrategy_to_taskruns_test.go:73

    Full Stack Trace
    github.com/shipwright-io/build/test/integration_test.glob..func5.4.2()
        /home/sascha/go/src/github.com/shipwright-io/build/test/integration/buildstrategy_to_taskruns_test.go:73 +0x30e
    github.com/shipwright-io/build/test/integration_test.TestIntegration(0xc000418a20)
        /home/sascha/go/src/github.com/shipwright-io/build/test/integration/integration_suite_test.go:19 +0x96
    testing.tRunner(0xc000418a20, 0x18b9a40)
        /usr/lib/go-1.14/src/testing/testing.go:991 +0xdc
    created by testing.(*T).Run
        /usr/lib/go-1.14/src/testing/testing.go:1042 +0x357
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Summarizing 1 Failure:

[Fail] SASCHA Integration tests BuildStrategies and TaskRuns when a buildrun is created [It] should create a taskrun with the correct annotations 
/home/sascha/go/src/github.com/shipwright-io/build/test/integration/buildstrategy_to_taskruns_test.go:73

Ran 1 of 39 Specs in 180.366 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 38 Skipped
--- FAIL: TestIntegration (180.37s)
FAIL

Ginkgo ran 1 suite in 3m8.720189s
Test Suite Failed
make: *** [Makefile:152: test-integration] Error 1
```

In case of successful test cases, no logs are printed which you can verify by looking at the PR build.