### PR TITLE
Publish images without full import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,11 @@ build-plain:
 
 .PHONY: build-image
 build-image:
-	GOFLAGS="$(GO_FLAGS)" ko publish --preserve-import-paths ./cmd/manager
+	KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE)" GOFLAGS="$(GO_FLAGS)" ko publish --bare ./cmd/manager
 
 .PHONY: build-image-with-pprof
 build-image-with-pprof:
-	GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko publish --preserve-import-paths --tags=pprof ./cmd/manager
+	KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE)" GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko publish --bare --tags=pprof ./cmd/manager
 
 .PHONY: release
 release:
@@ -234,7 +234,7 @@ test-e2e-plain: ginkgo
 .PHONY: install install-apis install-operator install-strategies
 
 install:
-	GOFLAGS="$(GO_FLAGS)" ko apply -R -f deploy/
+	KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE)" GOFLAGS="$(GO_FLAGS)" ko apply --bare -R -f deploy/
 
 install-with-pprof:
 	GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko apply -R -f deploy/
@@ -245,7 +245,7 @@ install-apis:
 	kubectl wait --timeout=10s --for condition=established crd/clusterbuildstrategies.build.dev
 
 install-operator: install-apis
-	GOFLAGS="$(GO_FLAGS)" ko apply -f deploy/
+	KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE)" GOFLAGS="$(GO_FLAGS)" ko apply --bare -f deploy/
 
 install-strategies: install-apis
 	kubectl apply -R -f samples/buildstrategy/

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -12,6 +12,6 @@ echo "$REGISTRY_PASSWORD" | ko login -u "$REGISTRY_USERNAME" --password-stdin "$
 echo "Building container image"
 
 # Using defaults, this pushes to:
-# quay.io/shipwright/shipwright-operator/github.com/shipwright-io/build/cmd/manager:latest
-KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS}" ko resolve -t "$TAG" -P -R -f deploy/ > release.yaml
-KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve -t "$TAG-debug" -P -R -f deploy/ > release-debug.yaml
+# quay.io/shipwright/shipwright-operator:latest
+KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS}" ko resolve -t "$TAG" --bare -R -f deploy/ > release.yaml
+KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve -t "$TAG-debug" --bare -R -f deploy/ > release-debug.yaml


### PR DESCRIPTION
It seems like quay.io doesn't support image refs that contain slashes, which runs afoul of hack/release.sh which tries to push to `quay.io/shipwright/shipwright-operator/github.com/shipwright-io/build/cmd/manager`

The error message is:

```
2021/02/09 17:50:12 error processing import paths in "deploy/operator.yaml": error resolving image references: GET https://quay.io/v2/auth?scope=repository%3Ashipwright%2Fshipwright-operator%2Fgithub.com%2Fshipwright-io%2Fbuild%2Fcmd%2Fmanager%3Apush%2Cpull&service=quay.io: NAME_INVALID: Nested repositories are not supported. Found: shipwright/shipwright-operator/github.com/shipwright-io/build/cmd/manager; map[]
```

~~With this change, `ko` will instead push to `quay.io/shipwright/shipwright-operator/manager` (🚨 which is still invalid 🚨 ).~~

Our options seem to be:
1. publish with `--bare`, in which case images will get pushed to `quay.io/shipwright/shipwright-operator` -- if this repo or other Shipwright repos push to this Quay repo it might become confusing which image is which.
2. ~~publish with `-B` and `KO_DOCKER_REPO=quay.io/shipwright`, which will publish to `quay.io/shipwright/manager` -- this is a change in the image name, but future images will get published with meaningful names.~~ (going with option 1)