### PR TITLE
add pull request template to integrate with prow release-note plugin

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+# Changes
+
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+<!-- Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+<!-- If this PR fixes a GitHub issue, please mention it like so:
+
+Fixes #<insert issue number here>
+
+-->
+
+# Submitter Checklist
+
+- [ ] Includes tests if functionality changed/was added
+- [ ] Includes docs if changes are user-facing
+- [ ] Release notes block has been filled in, or marked NONE
+
+See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
+for details on coding conventions, github and prow interactions, and the code review process.
+
+# Release Notes
+
+<!--
+Describe any user facing changes here, or delete this block.
+
+Examples of user facing changes:
+- API changes
+- Bug fixes
+- Any changes in behavior
+- Changes requiring upgrade notices or deprecation warnings
+
+For pull requests with a release note:
+
+```release-note
+Your release note here
+```
+
+For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
+
+```release-note
+action required: your release note here
+```
+
+For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
+
+```release-note
+NONE
+```
+-->


### PR DESCRIPTION
To mimic upstream tekton on how they curate release notes on a per PR basis using the prow release-note plugin

Related PR:  https://github.com/openshift/release/pull/15770

/assign @adambkaplan 

/assign @qu1queee 

@sbose78 FYI

ultimately what happens is a `release-note` or `release-note-none` label is required for PR merge, and which label is applied is triggered by what is placed in the `release-note` description of the PR.