### PR TITLE
Fix flaky unit-test spec for Build

### DIFF
--- a/pkg/validate/secrets.go
+++ b/pkg/validate/secrets.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
@@ -36,6 +37,9 @@ func (s SecretRef) ValidatePath(ctx context.Context) error {
 			missingSecrets = append(missingSecrets, refSecret)
 		}
 	}
+
+	// sorts a list of secret names in increasing order
+	sort.Strings(missingSecrets)
 
 	if len(missingSecrets) > 1 {
 		s.Build.Status.Reason = build.MultipleSecretRefNotFound


### PR DESCRIPTION
We assert for a combination of secret names under Status.Message when
the secrets validation fails. Because the list of secrets comes from a
map and a map is an unordered collection of key-value pairs, this
commits adds a sort, to ensure an ordered list in Status.Message and for
avoiding the flakiness in the unit-test spec.

Flaky test was [when source secret and output secret are specified](https://github.com/shipwright-io/build/blob/master/pkg/controller/build/build_controller_test.go#L228-L229)