### PR TITLE
Add GitHub Action for Sanity Checks

### DIFF
--- a/.github/workflows/sanity-checks.yaml
+++ b/.github/workflows/sanity-checks.yaml
@@ -1,0 +1,49 @@
+---
+name: Sanity Checks
+
+on:
+  push:
+    tags-ignore:
+      - '**'
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Sanity Checks
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Install Tools
+      run: |
+        pushd $(mktemp -d)
+        go get github.com/gordonklaus/ineffassign
+        go get golang.org/x/lint/golint
+        go get github.com/client9/misspell/cmd/misspell
+        go get honnef.co/go/tools/cmd/staticcheck
+        popd
+
+    - name: Sanity Check (go vet)
+      run: make govet
+
+    - name: Sanity Check (ineffassign)
+      run: make ineffassign
+
+    - name: Sanity Check (golint)
+      run: make golint
+
+    - name: Sanity Check (misspell)
+      run: make misspell
+
+    - name: Sanity Check (staticcheck)
+      run: make staticcheck

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -139,7 +139,8 @@ func InitPrometheus(config *config.Config) {
 	)
 }
 
-// ExtraHandlers returns a map of additional endpoint handlers
+// ExtraHandlers returns a mapping of paths and their respective
+// additional HTTP handlers to be configured at the metrics listener
 func ExtraHandlers() map[string]http.HandlerFunc {
 	return metricsExtraHandlers
 }


### PR DESCRIPTION
# Changes

Add GitHub Action workflow configuration to run sanity checks on the Go source. It should run by default only on the current default branch and in PRs against that branch.

Fixes #552

<img width="1898" alt="image" src="https://user-images.githubusercontent.com/1979133/108236247-f828b980-7146-11eb-91cb-ab3fb13609d5.png">

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

