### PR TITLE
Add serviceaccount name to status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ tags
 # JetBrains IDE config
 .idea
 **/*coverprofile*
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -103,12 +103,17 @@ Examples of `Build` resource using the example strategies installed by default.
   --type=kubernetes.io/dockerconfigjson
   ```
 
-* Create a [Cloud Native Buildpacks](samples/build/build_buildpacks_v3_cr.yaml) build, replacing
-  `<MY_REGISTRY>/<MY_USERNAME>/<MY_REPO>` with the registry hostname, username, and repository your
-  cluster has access to and that you have permission to push images to.
+* Set the following environment variables to match your destination image:
+  ```
+  export MY_REGISTRY=my-registry.io
+  export MY_USERNAME=my-username
+  export MY_REPO=my-image-repo
+  ```
+
+* Create a [Cloud Native Buildpacks](samples/build/build_buildpacks_v3_cr.yaml) build:
 
   ```bash
-  $ kubectl apply -f - <<EOF
+  $ envsubst <<EOF | kubectl apply -f -
   apiVersion: build.dev/v1alpha1
   kind: Build
   metadata:
@@ -120,7 +125,7 @@ Examples of `Build` resource using the example strategies installed by default.
       name: buildpacks-v3
       kind: ClusterBuildStrategy
     output:
-      image: <MY_REGISTRY>/<MY_USERNAME>/<MY_REPO>:latest
+      image: ${MY_REGISTRY}/${MY_USERNAME}/${MY_REPO}:latest
       credentials:
         name: push-secret
   EOF

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -89,7 +89,8 @@ spec:
 
 You can also use set the `spec.serviceAccount.generate` path to `true`. This will generate the service account during runtime for you.
 
-_**Note**_: When the SA is not defined, the `BuildRun` will default to the `default` SA in the namespace.
+_**Note**_: When the SA is not defined, the `BuildRun` will default to the `default` SA in the namespace. The effective 
+`serviceAccount` used to run a `BuildRun` is set in the `Status.ServiceAccountName` field.
 
 ## BuildRun Status
 

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -61,6 +61,10 @@ type BuildRunStatus struct {
 	// +optional
 	LatestTaskRunRef *string `json:"latestTaskRunRef,omitempty"`
 
+	// ServiceAccountName is the name of the serviceAccount used to run the build.
+	// +optional
+	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
+
 	// StartTime is the time the build is actually started.
 	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`

--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -127,7 +127,6 @@ var _ = Describe("Reconcile BuildRun", func() {
 
 				// initialize a TaskRun, we need this to fake the existence of a Tekton TaskRun
 				taskRunSample = ctl.DefaultTaskRunWithStatus(taskRunName, buildRunName, ns, corev1.ConditionTrue, "Succeeded")
-
 				// initialize a BuildRun, we need this to fake the existence of a BuildRun
 				buildRunSample = ctl.DefaultBuildRun(buildRunName, buildName)
 			})


### PR DESCRIPTION
release-note
Add serviceAccount name to the BuildRun status fixes #522 
Also adds env vars in the try it section to make contributions easier.


```release-note
Set serviceAccount name to the BuildRun status
```