### PR TITLE
Add more labels for Counter count metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,17 +10,17 @@ The Build component exposes several metrics to help you monitor the health and b
 
 Following build metrics are exposed at service `build-operator-metrics` on port `8383`.
 
-| Name | Type | Description | Labels | Status |
-| ---- | ---- | ----------- | ------ | ------ |
-| `build_builds_registered_total` | Counter | Number of total registered Builds. | buildstrategy=<build_buildstrategy_name> | experimental |
-| `build_buildruns_completed_total` | Counter | Number of total completed BuildRuns. | buildstrategy=<build_buildstrategy_name> | experimental |
-| `build_buildrun_establish_duration_seconds` | Histogram | BuildRun establish duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_completion_duration_seconds` | Histogram | BuildRun completion duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_rampup_duration_seconds` | Histogram | BuildRun ramp-up duration in seconds | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_rampup_duration_seconds` | Histogram | BuildRun taskrun ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| Name                                                 | Type      | Description                                       | Labels                                                                                                                                                                           | Status       |
+|:-----------------------------------------------------|:----------|:--------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------|
+| `build_builds_registered_total`                      | Counter   | Number of total registered Builds.                | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup>                                          | experimental |
+| `build_buildruns_completed_total`                    | Counter   | Number of total completed BuildRuns.              | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_establish_duration_seconds`          | Histogram | BuildRun establish duration in seconds.           | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_completion_duration_seconds`         | Histogram | BuildRun completion duration in seconds.          | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_rampup_duration_seconds`             | Histogram | BuildRun ramp-up duration in seconds              | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_rampup_duration_seconds`     | Histogram | BuildRun taskrun ramp-up duration in seconds.     | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
 
-<sup>1</sup> Labels for histograms are disabled by default. See [Configuration of histogram labels](#configuration-of-histogram-labels) to enable them.
+<sup>1</sup> Labels for metric are disabled by default. See [Configuration of metric labels](#configuration-of-metric-labels) to enable them.
 
 ## Configuration of histogram buckets
 
@@ -51,25 +51,26 @@ When you deploy the build operator in a Kubernetes cluster, you need to extend t
 [...]
 ```
 
-## Configuration of histogram labels
+## Configuration of metric labels
 
-As the amount of buckets and labels has a direct impact on the number of Prometheus time series, you can selectively enable labels that you are interested in using the `PROMETHEUS_HISTOGRAM_ENABLED_LABELS` environment variable. The supported labels are:
+As the amount of buckets and labels has a direct impact on the number of Prometheus time series, you can selectively enable labels that you are interested in using the `PROMETHEUS_ENABLED_LABELS` environment variable. The supported labels are:
 
 * buildstrategy
 * namespace
+* build
 * buildrun
 
 Use a comma-separated value to enable multiple labels. For example:
 
 ```bash
-export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=namespace
+export PROMETHEUS_ENABLED_LABELS=namespace
 make local
 ```
 
 or
 
 ```bash
-export PROMETHEUS_HISTOGRAM_ENABLED_LABELS=buildstrategy,namespace,buildrun
+export PROMETHEUS_ENABLED_LABELS=buildstrategy,namespace,build
 make local
 ```
 
@@ -78,7 +79,7 @@ When you deploy the build operator in a Kubernetes cluster, you need to extend t
 ```yaml
 [...]
   env:
-  - name: PROMETHEUS_HISTOGRAM_ENABLED_LABELS
+  - name: PROMETHEUS_ENABLED_LABELS
     value: namespace
 [...]
 ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,8 +27,8 @@ const (
 	metricBuildRunEstablishDurationBucketsEnvVar  = "PROMETHEUS_BR_EST_DUR_BUCKETS"
 	metricBuildRunRampUpDurationBucketsEnvVar     = "PROMETHEUS_BR_RAMPUP_DUR_BUCKETS"
 
-	// environment variable to enable histogram labels
-	prometheusHistogramEnabledLabelsEnvVar = "PROMETHEUS_HISTOGRAM_ENABLED_LABELS"
+	// environment variable to enable prometheus metric labels
+	prometheusEnabledLabelsEnvVar = "PROMETHEUS_ENABLED_LABELS"
 
 	leaderElectionNamespaceDefault = "default"
 	leaderElectionNamespaceEnvVar  = "BUILD_OPERATOR_LEADER_ELECTION_NAMESPACE"
@@ -59,7 +59,7 @@ type PrometheusConfig struct {
 	BuildRunCompletionDurationBuckets []float64
 	BuildRunEstablishDurationBuckets  []float64
 	BuildRunRampUpDurationBuckets     []float64
-	HistogramEnabledLabels            []string
+	EnabledLabels                     []string
 }
 
 // ManagerOptions contains configurable options for the build operator manager
@@ -112,7 +112,7 @@ func (c *Config) SetConfigFromEnv() error {
 		return err
 	}
 
-	c.Prometheus.HistogramEnabledLabels = strings.Split(os.Getenv(prometheusHistogramEnabledLabelsEnvVar), ",")
+	c.Prometheus.EnabledLabels = strings.Split(os.Getenv(prometheusEnabledLabelsEnvVar), ",")
 
 	if leaderElectionNamespace := os.Getenv(leaderElectionNamespaceEnvVar); leaderElectionNamespace != "" {
 		c.ManagerOptions.LeaderElectionNamespace = leaderElectionNamespace

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,9 +50,9 @@ var _ = Describe("Config", func() {
 		})
 
 		It("should allow for an override of the Prometheus enabled labels using an environment variable", func() {
-			var overrides = map[string]string{"PROMETHEUS_HISTOGRAM_ENABLED_LABELS": "namespace,strategy"}
+			var overrides = map[string]string{"PROMETHEUS_ENABLED_LABELS": "namespace,strategy"}
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.Prometheus.HistogramEnabledLabels).To(Equal([]string{"namespace", "strategy"}))
+				Expect(config.Prometheus.EnabledLabels).To(Equal([]string{"namespace", "strategy"}))
 			})
 		})
 

--- a/pkg/controller/build/build_controller.go
+++ b/pkg/controller/build/build_controller.go
@@ -302,7 +302,7 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 	}
 
 	// Increase Build count in metrics
-	buildmetrics.BuildCountInc(b.Spec.StrategyRef.Name)
+	buildmetrics.BuildCountInc(b.Spec.StrategyRef.Name, b.Namespace, b.Name)
 
 	ctxlog.Debug(ctx, "finishing reconciling Build", namespace, request.Namespace, name, request.Name)
 	return reconcile.Result{}, nil

--- a/pkg/controller/buildrun/buildrun_controller.go
+++ b/pkg/controller/buildrun/buildrun_controller.go
@@ -339,12 +339,13 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			}
 
 			// Increase BuildRun count in metrics
-			buildmetrics.BuildRunCountInc(buildRun.Status.BuildSpec.StrategyRef.Name)
+			buildmetrics.BuildRunCountInc(buildRun.Status.BuildSpec.StrategyRef.Name, buildRun.Namespace, buildRun.Spec.BuildRef.Name, buildRun.Name)
 
 			// Report buildrun ramp-up duration (time between buildrun creation and taskrun creation)
 			buildmetrics.BuildRunRampUpDurationObserve(
 				buildRun.Status.BuildSpec.StrategyRef.Name,
 				buildRun.Namespace,
+				buildRun.Spec.BuildRef.Name,
 				buildRun.Name,
 				generatedTaskRun.CreationTimestamp.Time.Sub(buildRun.CreationTimestamp.Time),
 			)
@@ -407,6 +408,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 				buildmetrics.BuildRunEstablishObserve(
 					buildRun.Status.BuildSpec.StrategyRef.Name,
 					buildRun.Namespace,
+					buildRun.Spec.BuildRef.Name,
 					buildRun.Name,
 					buildRun.Status.StartTime.Time.Sub(buildRun.CreationTimestamp.Time),
 				)
@@ -420,6 +422,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 					buildmetrics.BuildRunCompletionObserve(
 						buildRun.Status.BuildSpec.StrategyRef.Name,
 						buildRun.Namespace,
+						buildRun.Spec.BuildRef.Name,
 						buildRun.Name,
 						buildRun.Status.CompletionTime.Time.Sub(buildRun.CreationTimestamp.Time),
 					)
@@ -437,6 +440,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 								buildmetrics.TaskRunPodRampUpDurationObserve(
 									buildRun.Status.BuildSpec.StrategyRef.Name,
 									buildRun.Namespace,
+									buildRun.Spec.BuildRef.Name,
 									buildRun.Name,
 									lastInitPod.State.Terminated.FinishedAt.Sub(pod.CreationTimestamp.Time),
 								)
@@ -447,6 +451,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 						buildmetrics.TaskRunRampUpDurationObserve(
 							buildRun.Status.BuildSpec.StrategyRef.Name,
 							buildRun.Namespace,
+							buildRun.Spec.BuildRef.Name,
 							buildRun.Name,
 							pod.CreationTimestamp.Time.Sub(lastTaskRun.CreationTimestamp.Time),
 						)


### PR DESCRIPTION
Signed-off-by: xigxjn <xigxjn@cn.ibm.com>

We did some improvement for the current build and buildrun metrics:
- We just support `buildstrategy` label fro both `builds_registered_total` and `buildruns_completed_total` metrics: https://github.com/shipwright-io/build/blob/v0.2.0/pkg/metrics/metrics.go#L24-L36
- We don't have `build` label for the buildrun histogram related metrics: https://github.com/shipwright-io/build/blob/v0.2.0/pkg/metrics/metrics.go#L61-L72

The current metric looks good for the single-tenant user, but if we use Shipwright/build in a multiple-tenant environment, the tenant user cannot get correct build or buildrun total count by using the `namespace` or other labels, it is not a good usage

And it is also for histogram metric, we missed `build` label, such as the user would like to know some detail about ONE build.

So @xiujuan95 and I provided this PR to:
- Add `namespace` and `build` labels for `build_builds_registered_total` metric
- Add `namespace` and `build` and `buildrun` labels for `build_buildruns_completed_total` metric
- Add `build` label for all buildrun related histogram metrics
- Update test to cover the new labels
- Update metric document for the new labels


We also verified in local and in Sysdig, it works fine:

All labels are configured/enabled in deployment.yaml:
```
# TYPE build_buildrun_rampup_duration_seconds histogram
build_buildrun_rampup_duration_seconds_bucket{build="buildpack-nodejs-build-zoe1",buildrun="buildpack-nodejs-buildrun-zoe2",buildstrategy="buildpacks-v3-zoe",namespace="zoe-test",le="0"} 1
build_buildrun_rampup_duration_seconds_bucket{build="buildpack-nodejs-build-zoe1",buildrun="buildpack-nodejs-buildrun-zoe2",buildstrategy="buildpacks-v3-zoe",namespace="zoe-test",le="1"} 1
build_buildrun_rampup_duration_seconds_bucket{build="buildpack-nodejs-build-zoe1",buildrun="buildpack-nodejs-buildrun-zoe2",buildstrategy="buildpacks-v3-zoe",namespace="zoe-test",le="2"} 1
build_buildrun_rampup_duration_seconds_bucket{build="buildpack-nodejs-build-zoe1",buildrun="buildpack-nodejs-buildrun-zoe2",buildstrategy="buildpacks-v3-zoe",namespace="zoe-test",le="3"} 1
build_buildrun_rampup_duration_seconds_bucket{build="buildpack-nodejs-build-zoe1",buildrun="buildpack-nodejs-buildrun-zoe2",buildstrategy="buildpacks-v3-zoe",namespace="zoe-test",le="4"} 1

# TYPE build_buildruns_completed_total counter
build_buildruns_completed_total{build="buildpack-nodejs-build-zoe1",buildrun="buildpack-nodejs-buildrun-zoe2",buildstrategy="buildpacks-v3-zoe",namespace="zoe-test"} 1
build_buildruns_completed_total{build="kaniko-fdxhz",buildrun="kaniko-fdxhz",buildstrategy="kaniko-small",namespace="2uleosnfre4"} 1

# TYPE build_builds_registered_total counter
build_builds_registered_total{build="buildah-golang-build",buildstrategy="buildah",namespace="zoe-test"} 1
build_builds_registered_total{build="buildpack-node-build",buildstrategy="buildpacks-v3-small",namespace="159uuqi2uy7"} 1
build_builds_registered_total{build="buildpack-nodejs-build-zoe1",buildstrategy="buildpacks-v3-zoe",namespace="default"} 1
build_builds_registered_total{build="buildpack-nodejs-build-zoe2",buildstrategy="buildpacks-v3-zoe",namespace="default"} 1
```

Sysdig metric dashboard:
<img width="935" alt="Screen Shot 2021-01-27 at 12 49 17 PM" src="https://media.github.ibm.com/user/23544/files/97a1e180-609e-11eb-8951-03732c95904d">

Please review, thanks!