### PR TITLE
Add ko build strategy sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following [Build Strategies](docs/buildstrategies.md) are installed by defau
 * [Buildpacks-v3](docs/buildstrategies.md#buildpacks-v3)
 * [Buildah](docs/buildstrategies.md#buildah)
 * [Kaniko](docs/buildstrategies.md#kaniko)
+* [ko](docs/buildstrategies.md#ko)
 
 Users have the option to define their own `BuildStrategy` or `ClusterBuildStrategy` resources and make them available for consumption via the `Build` resource.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -153,6 +153,7 @@ A `Build` resource can specify the `BuildStrategy` to use, these are:
 - [Buildpacks-v3](buildstrategies.md#buildpacks-v3)
 - [Buildah](buildstrategies.md#buildah)
 - [Kaniko](buildstrategies.md#kaniko)
+* [ko](docs/buildstrategies.md#ko)
 
 Defining the strategy is straightforward, you need to define the `name` and the `kind`. For example:
 

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -16,13 +16,16 @@ SPDX-License-Identifier: Apache-2.0
   - [Try it](#try-it)
 - [Kaniko](#kaniko)
   - [Installing Kaniko Strategy](#installing-kaniko-strategy)
+- [ko](#ko)
+  - [Installing ko Strategy](#installing-ko-strategy)
 - [Source to Image](#source-to-image)
   - [Installing Source to Image Strategy](#installing-source-to-image-strategy)
   - [Build Steps](#build-steps)
-- [Steps resources definition](#steps-resources-definition)
+- [Steps Resource Definition](#steps-resource-definition)
   - [Strategies with different resources](#strategies-with-different-resources)
-  - [How does Tekton Pipelines handles resources](#how-does-tekton-pipelines-handles-resources)
+  - [How does Tekton Pipelines handle resources](#how-does-tekton-pipelines-handle-resources)
   - [Examples of Tekton resources management](#examples-of-tekton-resources-management)
+- [Annotations](#annotations)
 
 ## Overview
 
@@ -32,7 +35,7 @@ A `ClusterBuildStrategy` is available cluster-wide, while a `BuildStrategy` is a
 
 ## Available ClusterBuildStrategies
 
-Well-known strategies can be bootstrapped from [here](../samples/buildstrategy). The current supported Cluster BuildStrategy are:
+Well-known strategies can be boostrapped from [here](../samples/buildstrategy). The current supported Cluster BuildStrategy are:
 
 - [buildah](../samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml)
 - [buildpacks-v3-heroku](../samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml)
@@ -70,7 +73,6 @@ The [buildpacks-v3][buildpacks] BuildStrategy/ClusterBuildStrategy uses a Cloud 
 - [`heroku/buildpacks:18`][hubheroku]
 - [`cloudfoundry/cnb:bionic`][hubcloudfoundry]
 - [`docker.io/paketobuildpacks/builder:full`](https://hub.docker.com/r/paketobuildpacks/builder/tags)
-
 
 ### Installing Buildpacks v3 Strategy
 
@@ -139,6 +141,20 @@ kubectl apply -f samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
 ```
 
 ---
+
+## ko
+
+The `ko` ClusterBuilderStrategy is using [ko](https://github.com/google/ko)'s publish command to build an image from a Golang main package.
+
+### Installing ko Strategy
+
+To install the cluster scope strategy, use:
+
+```sh
+kubectl apply -f samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+```
+
+**Note**: The build strategy currently uses the `spec.contextDir` of the Build in a different way than this property is designed for: the Git repository must be a Go module with the go.mod file at the root. The `contextDir` specifies the path to the main package. You can check the [example](../samples/build/build_ko_cr.yaml) which is set up to build the Shipwright Build operator. This behavior will eventually be corrected once [Exhaustive list of generalized Build API/CRD attributes #184](https://github.com/shipwright-io/build/issues/184) / [Custom attributes from the Build CR could be used as parameters while defining a BuildStrategy #537](https://github.com/shipwright-io/build/issues/537) are done.
 
 ## Source to Image
 

--- a/samples/build/build_ko_cr.yaml
+++ b/samples/build/build_ko_cr.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: Build
+metadata:
+  name: ko-build
+  annotations:
+    build.build.dev/build-run-deletion: "false"
+spec:
+  source:
+    url: https://github.com/shipwright-io/build
+    contextDir: cmd/manager
+    revision: master
+  strategy:
+    name: ko
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/build-operator

--- a/samples/buildrun/buildrun_ko_cr.yaml
+++ b/samples/buildrun/buildrun_ko_cr.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: BuildRun
+metadata:
+  name: ko-buildrun
+spec:
+  buildRef:
+    name: ko-build
+  serviceAccount:
+    generate: true

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: build.dev/v1alpha1
+kind: ClusterBuildStrategy
+metadata:
+  name: ko
+spec:
+  buildSteps:
+    - name: prepare
+      image: golang:1.15
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add: 
+            - CHOWN
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          set -euo pipefail
+
+          chown -R 1000:1000 /workspace/output
+          chown -R 1000:1000 /workspace/source
+          chown -R 1000:1000 /tekton/home
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    - name: build-and-push
+      image: golang:1.15
+      workingDir: /workspace/source
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      env:
+        - name: DOCKER_CONFIG
+          value: /tekton/home/.docker
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          set -euo pipefail
+
+          # Parse image URL to extract repository and tag, must work with
+          # - a URL without a tag and a port: registry/image
+          # - a URL without a tag but a port: registry:port/image
+          # - a URL with a tag but without a port: registry/image:tag
+          # - a URL with both a tag and a port: registry:port/image:tag
+
+          IMAGE=$(build.output.image)
+
+          REPO=
+          TAG=
+
+          IFS=':' read -ra PARTS <<< "${IMAGE}"
+          for PART in "${PARTS[@]}"; do
+            if [ "${REPO}" == "" ]; then
+              REPO="${PART}"
+          	elif [[ "${PART}" == *"/"* ]]; then
+              REPO="${REPO}:${PART}"
+            elif [ "${TAG}" == "" ]; then
+              TAG="${PART}"
+            else
+              REPO="${REPO}:${TAG}"
+              TAG="${PART}"
+            fi
+          done
+
+          # Download ko
+          pushd /tmp > /dev/null
+            curl -f -s -L https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | tar xzf - ko
+          popd > /dev/null
+
+          # Run ko
+          if [ "${TAG}" == "" ]; then
+            GOROOT=$(go env GOROOT) KO_DOCKER_REPO="${REPO}" /tmp/ko publish "./$(build.source.contextDir)" --bare --oci-layout-path=/workspace/output/image
+          else
+            GOROOT=$(go env GOROOT) KO_DOCKER_REPO="${REPO}" /tmp/ko publish "./$(build.source.contextDir)" --bare --oci-layout-path=/workspace/output/image --tags="${TAG}"
+          fi
+      resources:
+        limits:
+          cpu: 500m
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 65Mi

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -375,6 +375,23 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
+	Context("when a ko build is defined", func() {
+
+		BeforeEach(func() {
+			testID = generateTestID("ko")
+
+			// create the build definition
+			createBuild(ctx, namespace, testID, "samples/build/build_ko_cr.yaml", cleanupTimeout, cleanupRetryInterval)
+		})
+
+		It("successfully runs a build", func() {
+			br, err = buildRunTestData(namespace, testID, "samples/buildrun/buildrun_ko_cr.yaml")
+			Expect(err).ToNot(HaveOccurred())
+
+			validateBuildRunToSucceed(ctx, namespace, br, cleanupTimeout, cleanupRetryInterval)
+		})
+	})
+
 	Context("when a s2i build is defined", func() {
 
 		BeforeEach(func() {


### PR DESCRIPTION
# Changes

Based on [this inquiry](https://kubernetes.slack.com/archives/C019ZRGUEJC/p1613685285101400?thread_ts=1613404922.076800&cid=C019ZRGUEJC), I am adding the ko sample build strategy that I recently created. I added a big note to the documentation about the creative interpretation of the `contextDir` property.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
- Adding a sample build strategy for [ko](https://github.com/google/ko)
```
