### PR TITLE
Add pprof support to build operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,11 @@ build-plain:
 
 .PHONY: build-image
 build-image:
-	GOFLAGS="$(GO_FLAGS)" ko publish -P ./cmd/manager
+	GOFLAGS="$(GO_FLAGS)" ko publish --preserve-import-paths ./cmd/manager
+
+.PHONY: build-image-with-pprof
+build-image-with-pprof:
+	GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko publish --preserve-import-paths --tags=pprof ./cmd/manager
 
 .PHONY: release
 release:
@@ -231,6 +235,9 @@ test-e2e-plain: ginkgo
 
 install:
 	GOFLAGS="$(GO_FLAGS)" ko apply -R -f deploy/
+
+install-with-pprof:
+	GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko apply -R -f deploy/
 
 install-apis:
 	kubectl apply -f deploy/crds/

--- a/Makefile
+++ b/Makefile
@@ -243,11 +243,11 @@ install-operator: install-apis
 install-strategies: install-apis
 	kubectl apply -R -f samples/buildstrategy/
 
-local: install-strategies build
+local: vendor install-strategies
 	OPERATOR_NAME=build-operator \
 	operator-sdk run local --operator-flags="$(ZAP_FLAGS)"
 
-local-plain: build-plain
+local-plain: vendor
 	OPERATOR_NAME=build-operator \
 	operator-sdk run local --operator-flags="$(ZAP_FLAGS)"
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -124,9 +124,17 @@ func main() {
 	addMetrics(ctx, cfg, namespace)
 	buildMetrics.InitPrometheus(buildCfg)
 
-	ctxlog.Info(ctx, "Starting the Cmd.")
+	// Add optionally configured extra handlers to metrics endpoint
+	for path, handler := range buildMetrics.MetricsExtraHandlers() {
+		ctxlog.Info(ctx, "Adding metrics extra handler path", "path", path)
+		if err := mgr.AddMetricsExtraHandler(path, handler); err != nil {
+			ctxlog.Error(ctx, err, "")
+			os.Exit(2)
+		}
+	}
 
 	// Start the Cmd
+	ctxlog.Info(ctx, "Starting the Cmd.")
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		ctxlog.Error(ctx, err, "Manager exited non-zero")
 		os.Exit(1)

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,43 @@
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Build Controller Profiling
+
+The build operator supports a `pprof` profiling mode, which is omitted from the binary by default. To use the profiling, use the operator image that was built with `pprof` enabled.
+
+## Enable `pprof` in the build operator
+
+In the Kubernetes cluster, edit the `build-operator` deployment to use the container tag with the `debug` suffix.
+
+```sh
+kubectl --namespace <namespace> set image \
+  deployment/build-operator \
+  build-operator="$(kubectl --namespace <namespace> get deployment build-operator --output jsonpath='{.spec.template.spec.containers[].image}')-debug"
+```
+
+## Connect `go pprof` to build operator
+
+Depending on the respective setup, there could be multiple build operator pods for high availability reasons. In this case, you have to look-up the current leader first. The following command can be used to verify the currently active leader:
+
+```sh
+kubectl --namespace <namespace> get configmap build-operator-lock --output json \
+  | jq --raw-output '.metadata.annotations["control-plane.alpha.kubernetes.io/leader"]' \
+  | jq --raw-output .holderIdentity
+```
+
+The `pprof` endpoint is not exposed in the cluster and can only be used from inside the container. Therefore, set-up port-forwarding to make the `pprof` port available locally.
+
+```sh
+kubectl --namespace <namespace> port-forward <build-operator-pod-name> 8383:8383
+```
+
+Now, you can setup a local webserver to browse through the profiling data.
+
+```sh
+go tool pprof -http localhost:8080 http://localhost:8383/debug/pprof/heap
+```
+
+_Please note:_ For it to work, you have to have `graphviz` installed on your system, for example using `brew install graphviz`, `apt-get install graphviz`, `yum install graphviz`, or similar.

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -4,8 +4,8 @@
 # 
 # SPDX-License-Identifier: Apache-2.0
 
+set -euo pipefail
 
-set -e
 echo "Logging into container registry $IMAGE_HOST"
 echo "$REGISTRY_PASSWORD" | ko login -u "$REGISTRY_USERNAME" --password-stdin "$IMAGE_HOST"
 
@@ -14,5 +14,4 @@ echo "Building container image"
 # Using defaults, this pushes to:
 # quay.io/shipwright/shipwright-operator/github.com/shipwright-io/build/cmd/manager:latest
 KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS}" ko resolve -t "$TAG" -P -R -f deploy/ > release.yaml
-
-set +e
+KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve -t "$TAG-debug" -P -R -f deploy/ > release-debug.yaml

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	buildCount *prometheus.CounterVec
+	buildCount    *prometheus.CounterVec
 	buildRunCount *prometheus.CounterVec
 
 	buildRunEstablishDuration  *prometheus.HistogramVec

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,13 +5,12 @@
 package metrics
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
 	"github.com/shipwright-io/build/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // Labels used in Prometheus metrics
@@ -40,6 +39,9 @@ var (
 
 	initialized = false
 )
+
+// Optional additional metrics endpoint handlers to be configured
+var metricsExtraHandlers = map[string]http.HandlerFunc{}
 
 // InitPrometheus initializes the prometheus stuff
 func InitPrometheus(config *config.Config) {
@@ -135,6 +137,10 @@ func InitPrometheus(config *config.Config) {
 		taskRunRampUpDuration,
 		taskRunPodRampUpDuration,
 	)
+}
+
+func MetricsExtraHandlers() map[string]http.HandlerFunc {
+	return metricsExtraHandlers
 }
 
 func contains(slice []string, element string) bool {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -31,9 +31,9 @@ var _ = Describe("Custom Metrics", func() {
 	}
 
 	var (
-		buildCounterMetrics         = map[string]map[buildLabels]float64{}
-		buildRunCounterMetrics      = map[string]map[buildRunLabels]float64{}
-		buildRunHistogramMetrics    = map[string]map[buildRunLabels]float64{}
+		buildCounterMetrics      = map[string]map[buildLabels]float64{}
+		buildRunCounterMetrics   = map[string]map[buildRunLabels]float64{}
+		buildRunHistogramMetrics = map[string]map[buildRunLabels]float64{}
 
 		promLabelPairToBuildLabels = func(in []*io_prometheus_client.LabelPair) buildLabels {
 			var result = buildLabels{}

--- a/pkg/metrics/pprof.go
+++ b/pkg/metrics/pprof.go
@@ -1,0 +1,18 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// +build pprof_enabled
+
+package metrics
+
+import "net/http/pprof"
+
+func init() {
+	// Extra handlers based on https://github.com/golang/go/blob/master/src/net/http/pprof/pprof.go#L80-L86
+	metricsExtraHandlers["/debug/pprof/"] = pprof.Index
+	metricsExtraHandlers["/debug/pprof/cmdline"] = pprof.Cmdline
+	metricsExtraHandlers["/debug/pprof/profile"] = pprof.Profile
+	metricsExtraHandlers["/debug/pprof/symbol"] = pprof.Symbol
+	metricsExtraHandlers["/debug/pprof/trace"] = pprof.Trace
+}


### PR DESCRIPTION
In preparation for production use cases, I realized that we have currently no means to diagnose memory usage of the controller during runtime in a cluster. I took a look and saw that other operators use `pprof` to optionally expose a profiling endpoint to be used, e.g. memory leak analysis.

The rough idea is:
- Enable `pprof` via change in the deployment.
- Set-up port-forwarding from local machine to current leader.
- Use `go tool pprof` to profile the operator during runtime.

Using [profiling in production seems to be safe](https://medium.com/google-cloud/continuous-profiling-of-go-programs-96d4416af77b), but -- of course -- it has performance implications.

![image](https://user-images.githubusercontent.com/1979133/107089738-6c866300-67ff-11eb-999e-a4707ce61f3a.png)

Feedback on this would be highly appreciated.
