### PR TITLE
Go back to main branch for dora

### DIFF
--- a/test/data/build_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/build_buildpacks-v3_ruby_cr.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     url: https://github.com/cloudfoundry/cf-acceptance-tests
     contextDir: assets/dora
-    revision: develop
+    revision: main
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy


### PR DESCRIPTION
Fixes #532

The new ruby buildpack has been released. This contains the lax version matching for bundler and is therefore supposed to work also with the main branch of cf-acceptance-test that references an older version of bundler.