### PR TITLE
Update release.yaml for github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2-beta
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Build Release Changelog
       run: |
         git fetch --all --tags --prune --force


### PR DESCRIPTION
This fixes the existing release.yaml to fetch all history of commits.