### PR TITLE
Add trimpath Go build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOCACHE ?= $(shell echo ${PWD})/$(OUTPUT_DIR)/gocache
 # golang target architecture
 GOARCH ?= amd64
 # golang global flags
-GO_FLAGS ?= -v -mod=vendor
+GO_FLAGS ?= -v -mod=vendor -trimpath
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
I recently learned of the `-trimpath` flag for Go builds. It will remove build
system specific file paths from the created Go binary. This seems to be a best
practice for reproducible builds as a build from my local machine yields the
same binary as the build from Travis and any other future build infrastructure.

Add `-trimpath` to the default Go flags.