### PR TITLE
This replaces the taxi go app repo

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -99,7 +99,7 @@ metadata:
     build.build.dev/verify.repository: "false"
 spec:
   source:
-    url: https://github.com/sbose78/taxi
+    url: https://github.com/qu1queee/taxi
     revision: master
 ```
 
@@ -141,7 +141,7 @@ metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/sbose78/taxi
+    url: https://github.com/qu1queee/taxi
     revision: master
 ```
 
@@ -178,7 +178,7 @@ metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/sbose78/taxi
+    url: https://github.com/qu1queee/taxi
     revision: master
   strategy:
     name: buildah

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -271,7 +271,7 @@ metadata:
   name: kaniko-medium
 spec:
   source:
-    url: https://github.com/sbose78/taxi
+    url: https://github.com/qu1queee/taxi
   strategy:
     name: kaniko
     kind: ClusterBuildStrategy

--- a/pkg/controller/build/build_controller_test.go
+++ b/pkg/controller/build/build_controller_test.go
@@ -384,7 +384,7 @@ var _ = Describe("Reconcile Build", func() {
 
 			// validate https protocol
 			It("fails when public source URL is unreachable", func() {
-				buildSample.Spec.Source.URL = "https://github.com/sbose78/taxi-fake"
+				buildSample.Spec.Source.URL = "https://github.com/qu1queee/taxi-fake"
 
 				statusCall := ctl.StubFunc(corev1.ConditionFalse, build.RemoteRepositoryUnreachable, "remote repository unreachable")
 				statusWriter.UpdateCalls(statusCall)

--- a/pkg/controller/buildrun/generate_taskrun_test.go
+++ b/pkg/controller/buildrun/generate_taskrun_test.go
@@ -36,7 +36,7 @@ var _ = Describe("GenerateTaskrun", func() {
 
 	BeforeEach(func() {
 		buildpacks = "buildpacks-v3"
-		url = "https://github.com/sbose78/taxi"
+		url = "https://github.com/qu1queee/taxi"
 		dockerfile = "Dockerfile"
 	})
 

--- a/samples/build/build_buildah_cr.yaml
+++ b/samples/build/build_buildah_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/sbose78/taxi
+    url: https://github.com/qu1queee/taxi
     revision: master
   strategy:
     name: buildah

--- a/samples/build/build_kaniko_cr.yaml
+++ b/samples/build/build_kaniko_cr.yaml
@@ -7,7 +7,7 @@ metadata:
     build.build.dev/build-run-deletion: "true"
 spec:
   source:
-    url: https://github.com/sbose78/taxi
+    url: https://github.com/qu1queee/taxi
   strategy:
     name: kaniko
     kind: ClusterBuildStrategy

--- a/test/build_samples.go
+++ b/test/build_samples.go
@@ -13,7 +13,7 @@ metadata:
   name: buildah
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     name: buildah
     kind: ClusterBuildStrategy
@@ -30,7 +30,7 @@ metadata:
   namespace: build-test
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     name: buildah
   output:
@@ -48,7 +48,7 @@ metadata:
   namespace: build-test
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
     revision: master
     contextDir: src
   strategy:
@@ -73,7 +73,7 @@ metadata:
   namespace: build-test
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     name: buildah
   output:
@@ -87,7 +87,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     kind: BuildStrategy
   output:
@@ -101,7 +101,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     kind: ClusterBuildStrategy
   output:
@@ -115,7 +115,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     kind: ClusterBuildStrategy
   output:
@@ -131,7 +131,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     kind: ClusterBuildStrategy
   output:
@@ -148,7 +148,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
     credentials:
       name: source-secret
   strategy:
@@ -165,7 +165,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   builder:
     image: heroku/buildpacks:18
     credentials:
@@ -184,7 +184,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
     credentials:
       name: source-secret
   builder:
@@ -205,7 +205,7 @@ apiVersion: build.dev/v1alpha1
 kind: Build
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     kind: ClusterBuildStrategy
   output:
@@ -265,7 +265,7 @@ metadata:
     build.build.dev/build-run-deletion: "true"
 spec:
   source:
-    url: "https://github.com/sbose78/taxi"
+    url: "https://github.com/qu1queee/taxi"
   strategy:
     kind: ClusterBuildStrategy
   output:

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -85,7 +85,7 @@ func (c *Catalog) BuildWithClusterBuildStrategy(name string, ns string, strategy
 		},
 		Spec: build.BuildSpec{
 			Source: build.GitSource{
-				URL: "https://github.com/sbose78/taxi",
+				URL: "https://github.com/qu1queee/taxi",
 			},
 			StrategyRef: &build.StrategyRef{
 				Name: strategyName,
@@ -111,7 +111,7 @@ func (c *Catalog) BuildWithClusterBuildStrategyAndSourceSecret(name string, ns s
 		},
 		Spec: build.BuildSpec{
 			Source: build.GitSource{
-				URL: "https://github.com/sbose78/taxi",
+				URL: "https://github.com/qu1queee/taxi",
 				SecretRef: &corev1.LocalObjectReference{
 					Name: "foobar",
 				},
@@ -137,7 +137,7 @@ func (c *Catalog) BuildWithBuildStrategy(name string, ns string, strategyName st
 		},
 		Spec: build.BuildSpec{
 			Source: build.GitSource{
-				URL: "https://github.com/sbose78/taxi",
+				URL: "https://github.com/qu1queee/taxi",
 			},
 			StrategyRef: &build.StrategyRef{
 				Name: strategyName,
@@ -156,7 +156,7 @@ func (c *Catalog) BuildWithNilBuildStrategyKind(name string, ns string, strategy
 		},
 		Spec: build.BuildSpec{
 			Source: build.GitSource{
-				URL: "https://github.com/sbose78/taxi",
+				URL: "https://github.com/qu1queee/taxi",
 			},
 			StrategyRef: &build.StrategyRef{
 				Name: strategyName,

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -314,11 +314,11 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 			tr01, err := tb.GetTaskRunFromBuildRun(buildRun01.Name)
 			Expect(err).To(BeNil())
-			Expect(tr01.Spec.Resources.Inputs[0].PipelineResourceBinding.ResourceSpec.Params[0].Value).To(Equal("https://github.com/sbose78/taxi"))
+			Expect(tr01.Spec.Resources.Inputs[0].PipelineResourceBinding.ResourceSpec.Params[0].Value).To(Equal("https://github.com/qu1queee/taxi"))
 
 			tr02, err := tb.GetTaskRunFromBuildRun(buildRun02.Name)
 			Expect(err).To(BeNil())
-			Expect(tr02.Spec.Resources.Inputs[0].PipelineResourceBinding.ResourceSpec.Params[0].Value).To(Equal("https://github.com/sbose78/taxi"))
+			Expect(tr02.Spec.Resources.Inputs[0].PipelineResourceBinding.ResourceSpec.Params[0].Value).To(Equal("https://github.com/qu1queee/taxi"))
 
 		})
 	})

--- a/test/integration/build_to_git_test.go
+++ b/test/integration/build_to_git_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(err).To(BeNil())
 
 			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
-			buildObject.Spec.Source.URL = "http://github.com/sbose78/taxi"
+			buildObject.Spec.Source.URL = "http://github.com/qu1queee/taxi"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
@@ -71,7 +71,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.Spec.Source.URL = "http://github.com/sbose78/taxi-fake"
+			buildObject.Spec.Source.URL = "http://github.com/qu1queee/taxi-fake"
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
 			// wait until the Build finish the validation
@@ -96,7 +96,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(err).To(BeNil())
 
 			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
-			buildObject.Spec.Source.URL = "https://github.com/sbose78/taxi"
+			buildObject.Spec.Source.URL = "https://github.com/qu1queee/taxi"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
@@ -121,7 +121,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.Spec.Source.URL = "https://github.com/sbose78/taxi-fake"
+			buildObject.Spec.Source.URL = "https://github.com/qu1queee/taxi-fake"
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
 			// wait until the Build finish the validation


### PR DESCRIPTION
# Changes

The existing one have an issue on the go.mod definition, leading
to build failures when using the latest golang image.

This PR changes the repo to use, which have the fixes in place. This
is a fix PR, the end-goal is to tackle issue #366 which should avoid
problems like this in the future.


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Release notes block has been filled in, or marked NONE


# Release Notes

```release-note
NONE
```

