### PR TITLE
Restructure buildrun code into separate resources 

### DIFF
--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -9,13 +9,39 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/ctxlog"
 	buildmetrics "github.com/shipwright-io/build/pkg/metrics"
 	"github.com/shipwright-io/build/pkg/validate"
 )
+
+// ReconcileBuild reconciles a Build object
+type ReconcileBuild struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	ctx                   context.Context
+	config                *config.Config
+	client                client.Client
+	scheme                *runtime.Scheme
+	setOwnerReferenceFunc setOwnerReferenceFunc
+}
+
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager, ownerRef setOwnerReferenceFunc) reconcile.Reconciler {
+	return &ReconcileBuild{
+		ctx:                   ctx,
+		config:                c,
+		client:                mgr.GetClient(),
+		scheme:                mgr.GetScheme(),
+		setOwnerReferenceFunc: ownerRef,
+	}
+}
 
 // Reconcile reads that state of the cluster for a Build object and makes changes based on the state read
 // and what is in the Build.Spec

--- a/pkg/reconciler/build/controller.go
+++ b/pkg/reconciler/build/controller.go
@@ -41,17 +41,6 @@ func Add(ctx context.Context, c *config.Config, mgr manager.Manager) error {
 	return add(ctx, mgr, NewReconciler(ctx, c, mgr, controllerutil.SetControllerReference))
 }
 
-// NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager, ownerRef setOwnerReferenceFunc) reconcile.Reconciler {
-	return &ReconcileBuild{
-		ctx:                   ctx,
-		config:                c,
-		client:                mgr.GetClient(),
-		scheme:                mgr.GetScheme(),
-		setOwnerReferenceFunc: ownerRef,
-	}
-}
-
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
@@ -183,17 +172,6 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 			return reconcileList
 		}),
 	}, preSecret)
-}
-
-// ReconcileBuild reconciles a Build object
-type ReconcileBuild struct {
-	// This client, initialized using mgr.Client() above, is a split client
-	// that reads objects from the cache and writes to the apiserver
-	ctx                   context.Context
-	config                *config.Config
-	client                client.Client
-	scheme                *runtime.Scheme
-	setOwnerReferenceFunc setOwnerReferenceFunc
 }
 
 func buildSecretRefAnnotationExist(annotation map[string]string) (string, bool) {

--- a/pkg/reconciler/buildrun/controller.go
+++ b/pkg/reconciler/buildrun/controller.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -40,17 +39,6 @@ type setOwnerReferenceFunc func(owner, object metav1.Object, scheme *runtime.Sch
 func Add(ctx context.Context, c *config.Config, mgr manager.Manager) error {
 	ctx = ctxlog.NewContext(ctx, "buildrun-controller")
 	return add(ctx, mgr, NewReconciler(ctx, c, mgr, controllerutil.SetControllerReference))
-}
-
-// NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager, ownerRef setOwnerReferenceFunc) reconcile.Reconciler {
-	return &ReconcileBuildRun{
-		ctx:                   ctx,
-		config:                c,
-		client:                mgr.GetClient(),
-		scheme:                mgr.GetScheme(),
-		setOwnerReferenceFunc: ownerRef,
-	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -140,18 +128,4 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 			}
 		}),
 	}, predTaskRun)
-}
-
-// blank assignment to verify that ReconcileBuildRun implements reconcile.Reconciler
-var _ reconcile.Reconciler = &ReconcileBuildRun{}
-
-// ReconcileBuildRun reconciles a BuildRun object
-type ReconcileBuildRun struct {
-	// This client, initialized using mgr.Client() above, is a split client
-	// that reads objects from the cache and writes to the apiserver
-	ctx                   context.Context
-	config                *config.Config
-	client                client.Client
-	scheme                *runtime.Scheme
-	setOwnerReferenceFunc setOwnerReferenceFunc
 }

--- a/pkg/reconciler/buildrun/controller.go
+++ b/pkg/reconciler/buildrun/controller.go
@@ -27,11 +27,6 @@ import (
 	"github.com/shipwright-io/build/pkg/ctxlog"
 )
 
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
-
 type setOwnerReferenceFunc func(owner, object metav1.Object, scheme *runtime.Scheme) error
 
 // Add creates a new BuildRun Controller and adds it to the Manager. The Manager will set fields on the Controller

--- a/pkg/reconciler/buildrun/resources/build.go
+++ b/pkg/reconciler/buildrun/resources/build.go
@@ -1,0 +1,33 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetBuildObject retrieves an existing Build based on a name and namespace
+func GetBuildObject(ctx context.Context, client client.Client, objectName string, objectNS string, build *buildv1alpha1.Build) error {
+	if err := client.Get(ctx, types.NamespacedName{Name: objectName, Namespace: objectNS}, build); err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsOwnedByBuild checks if the controllerReferences contains a well known owner Kind
+func IsOwnedByBuild(build *buildv1alpha1.Build, controlledReferences []metav1.OwnerReference) bool {
+	for _, ref := range controlledReferences {
+		if ref.Kind == build.Kind && ref.Name == build.Name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/reconciler/buildrun/resources/build.go
+++ b/pkg/reconciler/buildrun/resources/build.go
@@ -15,10 +15,7 @@ import (
 
 // GetBuildObject retrieves an existing Build based on a name and namespace
 func GetBuildObject(ctx context.Context, client client.Client, objectName string, objectNS string, build *buildv1alpha1.Build) error {
-	if err := client.Get(ctx, types.NamespacedName{Name: objectName, Namespace: objectNS}, build); err != nil {
-		return err
-	}
-	return nil
+	return client.Get(ctx, types.NamespacedName{Name: objectName, Namespace: objectNS}, build)
 }
 
 // IsOwnedByBuild checks if the controllerReferences contains a well known owner Kind

--- a/pkg/reconciler/buildrun/resources/build_test.go
+++ b/pkg/reconciler/buildrun/resources/build_test.go
@@ -1,0 +1,118 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/controller/fakes"
+	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
+	"github.com/shipwright-io/build/test"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Build Resource", func() {
+
+	var (
+		client    *fakes.FakeClient
+		ctl       test.Catalog
+		buildName string
+	)
+
+	Context("Operating on Build resources", func() {
+		// init vars
+		buildName = "foobuild"
+		client = &fakes.FakeClient{}
+
+		It("should be able to retrieve a build object if exists", func() {
+			buildSample := ctl.DefaultBuild(buildName, "foostrategy", build.ClusterBuildStrategyKind)
+
+			// stub a GET API call with buildSample contents
+			getClientStub := func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+				switch object := object.(type) {
+				case *build.Build:
+					buildSample.DeepCopyInto(object)
+					return nil
+				}
+				return k8serrors.NewNotFound(schema.GroupResource{}, nn.Name)
+			}
+
+			// fake the calls with the above stub definition
+			client.GetCalls(getClientStub)
+
+			build := &build.Build{}
+			Expect(resources.GetBuildObject(context.TODO(), client, buildName, "default", build)).To(BeNil())
+		})
+		It("should not retrieve a missing build object when missing", func() {
+			// stub a GET API call with buildSample contents that returns "not found"
+			getClientStub := func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+				switch object.(type) {
+				case *build.Build:
+					return errors.New("not found")
+				}
+				return k8serrors.NewNotFound(schema.GroupResource{}, nn.Name)
+			}
+			// fake the calls with the above stub
+			client.GetCalls(getClientStub)
+
+			build := &build.Build{}
+			Expect(resources.GetBuildObject(context.TODO(), client, buildName, "default", build)).ToNot(BeNil())
+		})
+		It("should be able to verify valid ownerships", func() {
+			managingController := true
+
+			buildSample := &build.Build{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "fakekind",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: buildName,
+				},
+			}
+			// fake an instance of OwnerReference with a
+			// well known fake Kind and Name
+			fakeOwnerRef := []metav1.OwnerReference{
+				{
+					Kind:       "fakekind",
+					Name:       buildName,
+					Controller: &managingController,
+				},
+			}
+			// Assert that our Build is owned by an owner
+			Expect(resources.IsOwnedByBuild(buildSample, fakeOwnerRef)).To(BeTrue())
+		})
+		It("should be able to verify invalid ownerships", func() {
+			managingController := true
+
+			buildSample := &build.Build{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "notthatkind",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: buildName,
+				},
+			}
+			// fake an instance of OwnerReference with a
+			// well known fake Kind and Name
+			fakeOwnerRef := []metav1.OwnerReference{
+				{
+					Kind:       "fakekind",
+					Name:       buildName,
+					Controller: &managingController,
+				},
+			}
+			// Assert that our Build is not owned by an owner
+			Expect(resources.IsOwnedByBuild(buildSample, fakeOwnerRef)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/reconciler/buildrun/resources/conditions.go
+++ b/pkg/reconciler/buildrun/resources/conditions.go
@@ -28,7 +28,7 @@ func UpdateBuildRunUsingTaskRunCondition(ctx context.Context, client client.Clie
 	case v1beta1.TaskRunReasonTimedOut:
 		reason = "BuildRunTimeout"
 		message = fmt.Sprintf("BuildRun %s failed to finish within %s",
-			taskRun.GetLabels()[buildv1alpha1.LabelBuildRun],
+			buildRun.Name,
 			taskRun.Spec.Timeout.Duration,
 		)
 

--- a/pkg/reconciler/buildrun/resources/conditions.go
+++ b/pkg/reconciler/buildrun/resources/conditions.go
@@ -1,0 +1,96 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+)
+
+// UpdateBuildRunUsingTaskRunCondition updates the BuildRun Succeeded Condition
+func UpdateBuildRunUsingTaskRunCondition(ctx context.Context, client client.Client, buildRun *buildv1alpha1.BuildRun, taskRun *v1beta1.TaskRun, trCondition *apis.Condition) error {
+	var reason, message string = trCondition.Reason, trCondition.Message
+
+	switch v1beta1.TaskRunReason(reason) {
+	case v1beta1.TaskRunReasonTimedOut:
+		reason = "BuildRunTimeout"
+		message = fmt.Sprintf("BuildRun %s failed to finish within %s",
+			taskRun.GetLabels()[buildv1alpha1.LabelBuildRun],
+			taskRun.Spec.Timeout.Duration,
+		)
+
+	case v1beta1.TaskRunReasonFailed:
+		if taskRun.Status.CompletionTime != nil {
+			var pod corev1.Pod
+			if err := client.Get(ctx, types.NamespacedName{Namespace: taskRun.Namespace, Name: taskRun.Status.PodName}, &pod); err != nil {
+				// when trying to customize the Condition Message field, ensure the Message cover the case
+				// when a Pod is deleted.
+				// Note: this is an edge case, but not doing this prevent a BuildRun from being marked as Failed
+				// while the TaskRun is already with a Failed Reason in it´s condition.
+				if apierrors.IsNotFound(err) {
+					message = fmt.Sprintf("buildrun failed, pod %s not found", taskRun.Status.PodName)
+					break
+				}
+				return err
+			}
+
+			buildRun.Status.FailedAt = &buildv1alpha1.FailedAt{Pod: pod.Name}
+
+			// Since the container status list is not sorted, as a quick workaround mark all failed containers
+			var failures = make(map[string]struct{})
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				if containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode != 0 {
+					failures[containerStatus.Name] = struct{}{}
+				}
+			}
+
+			// Find the first container that failed
+			var failedContainer *corev1.Container
+			for i, container := range pod.Spec.Containers {
+				if _, has := failures[container.Name]; has {
+					failedContainer = &pod.Spec.Containers[i]
+					break
+				}
+			}
+
+			if failedContainer != nil {
+				buildRun.Status.FailedAt.Container = failedContainer.Name
+				message = fmt.Sprintf("buildrun step failed in pod %s, for detailed information: kubectl --namespace %s logs %s --container=%s",
+					pod.Name,
+					pod.Namespace,
+					pod.Name,
+					failedContainer.Name,
+				)
+			} else {
+				message = fmt.Sprintf("buildrun failed due to an unexpected error in pod %s: for detailed information: kubectl --namespace %s logs %s --all-containers",
+					pod.Name,
+					pod.Namespace,
+					pod.Name,
+				)
+			}
+		}
+	}
+
+	buildRun.Status.SetCondition(&buildv1alpha1.Condition{
+		LastTransitionTime: metav1.Now(),
+		Type:               buildv1alpha1.Succeeded,
+		Status:             trCondition.Status,
+		Reason:             reason,
+		Message:            message,
+	})
+
+	return nil
+}

--- a/pkg/reconciler/buildrun/resources/errors.go
+++ b/pkg/reconciler/buildrun/resources/errors.go
@@ -1,0 +1,22 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+)
+
+// HandleError returns multiple errors if each error is not nil.
+// And its error message.
+func HandleError(message string, listOfErrors ...error) error {
+	var errSlice []string
+	for _, e := range listOfErrors {
+		if e != nil {
+			errSlice = append(errSlice, e.Error())
+		}
+	}
+	return fmt.Errorf("errors: %s, msg: %s", strings.Join(errSlice, ", "), message)
+}

--- a/pkg/reconciler/buildrun/resources/errors_test.go
+++ b/pkg/reconciler/buildrun/resources/errors_test.go
@@ -1,0 +1,26 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
+)
+
+var _ = Describe("Multiple errors", func() {
+	Context("Dealing with multiple errors", func() {
+		It("should handle multiple errors", func() {
+			error01 := errors.New("error01")
+			error02 := errors.New("error02")
+			msg := "handling multiple errors"
+			customError := resources.HandleError(msg, error01, error02)
+			Expect(customError).To(Equal(fmt.Errorf("errors: %s, %s, msg: %s", error01, error02, msg)))
+		})
+	})
+})

--- a/pkg/reconciler/buildrun/resources/resources_suite_test.go
+++ b/pkg/reconciler/buildrun/resources/resources_suite_test.go
@@ -1,0 +1,13 @@
+package resources_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resources Suite")
+}

--- a/pkg/reconciler/buildrun/resources/resources_suite_test.go
+++ b/pkg/reconciler/buildrun/resources/resources_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 package resources_test
 
 import (

--- a/pkg/reconciler/buildrun/resources/service_accounts.go
+++ b/pkg/reconciler/buildrun/resources/service_accounts.go
@@ -1,0 +1,100 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/ctxlog"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// DefaultServiceAccountName defines the default sa name
+	// in vanilla Kubernetes clusters
+	DefaultServiceAccountName = "default"
+	// PipelineServiceAccountName defines the default sa name
+	// in vanilla OpenShift clusters
+	PipelineServiceAccountName        = "pipeline"
+	namespace                  string = "namespace"
+	name                       string = "name"
+)
+
+// GetGeneratedServiceAccountName returns the name of the generated service account for a build run
+func GetGeneratedServiceAccountName(buildRun *buildv1alpha1.BuildRun) string {
+	return buildRun.Name + "-sa"
+}
+
+// IsGeneratedServiceAccountUsed checks if a build run uses a generated service account
+func IsGeneratedServiceAccountUsed(buildRun *buildv1alpha1.BuildRun) bool {
+	return buildRun.Spec.ServiceAccount != nil && buildRun.Spec.ServiceAccount.Generate
+}
+
+// RetrieveServiceAccount ...
+func RetrieveServiceAccount(ctx context.Context, client client.Client, build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) (*corev1.ServiceAccount, error) {
+	serviceAccount := &corev1.ServiceAccount{}
+
+	if IsGeneratedServiceAccountUsed(buildRun) {
+		serviceAccountName := GetGeneratedServiceAccountName(buildRun)
+
+		serviceAccount.Name = serviceAccountName
+		serviceAccount.Namespace = buildRun.Namespace
+
+		// Create the service account, use CreateOrUpdate as it might exist already from a previous reconciliation that
+		// succeeded to create the service account but failed to update the build run that references it
+		ctxlog.Info(ctx, "create or update serviceAccount for BuildRun", namespace, buildRun.Namespace, name, serviceAccountName, "BuildRun", buildRun.Name)
+		op, err := controllerutil.CreateOrUpdate(ctx, client, serviceAccount, func() error {
+			serviceAccount.SetLabels(map[string]string{buildv1alpha1.LabelBuildRun: buildRun.Name})
+
+			ownerReference := metav1.NewControllerRef(buildRun, buildv1alpha1.SchemeGroupVersion.WithKind("BuildRun"))
+			serviceAccount.SetOwnerReferences([]metav1.OwnerReference{*ownerReference})
+
+			ApplyCredentials(ctx, build, serviceAccount)
+
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		ctxlog.Debug(ctx, "automatic generation of service account", namespace, serviceAccount.Namespace, name, serviceAccount.Name, "Operation", op)
+	} else {
+		// If ServiceAccount or the name of ServiceAccount in buildRun is nil, use pipeline serviceaccount
+		if buildRun.Spec.ServiceAccount == nil || buildRun.Spec.ServiceAccount.Name == nil {
+			serviceAccountName := PipelineServiceAccountName
+			err := client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
+			if err != nil && !apierrors.IsNotFound(err) {
+				return nil, err
+			} else if apierrors.IsNotFound(err) {
+				serviceAccountName = DefaultServiceAccountName
+				ctxlog.Info(ctx, "falling back to default serviceAccount", namespace, buildRun.Namespace)
+				err = client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			serviceAccountName := *buildRun.Spec.ServiceAccount.Name
+			err := client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: buildRun.Namespace}, serviceAccount)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Add credentials and update the service account
+		if modified := ApplyCredentials(ctx, build, serviceAccount); modified {
+			ctxlog.Info(ctx, "updating ServiceAccount with secrets from build", namespace, serviceAccount.Namespace, name, serviceAccount.Name)
+			if err := client.Update(ctx, serviceAccount); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return serviceAccount, nil
+}

--- a/pkg/reconciler/buildrun/resources/service_accounts.go
+++ b/pkg/reconciler/buildrun/resources/service_accounts.go
@@ -38,7 +38,9 @@ func IsGeneratedServiceAccountUsed(buildRun *buildv1alpha1.BuildRun) bool {
 	return buildRun.Spec.ServiceAccount != nil && buildRun.Spec.ServiceAccount.Generate
 }
 
-// RetrieveServiceAccount ...
+// RetrieveServiceAccount provides either a default sa with a referenced secret or it will generate a new sa on the fly.
+// When not using the generate feature, it will modify and return the default sa from a k8s namespace, which is "default"
+// or the default sa inside an openshift namespace, which is "pipeline".
 func RetrieveServiceAccount(ctx context.Context, client client.Client, build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) (*corev1.ServiceAccount, error) {
 	serviceAccount := &corev1.ServiceAccount{}
 

--- a/pkg/reconciler/buildrun/resources/service_accounts_test.go
+++ b/pkg/reconciler/buildrun/resources/service_accounts_test.go
@@ -1,0 +1,61 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/shipwright-io/build/pkg/controller/fakes"
+	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
+	"github.com/shipwright-io/build/test"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Operating service accounts", func() {
+	var (
+		client                  *fakes.FakeClient
+		ctl                     test.Catalog
+		buildName, buildRunName string
+	)
+
+	Context("Retrieving service accounts", func() {
+
+		// init vars
+		buildName = "foobuild"
+		buildRunName = "foobuildrun"
+		client = &fakes.FakeClient{}
+		buildRunSample := ctl.DefaultBuildRun(buildRunName, buildName)
+
+		It("should return a modified one with a secret ref", func() {
+
+			// stub a GET API call for a service account
+			getClientStub := func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+				switch object := object.(type) {
+				case *corev1.ServiceAccount:
+					ctl.DefaultServiceAccount("foobar").DeepCopyInto(object)
+					return nil
+				}
+				return k8serrors.NewNotFound(schema.GroupResource{}, nn.Name)
+			}
+			// fake the calls with the above stub
+			client.GetCalls(getClientStub)
+
+			sa, err := resources.RetrieveServiceAccount(context.TODO(), client, ctl.BuildWithOutputSecret(buildName, "default", "foosecret"), buildRunSample)
+			Expect(err).To(BeNil())
+			// assert the build output secret is defined in the default SA
+			Expect(len(sa.Secrets)).To(Equal(1))
+		})
+
+		It("should provide a generated sa name", func() {
+			Expect(resources.GetGeneratedServiceAccountName(buildRunSample)).To(Equal(buildRunSample.Name + "-sa"))
+		})
+	})
+})

--- a/pkg/reconciler/buildrun/resources/strategies.go
+++ b/pkg/reconciler/buildrun/resources/strategies.go
@@ -1,0 +1,39 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/shipwright-io/build/pkg/ctxlog"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// RetrieveBuildStrategy returns a namespace scoped strategy
+func RetrieveBuildStrategy(ctx context.Context, client client.Client, build *buildv1alpha1.Build) (*buildv1alpha1.BuildStrategy, error) {
+	buildStrategyInstance := &buildv1alpha1.BuildStrategy{}
+
+	ctxlog.Debug(ctx, "retrieving BuildStrategy", namespace, build.Namespace, name, build.Name)
+	err := client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name, Namespace: build.Namespace}, buildStrategyInstance)
+	if err != nil {
+		return nil, err
+	}
+	return buildStrategyInstance, nil
+}
+
+// RetrieveClusterBuildStrategy returns a cluster scoped strategy
+func RetrieveClusterBuildStrategy(ctx context.Context, client client.Client, build *buildv1alpha1.Build) (*buildv1alpha1.ClusterBuildStrategy, error) {
+	clusterBuildStrategyInstance := &buildv1alpha1.ClusterBuildStrategy{}
+
+	ctxlog.Debug(ctx, "retrieving ClusterBuildStrategy", namespace, build.Namespace, name, build.Name)
+	err := client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name}, clusterBuildStrategyInstance)
+	if err != nil {
+		return nil, err
+	}
+	return clusterBuildStrategyInstance, nil
+}

--- a/pkg/reconciler/buildrun/resources/strategies.go
+++ b/pkg/reconciler/buildrun/resources/strategies.go
@@ -19,8 +19,7 @@ func RetrieveBuildStrategy(ctx context.Context, client client.Client, build *bui
 	buildStrategyInstance := &buildv1alpha1.BuildStrategy{}
 
 	ctxlog.Debug(ctx, "retrieving BuildStrategy", namespace, build.Namespace, name, build.Name)
-	err := client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name, Namespace: build.Namespace}, buildStrategyInstance)
-	if err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name, Namespace: build.Namespace}, buildStrategyInstance); err != nil {
 		return nil, err
 	}
 	return buildStrategyInstance, nil
@@ -31,8 +30,7 @@ func RetrieveClusterBuildStrategy(ctx context.Context, client client.Client, bui
 	clusterBuildStrategyInstance := &buildv1alpha1.ClusterBuildStrategy{}
 
 	ctxlog.Debug(ctx, "retrieving ClusterBuildStrategy", namespace, build.Namespace, name, build.Name)
-	err := client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name}, clusterBuildStrategyInstance)
-	if err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: build.Spec.StrategyRef.Name}, clusterBuildStrategyInstance); err != nil {
 		return nil, err
 	}
 	return clusterBuildStrategyInstance, nil

--- a/pkg/reconciler/buildrun/resources/strategies_test.go
+++ b/pkg/reconciler/buildrun/resources/strategies_test.go
@@ -1,0 +1,71 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/controller/fakes"
+	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
+	"github.com/shipwright-io/build/test"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Operating Build strategies", func() {
+	var (
+		client *fakes.FakeClient
+		ctl    test.Catalog
+	)
+
+	Context("Retrieving build strategies", func() {
+		client = &fakes.FakeClient{}
+		buildSample := ctl.BuildWithBuildStrategy("foobuild", "foostrategy", "foostrategy")
+
+		It("should return a cluster buildstrategy", func() {
+
+			// stub a GET API call with a cluster strategy
+			getClientStub := func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+				switch object := object.(type) {
+				case *buildv1alpha1.ClusterBuildStrategy:
+					ctl.DefaultClusterBuildStrategy().DeepCopyInto(object)
+					return nil
+				}
+				return k8serrors.NewNotFound(schema.GroupResource{}, nn.Name)
+			}
+			// fake the calls with the above stub
+			client.GetCalls(getClientStub)
+
+			cbs, err := resources.RetrieveClusterBuildStrategy(context.TODO(), client, buildSample)
+			Expect(err).To(BeNil())
+			Expect(cbs.Name).To(Equal("foobar"))
+		})
+
+		It("should return a namespaced buildstrategy", func() {
+
+			// stub a GET API call with a namespace strategy
+			getClientStub := func(context context.Context, nn types.NamespacedName, object runtime.Object) error {
+				switch object := object.(type) {
+				case *buildv1alpha1.BuildStrategy:
+					ctl.DefaultNamespacedBuildStrategy().DeepCopyInto(object)
+					return nil
+				}
+				return k8serrors.NewNotFound(schema.GroupResource{}, nn.Name)
+			}
+			// fake the calls with the above stub
+			client.GetCalls(getClientStub)
+
+			cbs, err := resources.RetrieveBuildStrategy(context.TODO(), client, buildSample)
+			Expect(err).To(BeNil())
+			Expect(cbs.Name).To(Equal("foobar"))
+		})
+
+	})
+})

--- a/pkg/reconciler/buildrun/resources/taskrun.go
+++ b/pkg/reconciler/buildrun/resources/taskrun.go
@@ -20,20 +20,14 @@ import (
 )
 
 const (
-	// DefaultServiceAccountName defines the default sa name
-	// in vanilla Kubernetes clusters
-	DefaultServiceAccountName = "default"
-	// PipelineServiceAccountName defines the default sa name
-	// in vanilla OpenShift clusters
-	PipelineServiceAccountName = "pipeline"
-	inputSourceResourceName    = "source"
-	inputGitSourceURL          = "url"
-	inputGitSourceRevision     = "revision"
-	inputParamBuilderImage     = "BUILDER_IMAGE"
-	inputParamDockerfile       = "DOCKERFILE"
-	inputParamContextDir       = "CONTEXT_DIR"
-	outputImageResourceName    = "image"
-	outputImageResourceURL     = "url"
+	inputSourceResourceName = "source"
+	inputGitSourceURL       = "url"
+	inputGitSourceRevision  = "revision"
+	inputParamBuilderImage  = "BUILDER_IMAGE"
+	inputParamDockerfile    = "DOCKERFILE"
+	inputParamContextDir    = "CONTEXT_DIR"
+	outputImageResourceName = "image"
+	outputImageResourceURL  = "url"
 )
 
 // getStringTransformations gets us MANDATORY replacements using

--- a/pkg/reconciler/buildstrategy/buildstrategy.go
+++ b/pkg/reconciler/buildstrategy/buildstrategy.go
@@ -7,9 +7,36 @@ package buildstrategy
 import (
 	"context"
 
+	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/ctxlog"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// blank assignment to verify that ReconcileBuildStrategy implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileBuildStrategy{}
+
+// ReconcileBuildStrategy reconciles a BuildStrategy object
+type ReconcileBuildStrategy struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	ctx    context.Context
+	config *config.Config
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileBuildStrategy{
+		ctx:    ctx,
+		config: c,
+		client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
+}
 
 // Reconcile reads that state of the cluster for a BuildStrategy object and makes changes based on the state read
 // and what is in the BuildStrategy.Spec

--- a/pkg/reconciler/buildstrategy/controller.go
+++ b/pkg/reconciler/buildstrategy/controller.go
@@ -7,8 +7,6 @@ package buildstrategy
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -27,16 +25,6 @@ func Add(ctx context.Context, c *config.Config, mgr manager.Manager) error {
 	return add(ctx, mgr, NewReconciler(ctx, c, mgr))
 }
 
-// NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileBuildStrategy{
-		ctx:    ctx,
-		config: c,
-		client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-	}
-}
-
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
@@ -52,17 +40,4 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 	}
 
 	return nil
-}
-
-// blank assignment to verify that ReconcileBuildStrategy implements reconcile.Reconciler
-var _ reconcile.Reconciler = &ReconcileBuildStrategy{}
-
-// ReconcileBuildStrategy reconciles a BuildStrategy object
-type ReconcileBuildStrategy struct {
-	// This client, initialized using mgr.Client() above, is a split client
-	// that reads objects from the cache and writes to the apiserver
-	ctx    context.Context
-	config *config.Config
-	client client.Client
-	scheme *runtime.Scheme
 }

--- a/pkg/reconciler/clusterbuildstrategy/clusterbuildstrategy.go
+++ b/pkg/reconciler/clusterbuildstrategy/clusterbuildstrategy.go
@@ -7,10 +7,37 @@ package clusterbuildstrategy
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/ctxlog"
 )
+
+// blank assignment to verify that ReconcileClusterBuildStrategy implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileClusterBuildStrategy{}
+
+// ReconcileClusterBuildStrategy reconciles a ClusterBuildStrategy object
+type ReconcileClusterBuildStrategy struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	ctx    context.Context
+	config *config.Config
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileClusterBuildStrategy{
+		ctx:    ctx,
+		config: c,
+		client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
+}
 
 // Reconcile reads that state of the cluster for a ClusterBuildStrategy object and makes changes based on the state read
 // and what is in the BuildStrategy.Spec

--- a/pkg/reconciler/clusterbuildstrategy/controller.go
+++ b/pkg/reconciler/clusterbuildstrategy/controller.go
@@ -7,8 +7,6 @@ package clusterbuildstrategy
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -27,16 +25,6 @@ func Add(ctx context.Context, c *config.Config, mgr manager.Manager) error {
 	return add(ctx, mgr, NewReconciler(ctx, c, mgr))
 }
 
-// NewReconciler returns a new reconcile.Reconciler
-func NewReconciler(ctx context.Context, c *config.Config, mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileClusterBuildStrategy{
-		ctx:    ctx,
-		config: c,
-		client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-	}
-}
-
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
@@ -52,17 +40,4 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 	}
 
 	return nil
-}
-
-// blank assignment to verify that ReconcileClusterBuildStrategy implements reconcile.Reconciler
-var _ reconcile.Reconciler = &ReconcileClusterBuildStrategy{}
-
-// ReconcileClusterBuildStrategy reconciles a ClusterBuildStrategy object
-type ReconcileClusterBuildStrategy struct {
-	// This client, initialized using mgr.Client() above, is a split client
-	// that reads objects from the cache and writes to the apiserver
-	ctx    context.Context
-	config *config.Config
-	client client.Client
-	scheme *runtime.Scheme
 }

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -165,6 +165,26 @@ func (c *Catalog) BuildWithNilBuildStrategyKind(name string, ns string, strategy
 	}
 }
 
+// BuildWithOutputSecret ....
+func (c *Catalog) BuildWithOutputSecret(name string, ns string, secretName string) *build.Build {
+	return &build.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: build.BuildSpec{
+			Source: build.GitSource{
+				URL: "https://github.com/qu1queee/taxi",
+			},
+			Output: build.Image{
+				SecretRef: &corev1.LocalObjectReference{
+					Name: secretName,
+				},
+			},
+		},
+	}
+}
+
 // ClusterBuildStrategy to support tests
 func (c *Catalog) ClusterBuildStrategy(name string) *build.ClusterBuildStrategy {
 	return &build.ClusterBuildStrategy{
@@ -447,6 +467,41 @@ func (c *Catalog) StubBuildCRDsPodAndTaskRun(
 			return nil
 		}
 		return errors.NewNotFound(schema.GroupResource{}, nn.Name)
+	}
+}
+
+// TaskRunWithStatus returns a minimal tekton TaskRun with an Status
+func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
+	return &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      trName,
+			Namespace: ns,
+		},
+		Spec: v1beta1.TaskRunSpec{
+			Timeout: &metav1.Duration{
+				Duration: time.Minute * 2,
+			},
+		},
+		Status: v1beta1.TaskRunStatus{
+			Status: knativev1beta1.Status{
+				Conditions: knativev1beta1.Conditions{
+					{
+						Type:   apis.ConditionSucceeded,
+						Reason: "Unknown",
+						Status: corev1.ConditionUnknown,
+					},
+				},
+			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				PodName: "foobar-pod",
+				StartTime: &metav1.Time{
+					Time: time.Now(),
+				},
+				CompletionTime: &metav1.Time{
+					Time: time.Now(),
+				},
+			},
+		},
 	}
 }
 
@@ -735,6 +790,21 @@ func (c *Catalog) DefaultServiceAccount(name string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+		},
+	}
+}
+
+// ServiceAccountWithControllerRef ... TODO
+func (c *Catalog) ServiceAccountWithControllerRef(name string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "ss",
+					Kind: "BuildRun",
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
# Changes

This is a rebase on top of #593 . This PR is doing the following:

- [1] Separate controller/reconcile logic. This ensures that between controller definition and reconcile logic, we have a clear separation.
- [2] Refactor buildRun reconciler class. Move some functions into new or existing classes under the internal resource package. This class was one of the most hardest files to read. So the goal here is to make it easier for future contributors.
- [3] Ensure proper code coverage. Because I externalize a lot of the functions in [2], into the internal `resource` pkg, I´m adding a bunch of new unit-tests to increase the coverage of those functions.


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Release notes block has been filled in, or marked NONE


# Release Notes

```release-note
Restructure BuildRun reconcile code into separate classes.
```

