### PR TITLE
Publish nightly releases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,73 @@
+name: Nightly Release
+
+on:
+  workflow_dispatch:  # Manual trigger
+
+  schedule:
+  - cron: '0 5 * * *' # 5 AM UTC = Midnight EST
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+    # TODO: Don't publish a new release if there are no changes since the last release.
+    - name: Draft release
+      id: draft_release
+      uses: actions/create-release@v1
+      continue-on-error: true
+      with:
+        release_name: "Shipwright Build Nightly Release ${{ steps.date.outputs.date }}"
+        body: "Nightly release ${{ steps.date.outputs.date }}"
+        tag_name: nightly
+        draft: true
+        prerelease: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install Go
+      uses: actions/setup-go@v2
+    - name: Install Ko
+      run: |
+        echo '::group:: install ko'
+        curl -L https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | tar xzf - ko
+        chmod +x ./ko
+        sudo mv ko /usr/local/bin
+        echo '::endgroup::'
+    - name: Ko resolve nightly.yaml
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+        IMAGE_HOST: quay.io
+        IMAGE: shipwright/shipwright-operator
+      run: |
+        make release
+        mv release.yaml nightly-${{ steps.date.outputs.date }}.yaml
+        mv release-debug.yaml nightly-${{ steps.date.outputs.date }}-debug.yaml
+
+    - name: Upload Release Asset
+      id: upload_release_asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.draft_release.outputs.upload_url }} 
+        asset_path: ./nightly-${{ steps.date.outputs.date }}.yaml
+        asset_name: nightly-${{ steps.date.outputs.date}}.yaml
+        asset_content_type: application/x-yaml
+    - name: Upload Release Asset
+      id: upload_release_asset-debug
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.draft_release.outputs.upload_url }} 
+        asset_path: ./nightly-${{ steps.date.outputs.date }}-debug.yaml
+        asset_name: nightly-${{ steps.date.outputs.date}}-debug.yaml
+        asset_content_type: application/x-yaml
+


### PR DESCRIPTION
# Changes

This will run at midnight EST and produce a `nightly-YYYY-MM-DD.yaml` (and `-debug.yaml`) attached to a new (draft, pre-release) GitHub Release each night.

**Note:** This creates new GitHub Releases each day, and I assume this will become unwieldy at some point. Ideas welcome.

Related to discussion in #599 

# Submitter Checklist

- [n] Includes tests if functionality changed/was added
- [n] Includes docs if changes are user-facing
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```