### PR TITLE
Run target install-strategies after install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ test-e2e-plain: ginkgo
 
 install:
 	KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE)" GOFLAGS="$(GO_FLAGS)" ko apply --bare -R -f deploy/
+	install-strategies
 
 install-with-pprof:
 	GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko apply -R -f deploy/


### PR DESCRIPTION
The current README.md says:
```
* Install the operator and sample strategies via `make`:

```bash
$ make install
```

However, the `make install` command does not install the sample strategies making the test buildrun to fail because it cannot find the `buildpacks-v3` `ClusterBuildStrategy `

This is just a quick fix, so people testing the project may not be confused.