### PR TITLE
Sync Go and operator SDK versions used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: go
 go:
-  - 1.14.x
+  - 1.15.x
 services:
   - docker
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM openshift/origin-release:golang-1.13 AS builder
+FROM openshift/origin-release:golang-1.15 AS builder
 
 ENV LANG=en_US.utf8
 ENV GIT_COMMITTER_NAME devtools

--- a/HACK.md
+++ b/HACK.md
@@ -41,7 +41,7 @@ In the near future, the above would be setup by the operator.
 make clean && make build
 ```
 
-* This project uses Golang 1.13+ and operator-sdk 1.15.1.
+* This project uses Golang 1.15+ and operator-sdk v0.18.2.
 * The controllers create/watch Tekton objects.
 
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ TEST_NAMESPACE ?= default
 # CI: tekton pipelines operator version
 TEKTON_VERSION ?= v0.20.1
 # CI: operator-sdk version
-SDK_VERSION ?= v0.17.0
+SDK_VERSION ?= v0.18.2
 
 # E2E test flags
 TEST_E2E_FLAGS ?= -failFast -flakeAttempts=2 -p -randomizeAllSpecs -slowSpecThreshold=300 -timeout=30m -progress -stream -trace -v

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shipwright-io/build
 
-go 1.14
+go 1.15
 
 require (
 	github.com/go-git/go-git/v5 v5.2.0

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -32,13 +32,13 @@ WORKDIR /tmp
 RUN mkdir -p $GOPATH/bin
 RUN mkdir -p /tmp/goroot
 
-RUN curl -Lo go1.13.8.linux-amd64.tar.gz https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz && tar -C /tmp/goroot -xzf go1.13.8.linux-amd64.tar.gz
+RUN curl -Lo go1.15.7.linux-amd64.tar.gz https://dl.google.com/go/go1.15.7.linux-amd64.tar.gz && tar -C /tmp/goroot -xzf go1.15.7.linux-amd64.tar.gz
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl $GOPATH/bin/
 
 RUN go get -u github.com/onsi/ginkgo/ginkgo  # installs the ginkgo CLI
 RUN go get -u github.com/onsi/gomega/...     # fetches the matcher library
 
-RUN curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.15.2/operator-sdk-v0.15.2-x86_64-linux-gnu && chmod +x operator-sdk && mv operator-sdk $GOPATH/bin/
+RUN curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.18.2/operator-sdk-v0.18.2-x86_64-linux-gnu && chmod +x operator-sdk && mv operator-sdk $GOPATH/bin/
 
 RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/
 


### PR DESCRIPTION
There were different Go versions used in the Go module, Travis configuration,
GitHub Actions configuration, and the project Dockerfile. Also, the version
of the operator SDK was different in some places.

Sync Go version to be `1.15` everywhere.

Make operator SDK version `v0.18.2` consistently.