### PR TITLE
Remove operator-sdk install from integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
             go-version: ${{ matrix.go-version }}
         - name: Check out code
           uses: actions/checkout@v2
-        - name: Install operator-sdk
-          run: make install-operator-sdk
         - name: Install kubectl
           uses: azure/setup-kubectl@v1
           with:


### PR DESCRIPTION
Integration tests don't need the operator-sdk binary to run.
Remove the install operator-sdk step to improve performance.