### PR TITLE
Email communication channels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,5 @@ To join, please request an invite in our Slack [channel](https://kubernetes.slac
 ## Contact Information
 
 - [Slack channel](https://kubernetes.slack.com/archives/C019ZRGUEJC)
+- End-user email list: [shipwright-users@lists.shipwright.io](https://lists.shipwright.io/admin/lists/shipwright-users.lists.shipwright.io/)
+- Developer email list: [shipwright-dev@lists.shipwright.io](https://lists.shipwright.io/admin/lists/shipwright-dev.lists.shipwright.io/)

--- a/README.md
+++ b/README.md
@@ -159,11 +159,16 @@ We are so excited to have you!
 - See [DEVELOPMENT.md](DEVELOPMENT.md) for how to get started
 - See [HACK.md](HACK.md) for how to build, test & run
   (advanced reading material)
-- Contact us in Kubernetes slack: [#shipwright](https://kubernetes.slack.com/messages/shipwright)
 - Look at our
   [good first issues](https://github.com/shipwright-io/build/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
   and our
   [help wanted issues](https://github.com/shipwright-io/build/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- Contact us:
+  - Kubernetes Slack: [#shipwright](https://kubernetes.slack.com/messages/shipwright)
+  - Users can discuss help, feature requests, or potential bugs at [shipwright-users@lists.shipwright.io](https://lists.shipwright.io/archives/list/shipwright-users@lists.shipwright.io/).
+  Click [here](<mailto:shipwright-users-join@lists.shipwright.io?subject=Subscribe to shipwright-users>) to join.
+  - Contributors can discuss active development topics at [shipwright-dev@lists.shipwright.io](https://lists.shipwright.io/archives/list/shipwright-dev@lists.shipwright.io/).
+  Click [here](<mailto:shipwright-dev-join@lists.shipwright.io?subject=Subscribe to shipwright-dev>) to join.
 
 [corev1container]: https://github.com/kubernetes/api/blob/v0.17.3/core/v1/types.go#L2106
 [pipelinesoperator]: https://www.openshift.com/learn/topics/pipelines

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Shipwright Security and Disclosure Information
+
+Shipwright encourages all users and contributors to report potential security vulnerabilities to the project maintainers.
+If you think you have found a security flaw related to Shipwright's code, please send a report to <shipwright-security@lists.shipwright.io>.
+Encryption using GPG is NOT required to make a disclosure.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -7,3 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 # Shipwright Code of Conduct
 
 Shipwright follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing others' private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Contributors are expected to adhere to the code of contact in all interactions with fellow Shipwright community members, which includes electronic communications (email, Slack) as well as direct in-person contact.
+Violators of the code of conduct are subject to removal from relevant project forums.
+
+If you witness a violation of the code of conduct, please report it to the Shipwright maintainers by emailing <shipwright-admin@lists.shipwright.io>.


### PR DESCRIPTION
Add our email communication channels to relevant shipwright/build documentation.

- End user list - shipwright-users@lists.shipwright.io
- Dev topics list - shipwright-dev@lists.shipwright.io
- Admins - shipwright-admin@lists.shipwright.io
- Security - shipwright-security@lists.shipwright.io