### PR TITLE
Improve find for misspell check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ golint:
 .PHONY: misspell
 misspell:
 	@echo "Checking misspell"
-	@find . -type f | grep -v /vendor | xargs misspell -source=text -error
+	@find . -type f -not -path './vendor/*' -not -path './.git/*' -not -path './build/*' -print0 | xargs -0 misspell -source=text -error
 
 # Install it via: go get -u honnef.co/go/tools/cmd/staticcheck
 .PHONY: staticcheck


### PR DESCRIPTION
# Changes

The `find` command for the `misspell` Makefile target included a lot of files
that should not be included, ie. `.git` directory.

Add exceptions to the find command to filter for only relevant files.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
