### PR TITLE
Tweak build operator build settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOCACHE ?= $(shell echo ${PWD})/$(OUTPUT_DIR)/gocache
 # golang target architecture
 GOARCH ?= amd64
 # golang global flags
-GO_FLAGS ?= -v -mod=vendor
+GO_FLAGS ?= -v -mod=vendor -ldflags=-w
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
There are linker flags that can make our build operator binary and therefore our container image smaller. For example, we can [omit the symbol table and debug information and the DWARF symbol table](https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/). In case of the build operator this means we can save 20% of the regular size. The majority of the container image size is still the base image, but we could save a bit more than 14 MiB or so.

