### PR TITLE
Fix missing BuildRun Conditions updates on errors

### DIFF
--- a/pkg/controller/buildrun/buildrun_controller_test.go
+++ b/pkg/controller/buildrun/buildrun_controller_test.go
@@ -172,6 +172,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 				statusCall := ctl.StubBuildRunStatus(
 					"Succeeded",
 					&taskRunName,
+					build.Condition{
+						Type:    build.Succeeded,
+						Reason:  "Succeeded",
+						Status:  corev1.ConditionTrue,
+					},
 					corev1.ConditionTrue,
 					buildSample.Spec,
 					false,
@@ -262,6 +267,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 				statusCall := ctl.StubBuildRunStatus(
 					"Pending",
 					&taskRunName,
+					build.Condition{
+						Type:    build.Succeeded,
+						Reason:  "Pending",
+						Status:  corev1.ConditionUnknown,
+					},
 					corev1.ConditionUnknown,
 					buildSample.Spec,
 					false,
@@ -287,6 +297,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 				statusCall := ctl.StubBuildRunStatus(
 					"Running",
 					&taskRunName,
+					build.Condition{
+						Type:    build.Succeeded,
+						Reason:  "Running",
+						Status:  corev1.ConditionUnknown,
+					},
 					corev1.ConditionUnknown,
 					buildSample.Spec,
 					false,
@@ -309,6 +324,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 				statusCall := ctl.StubBuildRunStatus(
 					"Succeeded",
 					&taskRunName,
+					build.Condition{
+						Type:    build.Succeeded,
+						Reason:  "Succeeded",
+						Status:  corev1.ConditionTrue,
+					},
 					corev1.ConditionTrue,
 					buildSample.Spec,
 					false,
@@ -332,6 +352,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 				statusCall := ctl.StubBuildRunStatus(
 					"some message",
 					&taskRunName,
+					build.Condition{
+						Type:    build.Succeeded,
+						Reason:  "something bad happened",
+						Status:  corev1.ConditionFalse,
+					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
 					false,
@@ -408,6 +433,11 @@ var _ = Describe("Reconcile BuildRun", func() {
 				statusCall := ctl.StubBuildRunStatus(
 					fmt.Sprintf(" \"%s\" not found", saName),
 					emptyTaskRunName,
+					build.Condition{
+						Type:    build.Succeeded,
+						Reason:  "Failed",
+						Status:  corev1.ConditionFalse,
+					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
 					true,

--- a/test/buildrun_samples.go
+++ b/test/buildrun_samples.go
@@ -90,6 +90,18 @@ spec:
     name: foobar
 `
 
+// MinimalBuildRunWithSpecifiedServiceAccount defines a minimal BuildRun
+// with a reference to a not existing serviceAccount
+const MinimalBuildRunWithSpecifiedServiceAccount = `
+apiVersion: build.dev/v1alpha1
+kind: BuildRun
+spec:
+  buildRef:
+    name: buildah
+  serviceAccount:
+    name: foobar
+`
+
 // MinimalBuildRunWithSAGeneration defines a minimal BuildRun
 // with a reference to a not existing Build
 const MinimalBuildRunWithSAGeneration = `

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -280,11 +280,13 @@ func (c *Catalog) StubBuildStatusReason(reason build.BuildReason, message string
 }
 
 // StubBuildRunStatus asserts Status fields on a BuildRun resource
-func (c *Catalog) StubBuildRunStatus(reason string, name *string, status corev1.ConditionStatus, buildSpec build.BuildSpec, tolerateEmptyStatus bool) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+func (c *Catalog) StubBuildRunStatus(reason string, name *string, condition build.Condition, status corev1.ConditionStatus, buildSpec build.BuildSpec, tolerateEmptyStatus bool) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 	return func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 		switch object := object.(type) {
 		case *build.BuildRun:
 			if !tolerateEmptyStatus || object.Status.Succeeded != "" {
+				Expect(object.Status.GetCondition(build.Succeeded).Status).To(Equal(condition.Status))
+				Expect(object.Status.GetCondition(build.Succeeded).Reason).To(Equal(condition.Reason))
 				Expect(object.Status.Succeeded).To(Equal(status))
 				Expect(object.Status.Reason).To(Equal(reason))
 				Expect(object.Status.LatestTaskRunRef).To(Equal(name))

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -6,6 +6,7 @@ package integration_test
 
 import (
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -85,7 +86,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())
 			Expect(br.Status.Reason).To(ContainSubstring("failed to finish within"))
-
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("BuildRunTimeout"))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Message).To(ContainSubstring("failed to finish within"))
 		})
 	})
 
@@ -105,6 +108,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())
 			Expect(br.Status.Reason).To(ContainSubstring("failed to finish within \"1s\""))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("BuildRunTimeout"))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Message).To(ContainSubstring("failed to finish within"))
 		})
 
 		It("should be able to override the build output", func() {
@@ -179,7 +185,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			br, err = tb.GetBR(buildRunObject.Name)
 			Expect(err).To(BeNil())
 			Expect(br.Status.CompletionTime).To(BeNil())
-
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Type).To(Equal(v1alpha1.Succeeded))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionUnknown))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("Pending"))
 		})
 	})
 
@@ -206,6 +214,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("Build.build.dev \"%s\" not found", BUILD+tb.Namespace)))
 			Expect(br.Status.StartTime).To(BeNil())
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("Failed"))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Message).To(ContainSubstring("not found"))
 
 		})
 	})
@@ -227,6 +238,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 
 			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("the Build is not registered correctly, build: %s, registered status: False, reason: SpecOutputSecretRefNotFound", BUILD+tb.Namespace)))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("Failed"))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Message).To(ContainSubstring("Build is not registered correctly"))
 		})
 	})
 
@@ -254,6 +268,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(br.Status.CompletionTime).ToNot(BeNil())
 			Expect(br.Status.StartTime).To(BeNil())
 			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("Build.build.dev \"%s\" not found", BUILD+tb.Namespace+"foobar")))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("Failed"))
+			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Message).To(ContainSubstring("not found"))
 		})
 	})
 

--- a/test/integration/buildruns_to_sa_test.go
+++ b/test/integration/buildruns_to_sa_test.go
@@ -6,6 +6,7 @@ package integration_test
 
 import (
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -125,4 +126,27 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 			Expect(tr.Spec.ServiceAccountName).To(Equal(expectedServiceAccount))
 		})
 	})
+
+	Context("when a buildrun is created with a specified service-account", func() {
+
+		BeforeEach(func() {
+			buildSample = []byte(test.BuildCBSWithShortTimeOut)
+			buildRunSample = []byte(test.MinimalBuildRunWithSpecifiedServiceAccount)
+		})
+
+		It("it fails and updates buildrun conditions if the specified serviceaccount doesn't exist", func() {
+			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
+
+			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
+			Expect(err).To(BeNil())
+			buildRunCondition := br.Status.GetCondition(v1alpha1.Succeeded)
+			Expect(buildRunCondition).ToNot(BeNil())
+			Expect(buildRunCondition.Status).To(Equal(corev1.ConditionFalse))
+			Expect(buildRunCondition.Reason).To(Equal("Failed"))
+			Expect(buildRunCondition.Message).To(ContainSubstring("not found"))
+		})
+	})
 })
+


### PR DESCRIPTION
The `Status.Conditions` under this [function](https://github.com/shipwright-io/build/blob/master/pkg/controller/buildrun/buildrun_controller.go#L676-L684) is not being populated, this PR enhances this.

- when validate failed during buildRun reconciles, this buildRun condition field will be set. The reason is `Failed` and status is `False`. Below is a buildRun example about the specified serviceAccount in buildRun doesn't exist:
```
apiVersion: v1
items:
- apiVersion: build.dev/v1alpha1
  kind: BuildRun
  metadata:
    creationTimestamp: "2021-01-28T08:20:38Z"
    generation: 1
    labels:
      build.build.dev/generation: "1"
      build.build.dev/name: build-test-build-201
    name: buildrun-test-build-201
    namespace: test-build-201
    resourceVersion: "79744925"
    selfLink: /apis/build.dev/v1alpha1/namespaces/test-build-201/buildruns/buildrun-test-build-201
    uid: 5733ec27-b475-4199-8437-18f76551e82e
  spec:
    buildRef:
      name: build-test-build-201
    serviceAccount:
      name: foobar
  status:
    buildSpec:
      output:
        image: image-registry.openshift-image-registry.svc:5000/example/buildpacks-app
      source:
        url: https://github.com/sbose78/taxi
      strategy:
        kind: ClusterBuildStrategy
        name: strategy-test-build-201
      timeout: 5s
    completionTime: "2021-01-28T08:20:43Z"
    conditions:
    - lastTransitionTime: "2021-01-28T08:20:43Z"
      message: ServiceAccount "foobar" not found
      reason: Failed
      status: "False"
      type: Succeeded
    reason: ServiceAccount "foobar" not found
    succeeded: "False"
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
- Update related test castes to check the condition field;

- Fix a typo of isOwnedByBuild func.