### PR TITLE
Use go test to run unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,22 +189,16 @@ sanity-check: ineffassign golint govet misspell staticcheck
 test: test-unit
 
 .PHONY: test-unit
-test-unit: ginkgo
+test-unit:
 	rm -rf build/coverage
 	mkdir build/coverage
-	GO111MODULE=on $(GINKGO) \
-		-randomizeAllSpecs \
-		-randomizeSuites \
-		-failOnPending \
-		-p \
-		-compilers=2 \
-		-slowSpecThreshold=240 \
-		-race \
-		-cover \
+	go test \
+		./cmd/... \
+		./pkg/... \
+		-coverprofile=unit.coverprofile \
 		-outputdir=build/coverage \
-		-trace \
-		internal/... \
-		pkg/...
+		-race \
+		-v
 
 test-unit-coverage: test-unit gocov
 	echo "Combining coverage profiles"


### PR DESCRIPTION
Run `make test-unit` via go test so that we do not need to download ginkgo on each run.
Some ginko flags have counterparts for `go test`.

The following flag modifications were made:

- -randomizeAllSpecs - removed, not available for go test. Randomizing the order specs run in has limited value for unit testing.
- -randomizeAllSuites - removed, not available for go test. Randomizing the order suites run in has limited value for unit testing.
- -failOnPending - removed, not available for go test. This prevents developers from checking in tests that are marked "Pending" in ginkgo.
- -slowSpecThreshold - removed, not available for go test. This displays a warning if a spec takes longer than the provided threshold. Not really relevant for unit tests, which should run quickly. There is a global default timeout of 10 minutes for go test.
- -p - runs tests in parallel. This is enabled by default in go test, based on the number of cpus on the system.
- -compilers - number of compilers used to make the test binary. Likewise enabled by default in go test, based on the number of cpus on the system.
- -cover - implied by the addition of the added -coverprofile flag
- -trace - prints stack traces for failures. There is no equivalent for go test, however we still get line numbers. Unit tests should be  simple enough that a line number can help diagnose failures.
- -v - runs go tests in verbose mode. This is the best replacement for the -trace flag, ensuring tests report line numbers and full context with failures.