### PR TITLE
Add release.yaml github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Desired tag'
+        required: true
+      tags:
+        description: 'Previous tag'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2-beta
+    - name: Build Release Changelog
+      run: |
+        git fetch --all --tags --prune --force
+        echo -e "# Insert Title\n" > Changes.md
+        git log --pretty=format:"%h -  %s - %an" ${{ github.event.inputs.tags }}..HEAD | grep -v "Merge pull" >> Changes.md
+        echo -e "## Features\n\n## Fixes\n\n## Backwards incompatible changes\n\n## Docs\n\n## Misc\n\n## Thanks" >> Changes.md    - name: Draft Release
+      id: draft_release
+      uses: actions/create-release@v1
+      with:
+        release_name: "Shipwright Build release ${{ github.event.inputs.release }}"
+        tag_name: ${{ github.event.inputs.release }}
+        body_path: Changes.md
+        draft: true
+        prerelease: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will allow us to construct a draft release with:
- Template for the release notes (based on previous releases)
- History of commits since latest release
- Automatic creation of new desired tag