### PR TITLE
Fix travis by installing ko

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ services:
   - docker
 install:
   - make travis
+  - |
+    # Install ko
+    curl -L https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | tar xzf - ko
+    chmod +x ./ko
+    sudo mv ko /usr/local/bin
+
 script:
   - set -e
   - make


### PR DESCRIPTION
Without this, `hack/release.sh` fails with:

```
hack/release.sh: line 10: ko: command not found
```

See https://travis-ci.org/github/shipwright-io/build/builds/758200833#L5665