### PR TITLE
Refactor travis tests to only run e2e

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ install:
 script:
   - set -e
   - make
-  - make verify-codegen
-  # https://github.com/shipwright-io/build/issues/123
-  - make test-unit-coverage
-  - make test-integration
   - make test-e2e TEST_IMAGE_REPO="$(./hack/install-registry.sh show):5000/shipwright-io/build-e2e"
   - set +e
 deploy:


### PR DESCRIPTION
Ensure only e2e tests are executed, unit and integration should
be done via git actions