### PR TITLE
Rename build.dev -> shipwright.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ install-with-pprof:
 install-apis:
 	kubectl apply -f deploy/crds/
 	# Wait for the CRD type to be established; this can take a second or two.
-	kubectl wait --timeout=10s --for condition=established crd/clusterbuildstrategies.build.dev
+	kubectl wait --timeout=10s --for condition=established crd/clusterbuildstrategies.shipwright.io
 
 install-controller: install-apis
 	KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE)" GOFLAGS="$(GO_FLAGS)" ko apply --bare -f deploy/

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Examples of `Build` resource using the example strategies installed by default.
 
   ```bash
   $ kubectl apply -f - <<EOF
-  apiVersion: build.dev/v1alpha1
+  apiVersion: shipwright.io/v1alpha1
   kind: Build
   metadata:
     name: buildpack-nodejs-build
@@ -130,7 +130,7 @@ Examples of `Build` resource using the example strategies installed by default.
 
   ```bash
   $ kubectl apply -f - <<EOF
-  apiVersion: build.dev/v1alpha1
+  apiVersion: shipwright.io/v1alpha1
   kind: BuildRun
   metadata:
     name: buildpack-nodejs-build-1

--- a/deploy/200-role.yaml
+++ b/deploy/200-role.yaml
@@ -67,7 +67,7 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - build.dev
+  - shipwright.io
   resources:
   - '*'
   - buildstrategies

--- a/deploy/crds/build.yaml
+++ b/deploy/crds/build.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: builds.build.dev
+  name: builds.shipwright.io
 spec:
-  group: build.dev
+  group: shipwright.io
   names:
     kind: Build
     listKind: BuildList

--- a/deploy/crds/buildrun.yaml
+++ b/deploy/crds/buildrun.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: buildruns.build.dev
+  name: buildruns.shipwright.io
 spec:
-  group: build.dev
+  group: shipwright.io
   names:
     kind: BuildRun
     listKind: BuildRunList

--- a/deploy/crds/buildstrategy.yaml
+++ b/deploy/crds/buildstrategy.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: buildstrategies.build.dev
+  name: buildstrategies.shipwright.io
 spec:
-  group: build.dev
+  group: shipwright.io
   names:
     kind: BuildStrategy
     listKind: BuildStrategyList

--- a/deploy/crds/clusterbuildstrategy.yaml
+++ b/deploy/crds/clusterbuildstrategy.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterbuildstrategies.build.dev
+  name: clusterbuildstrategies.shipwright.io
 spec:
-  group: build.dev
+  group: shipwright.io
   names:
     kind: ClusterBuildStrategy
     listKind: ClusterBuildStrategyList

--- a/docs/build.md
+++ b/docs/build.md
@@ -49,7 +49,7 @@ In order to prevent users from triggering `BuildRuns` (_execution of a Build_) t
 | --- | --- |
 | BuildStrategyNotFound   | The referenced namespace-scope strategy doesn´t exist. |
 | ClusterBuildStrategyNotFound   | The referenced cluster-scope strategy doesn´t exist. |
-| SetOwnerReferenceFailed   | Setting ownerreferences between a Build and a BuildRun failed. This is triggered when making use of the `build.build.dev/build-run-deletion` annotation in a Build. |
+| SetOwnerReferenceFailed   | Setting ownerreferences between a Build and a BuildRun failed. This is triggered when making use of the `build.shipwright.io/build-run-deletion` annotation in a Build. |
 | SpecSourceSecretNotFound | The secret used to authenticate to git doesn´t exist. |
 | SpecOutputSecretRefNotFound | The secret used to authenticate to the container registry doesn´t exist. |
 | SpecRuntimeSecretRefNotFound | The secret used to authenticate to the container registry doesn´t exist.|
@@ -62,7 +62,7 @@ In order to prevent users from triggering `BuildRuns` (_execution of a Build_) t
 The `Build` definition supports the following fields:
 
 - Required:
-  - [`apiVersion`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the API version, for example `build.dev/v1alpha1`.
+  - [`apiVersion`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the API version, for example `shipwright.io/v1alpha1`.
   - [`kind`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the Kind type, for example `Build`.
   - [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Metadata that identify the CRD instance, for example the name of the `Build`.
   - `spec.source.URL` - Refers to the Git repository containing the source code.
@@ -76,7 +76,7 @@ The `Build` definition supports the following fields:
   - `spec.dockerfile` - Path to a Dockerfile to be used for building an image. (_Use this path for strategies that require a Dockerfile_)
   - `spec.runtime` - Runtime-Image settings, to be used for a multi-stage build.
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example `5m`. The default is ten minutes. The value can be overwritten in the `BuildRun`.
-  - `metadata.annotations[build.build.dev/build-run-deletion]` - Defines if delete all related BuildRuns when deleting the Build. The default is `false`.
+  - `metadata.annotations[build.shipwright.io/build-run-deletion]` - Defines if delete all related BuildRuns when deleting the Build. The default is `false`.
 
 ### Defining the Source
 
@@ -86,17 +86,17 @@ A `Build` resource can specify a Git source, together with other parameters like
 - `source.revision` - An specific revision to select from the source repository, this can be a commit or branch name.
 - `source.contextDir` - For repositories where the source code is not located at the root folder, you can specify this path here. Currently, only supported by `buildah`, `kaniko` and `buildpacks` build strategies.
 
-By default, the Build controller will validate that the Git repository exists. If the validation is not desired, users can define the `build.build.dev/verify.repository` annotation with `false`. For example:
+By default, the Build controller will validate that the Git repository exists. If the validation is not desired, users can define the `build.shipwright.io/verify.repository` annotation with `false`. For example:
 
-Example of a `Build` with the **build.build.dev/verify.repository** annotation, in order to disable the `spec.source.url` validation.
+Example of a `Build` with the **build.shipwright.io/verify.repository** annotation, in order to disable the `spec.source.url` validation.
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build
   annotations:
-    build.build.dev/verify.repository: "false"
+    build.shipwright.io/verify.repository: "false"
 spec:
   source:
     url: https://github.com/qu1queee/taxi
@@ -108,7 +108,7 @@ _Note_: The Build controller only validates two scenarios. The first one where t
 Example of a `Build` with a source with **credentials** defined by the user.
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build
@@ -122,7 +122,7 @@ spec:
 Example of a `Build` with a source that specifies an specific subfolder on the repository.
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-custom-context-dockerfile
@@ -135,7 +135,7 @@ spec:
 Example of a `Build` that specifies an specific branch on the git repository:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build
@@ -157,7 +157,7 @@ A `Build` resource can specify the `BuildStrategy` to use, these are:
 Defining the strategy is straightforward, you need to define the `name` and the `kind`. For example:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build
@@ -172,7 +172,7 @@ spec:
 A `Build` resource can specify an image containing the tools to build the final image. Users can do this via the `spec.builder` or the `spec.dockerfile`. For example, the user choose  the `Dockerfile` file under the source repository.
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build
@@ -189,7 +189,7 @@ spec:
 Another example, when the user chooses to use a `builder` image ( This is required for `source-to-image` buildStrategy, because for different code languages, they have different builders. ):
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: s2i-nodejs-build
@@ -210,7 +210,7 @@ A `Build` resource can specify the output where the image should be pushed. For 
 For example, the user specify a public registry:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: s2i-nodejs-build
@@ -229,7 +229,7 @@ spec:
 Another example, is when the user specifies a private registry:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: s2i-nodejs-build
@@ -254,7 +254,7 @@ Runtime-image is a new image composed with build-strategy outcome. On which you 
 The following examples illustrates how to the `runtime`:
 
 ```yml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: nodejs-ex-runtime
@@ -305,13 +305,13 @@ Under the cover, the runtime image will be an additional step in the generated T
 
 ## BuildRun deletion
 
-A `Build` can automatically delete a related `BuildRun`. To enable this feature set the  `build.build.dev/build-run-deletion` annotation to `true` in the `Build` instance. By default the annotation is never present in a `Build` definition. See an example of how to define this annotation:
+A `Build` can automatically delete a related `BuildRun`. To enable this feature set the  `build.shipwright.io/build-run-deletion` annotation to `true` in the `Build` instance. By default the annotation is never present in a `Build` definition. See an example of how to define this annotation:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: kaniko-golang-build
   annotations:
-    build.build.dev/build-run-deletion: "true"
+    build.shipwright.io/build-run-deletion: "true"
 ```

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -47,7 +47,7 @@ When the controller reconciles it:
 The `BuildRun` definition supports the following fields:
 
 - Required:
-  - [`apiVersion`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the API version, for example `build.dev/v1alpha1`.
+  - [`apiVersion`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the API version, for example `shipwright.io/v1alpha1`.
   - [`kind`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the Kind type, for example `BuildRun`.
   - [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Metadata that identify the CRD instance, for example the name of the `BuildRun`.
   - `spec.buildRef` - Specifies an existing `Build` resource instance to use.
@@ -62,7 +62,7 @@ The `BuildRun` definition supports the following fields:
 A `BuildRun` resource can reference a `Build` resource, that indicates what image to build. For example:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun-namespaced
@@ -76,7 +76,7 @@ spec:
 A `BuildRun` resource can define a serviceaccount to use. Usually this SA will host all related secrets referenced on the `Build` resource, for example:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun-namespaced

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -26,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Overview
 
-There are two types of strategies, the `ClusterBuildStrategy` (`clusterbuildstrategies.build.dev/v1alpha1`) and the `BuildStrategy` (`buildstrategies.build.dev/v1alpha1`). Both strategies define a shared group of steps, needed to fullfil the application build.
+There are two types of strategies, the `ClusterBuildStrategy` (`clusterbuildstrategies.shipwright.io/v1alpha1`) and the `BuildStrategy` (`buildstrategies.shipwright.io/v1alpha1`). Both strategies define a shared group of steps, needed to fullfil the application build.
 
 A `ClusterBuildStrategy` is available cluster-wide, while a `BuildStrategy` is available within a namespace.
 
@@ -97,7 +97,7 @@ To use this strategy follow this steps:
 - Create a `Build` resource that uses `quay.io` or `DockerHub` image repository for pushing the image. Also, provide credentials to access it.
 
   ```yaml
-  apiVersion: build.dev/v1alpha1
+  apiVersion: shipwright.io/v1alpha1
   kind: Build
   metadata:
     name: buildpack-nodejs-build
@@ -115,7 +115,7 @@ To use this strategy follow this steps:
 - Start a `BuildRun` resource.
 
   ```yaml
-  apiVersion: build.dev/v1alpha1
+  apiVersion: shipwright.io/v1alpha1
   kind: BuildRun
   metadata:
     name: buildpack-nodejs-buildrun
@@ -178,7 +178,7 @@ If the strategy admins would require to have multiple flavours of the same strat
 
 ```yaml
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: kaniko-small
@@ -222,7 +222,7 @@ spec:
           cpu: 250m
           memory: 65Mi
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: kaniko-medium
@@ -271,7 +271,7 @@ The above provides more control and flexibility for the strategy admins. For `en
 
 ```yaml
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: kaniko-medium
@@ -495,9 +495,9 @@ Annotations can be defined for a BuildStrategy/ClusterBuildStrategy as for any o
 The following annotations are not propagated:
 
 - `kubectl.kubernetes.io/last-applied-configuration`
-- `clusterbuildstrategy.build.dev/*`
-- `buildstrategy.build.dev/*`
-- `build.build.dev/*`
-- `buildrun.build.dev/*`
+- `clusterbuildstrategy.shipwright.io/*`
+- `buildstrategy.shipwright.io/*`
+- `build.shipwright.io/*`
+- `buildrun.shipwright.io/*`
 
 A Kubernetes administrator can further restrict the usage of annotations by using policy engines like [Open Policy Agent](https://www.openpolicyagent.org/).

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -25,7 +25,7 @@ There are two places where users might need to define authentication when buildi
 
 ## Build Secrets Annotation
 
-Users need to add an annotation `build.build.dev/referenced.secret: "true"` to a build secret so that build controller can decide to take a reconcile action when a secret event (`create`, `update` and `delete`) happens. Below is a secret example with build annotation:
+Users need to add an annotation `build.shipwright.io/referenced.secret: "true"` to a build secret so that build controller can decide to take a reconcile action when a secret event (`create`, `update` and `delete`) happens. Below is a secret example with build annotation:
 
 ```yaml
 apiVersion: v1
@@ -34,7 +34,7 @@ data:
 kind: Secret
 metadata:
   annotations:
-    build.build.dev/referenced.secret: "true"
+    build.shipwright.io/referenced.secret: "true"
   name: secret-docker
 type: kubernetes.io/dockerconfigjson
 ```
@@ -45,7 +45,7 @@ If you are using `kubectl` command create secrets, then you can first create bui
 
 ```sh
 kubectl -n ${namespace} create secret docker-registry example-secret --docker-server=${docker-server} --docker-username="${username}" --docker-password="${password}" --docker-email=me@here.com
-kubectl -n ${namespace} annotate secrets example-secret build.build.dev/referenced.secret='true'
+kubectl -n ${namespace} annotate secrets example-secret build.shipwright.io/referenced.secret='true'
 ```
 
 ## Authentication for Git
@@ -70,7 +70,7 @@ metadata:
   annotations:
     tekton.dev/git-0: github.com
     tekton.dev/git-1: gitlab.com
-    build.build.dev/referenced.secret: "true"
+    build.shipwright.io/referenced.secret: "true"
 type: kubernetes.io/ssh-auth
 data:
   ssh-privatekey: <base64 <~/.ssh/id_rsa>
@@ -91,7 +91,7 @@ metadata:
   annotations:
     tekton.dev/git-0: https://github.com
     tekton.dev/git-1: https://gitlab.com
-    build.build.dev/referenced.secret: "true"
+    build.shipwright.io/referenced.secret: "true"
 type: kubernetes.io/basic-auth
 stringData:
   username: <cleartext username>
@@ -107,7 +107,7 @@ Depending on the secret type, there are two ways of doing this:
 When using ssh auth, users should follow:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build
@@ -121,7 +121,7 @@ spec:
 When using basic auth, users should follow:
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build
@@ -146,7 +146,7 @@ kubectl --namespace <YOUR_NAMESPACE> create secret docker-registry <CONTAINER_RE
   --docker-username=<USERNAME> \
   --docker-password=<PASSWORD> \
   --docker-email=me@here.com
-kubectl --namespace <YOUR_NAMESPACE> annotate secrets <CONTAINER_REGISTRY_SECRET_NAME> build.build.dev/referenced.secret='true'
+kubectl --namespace <YOUR_NAMESPACE> annotate secrets <CONTAINER_REGISTRY_SECRET_NAME> build.shipwright.io/referenced.secret='true'
 ```
 
 _Notes:_ When generating a secret to access docker hub, the `REGISTRY_HOST` value should be `https://index.docker.io/v1/`, the username is the Docker ID.
@@ -158,7 +158,7 @@ With the right secret in place (_note: Ensure creation of secret in the proper K
 For container registries, the secret should be placed under the `spec.output.credentials` path.
 
 ```yaml
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build

--- a/hack/build-logs.sh
+++ b/hack/build-logs.sh
@@ -73,7 +73,7 @@ echo "Task run: ${TASK_RUN_NAME}"
 
 # Find the pod, it has labels for the build run and task run name
 
-PODS=$(kubectl get pods -l "buildrun.build.dev/name=${BUILD_RUN_NAME},tekton.dev/taskRun=${TASK_RUN_NAME}" -n "${NAMESPACE}" -o json)
+PODS=$(kubectl get pods -l "buildrun.shipwright.io/name=${BUILD_RUN_NAME},tekton.dev/taskRun=${TASK_RUN_NAME}" -n "${NAMESPACE}" -o json)
 PODS_LENGTH=$(echo "${PODS}" | jq ".items | length")
 
 if [ "${PODS_LENGTH}" -eq 0 ]; then

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -40,7 +40,7 @@ const (
 
 const (
 	// BuildDomain is the domain used for all labels and annotations for this resource
-	BuildDomain = "build.build.dev"
+	BuildDomain = "build.shipwright.io"
 
 	// LabelBuild is a label key for defining the build name
 	LabelBuild = BuildDomain + "/name"

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// BuildRunDomain is the domain used for all labels and annotations for this resource
-	BuildRunDomain = "buildrun.build.dev"
+	BuildRunDomain = "buildrun.shipwright.io"
 
 	// LabelBuildRun is a label key for BuildRuns to define the name of the BuildRun
 	LabelBuildRun = BuildRunDomain + "/name"

--- a/pkg/apis/build/v1alpha1/buildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/buildstrategy_types.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// BuildStrategyDomain is the domain used for all labels and annotations for this resource
-	BuildStrategyDomain = "buildstrategy.build.dev"
+	BuildStrategyDomain = "buildstrategy.shipwright.io"
 
 	// LabelBuildStrategyName is a label key for defining the build strategy name
 	LabelBuildStrategyName = BuildStrategyDomain + "/name"

--- a/pkg/apis/build/v1alpha1/clusterbuildstrategy_types.go
+++ b/pkg/apis/build/v1alpha1/clusterbuildstrategy_types.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// ClusterBuildStrategyDomain is the domain used for all labels and annotations for this resource
-	ClusterBuildStrategyDomain = "clusterbuildstrategy.build.dev"
+	ClusterBuildStrategyDomain = "clusterbuildstrategy.shipwright.io"
 
 	// LabelClusterBuildStrategyName is a label key for defining the cluster build strategy name
 	LabelClusterBuildStrategyName = ClusterBuildStrategyDomain + "/name"

--- a/pkg/apis/build/v1alpha1/doc.go
+++ b/pkg/apis/build/v1alpha1/doc.go
@@ -4,5 +4,5 @@
 
 // Package v1alpha1 contains API Schema definitions for the build v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=build.dev
+// +groupName=shipwright.io
 package v1alpha1

--- a/pkg/apis/build/v1alpha1/register.go
+++ b/pkg/apis/build/v1alpha1/register.go
@@ -6,7 +6,7 @@
 
 // Package v1alpha1 contains API Schema definitions for the build v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=build.dev
+// +groupName=shipwright.io
 package v1alpha1
 
 import (
@@ -16,7 +16,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "build.dev", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "shipwright.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/pkg/client/build/clientset/versioned/typed/build/v1alpha1/build_client.go
+++ b/pkg/client/build/clientset/versioned/typed/build/v1alpha1/build_client.go
@@ -20,7 +20,7 @@ type BuildV1alpha1Interface interface {
 	ClusterBuildStrategiesGetter
 }
 
-// BuildV1alpha1Client is used to interact with features provided by the build.dev group.
+// BuildV1alpha1Client is used to interact with features provided by the shipwright.io group.
 type BuildV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_build.go
+++ b/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_build.go
@@ -24,9 +24,9 @@ type FakeBuilds struct {
 	ns   string
 }
 
-var buildsResource = schema.GroupVersionResource{Group: "build.dev", Version: "v1alpha1", Resource: "builds"}
+var buildsResource = schema.GroupVersionResource{Group: "shipwright.io", Version: "v1alpha1", Resource: "builds"}
 
-var buildsKind = schema.GroupVersionKind{Group: "build.dev", Version: "v1alpha1", Kind: "Build"}
+var buildsKind = schema.GroupVersionKind{Group: "shipwright.io", Version: "v1alpha1", Kind: "Build"}
 
 // Get takes name of the build, and returns the corresponding build object, and an error if there is any.
 func (c *FakeBuilds) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Build, err error) {

--- a/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_buildrun.go
+++ b/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_buildrun.go
@@ -24,9 +24,9 @@ type FakeBuildRuns struct {
 	ns   string
 }
 
-var buildrunsResource = schema.GroupVersionResource{Group: "build.dev", Version: "v1alpha1", Resource: "buildruns"}
+var buildrunsResource = schema.GroupVersionResource{Group: "shipwright.io", Version: "v1alpha1", Resource: "buildruns"}
 
-var buildrunsKind = schema.GroupVersionKind{Group: "build.dev", Version: "v1alpha1", Kind: "BuildRun"}
+var buildrunsKind = schema.GroupVersionKind{Group: "shipwright.io", Version: "v1alpha1", Kind: "BuildRun"}
 
 // Get takes name of the buildRun, and returns the corresponding buildRun object, and an error if there is any.
 func (c *FakeBuildRuns) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.BuildRun, err error) {

--- a/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_buildstrategy.go
+++ b/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_buildstrategy.go
@@ -24,9 +24,9 @@ type FakeBuildStrategies struct {
 	ns   string
 }
 
-var buildstrategiesResource = schema.GroupVersionResource{Group: "build.dev", Version: "v1alpha1", Resource: "buildstrategies"}
+var buildstrategiesResource = schema.GroupVersionResource{Group: "shipwright.io", Version: "v1alpha1", Resource: "buildstrategies"}
 
-var buildstrategiesKind = schema.GroupVersionKind{Group: "build.dev", Version: "v1alpha1", Kind: "BuildStrategy"}
+var buildstrategiesKind = schema.GroupVersionKind{Group: "shipwright.io", Version: "v1alpha1", Kind: "BuildStrategy"}
 
 // Get takes name of the buildStrategy, and returns the corresponding buildStrategy object, and an error if there is any.
 func (c *FakeBuildStrategies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.BuildStrategy, err error) {

--- a/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_clusterbuildstrategy.go
+++ b/pkg/client/build/clientset/versioned/typed/build/v1alpha1/fake/fake_clusterbuildstrategy.go
@@ -23,9 +23,9 @@ type FakeClusterBuildStrategies struct {
 	Fake *FakeBuildV1alpha1
 }
 
-var clusterbuildstrategiesResource = schema.GroupVersionResource{Group: "build.dev", Version: "v1alpha1", Resource: "clusterbuildstrategies"}
+var clusterbuildstrategiesResource = schema.GroupVersionResource{Group: "shipwright.io", Version: "v1alpha1", Resource: "clusterbuildstrategies"}
 
-var clusterbuildstrategiesKind = schema.GroupVersionKind{Group: "build.dev", Version: "v1alpha1", Kind: "ClusterBuildStrategy"}
+var clusterbuildstrategiesKind = schema.GroupVersionKind{Group: "shipwright.io", Version: "v1alpha1", Kind: "ClusterBuildStrategy"}
 
 // Get takes name of the clusterBuildStrategy, and returns the corresponding clusterBuildStrategy object, and an error if there is any.
 func (c *FakeClusterBuildStrategies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.ClusterBuildStrategy, err error) {

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -107,7 +107,7 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 				buildRun.Labels = make(map[string]string)
 			}
 
-			// Set OwnerReference for Build and BuildRun only when build.build.dev/build-run-deletion is set "true"
+			// Set OwnerReference for Build and BuildRun only when build.shipwright.io/build-run-deletion is set "true"
 			if build.GetAnnotations()[buildv1alpha1.AnnotationBuildRunDeletion] == "true" && !resources.IsOwnedByBuild(build, buildRun.OwnerReferences) {
 				if err := r.setOwnerReferenceFunc(build, buildRun, r.scheme); err != nil {
 					build.Status.Reason = buildv1alpha1.SetOwnerReferenceFailed

--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -402,7 +402,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      taskRunName,
 						Namespace: ns,
-						Labels:    map[string]string{"buildrun.build.dev/name": buildRunName},
+						Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 					},
 					Spec: v1beta1.TaskRunSpec{},
 					Status: v1beta1.TaskRunStatus{

--- a/pkg/reconciler/buildrun/controller.go
+++ b/pkg/reconciler/buildrun/controller.go
@@ -56,7 +56,7 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 			// Ignore updates to CR status in which case metadata.Generation does not change
 			o := e.ObjectOld.(*buildv1alpha1.BuildRun)
 
-			// Avoid reconciling when for updates on the BuildRun, the build.build.dev/name
+			// Avoid reconciling when for updates on the BuildRun, the build.shipwright.io/name
 			// label is set, and when a BuildRun already have a referenced TaskRun.
 			if o.GetLabels()[buildv1alpha1.LabelBuild] == "" || o.Status.LatestTaskRunRef != nil {
 				return false

--- a/samples/build/build_buildah_cr.yaml
+++ b/samples/build/build_buildah_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build

--- a/samples/build/build_buildpacks-v3-heroku_cr.yaml
+++ b/samples/build/build_buildpacks-v3-heroku_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build-heroku

--- a/samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build-namespaced-heroku

--- a/samples/build/build_buildpacks-v3_cr.yaml
+++ b/samples/build/build_buildpacks-v3_cr.yaml
@@ -1,10 +1,10 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build
   annotations:
-    build.build.dev/build-run-deletion: "false"
+    build.shipwright.io/build-run-deletion: "false"
 spec:
   source:
     url: https://github.com/sclorg/nodejs-ex

--- a/samples/build/build_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/build/build_buildpacks-v3_namespaced_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build-namespaced

--- a/samples/build/build_kaniko_cr.yaml
+++ b/samples/build/build_kaniko_cr.yaml
@@ -1,10 +1,10 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: kaniko-golang-build
   annotations:
-    build.build.dev/build-run-deletion: "true"
+    build.shipwright.io/build-run-deletion: "true"
 spec:
   source:
     url: https://github.com/qu1queee/taxi

--- a/samples/build/build_source-to-image_cr.yaml
+++ b/samples/build/build_source-to-image_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: s2i-nodejs-build

--- a/samples/buildrun/buildrun_buildah_cr.yaml
+++ b/samples/buildrun/buildrun_buildah_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildah-golang-buildrun

--- a/samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3-heroku_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun-heroku

--- a/samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun-namespaced-heroku

--- a/samples/buildrun/buildrun_buildpacks-v3_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun

--- a/samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildrun/buildrun_buildpacks-v3_namespaced_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun-namespaced

--- a/samples/buildrun/buildrun_kaniko_cr.yaml
+++ b/samples/buildrun/buildrun_kaniko_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: kaniko-golang-buildrun

--- a/samples/buildrun/buildrun_source-to-image_cr.yaml
+++ b/samples/buildrun/buildrun_source-to-image_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: s2i-nodejs-buildrun

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: buildah

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: buildpacks-v3-heroku

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildpacks-v3-heroku

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: buildpacks-v3

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildpacks-v3

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: kaniko

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: source-to-image-redhat

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: source-to-image

--- a/test/build_samples.go
+++ b/test/build_samples.go
@@ -7,7 +7,7 @@ package test
 // MinimalBuildahBuild defines a simple
 // Build with a source and a strategy
 const MinimalBuildahBuild = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah
@@ -23,7 +23,7 @@ spec:
 // BuildahBuildWithOutput defines a simple
 // Build with a source, strategy and output
 const BuildahBuildWithOutput = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah
@@ -41,7 +41,7 @@ spec:
 // source, strategy, builder, output and
 // timeout
 const BuildpacksBuildWithBuilderAndTimeOut = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpacks-v3
@@ -66,7 +66,7 @@ spec:
 // Buildah with source, strategy, output and
 // timeout
 const BuildahBuildWithTimeOut = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah
@@ -83,7 +83,7 @@ spec:
 
 // BuildBSMinimal defines a Build with a BuildStrategy
 const BuildBSMinimal = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -97,7 +97,7 @@ spec:
 // BuildCBSMinimal defines a Build with a
 // ClusterBuildStrategy
 const BuildCBSMinimal = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -111,7 +111,7 @@ spec:
 // BuildCBSMinimalWithFakeSecret defines a Build with a
 // ClusterBuildStrategy and an not existing secret
 const BuildCBSMinimalWithFakeSecret = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -127,7 +127,7 @@ spec:
 // BuildWithOutputRefSecret defines a Build with a
 // referenced secret under spec.output
 const BuildWithOutputRefSecret = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -144,7 +144,7 @@ spec:
 // BuildWithSourceRefSecret defines a Build with a
 // referenced secret under spec.source
 const BuildWithSourceRefSecret = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -161,7 +161,7 @@ spec:
 // BuildWithBuilderRefSecret defines a Build with a
 // referenced secret under spec.builder
 const BuildWithBuilderRefSecret = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -180,7 +180,7 @@ spec:
 // BuildWithMultipleRefSecrets defines a Build with
 // multiple referenced secrets under spec
 const BuildWithMultipleRefSecrets = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -201,7 +201,7 @@ spec:
 // BuildCBSWithShortTimeOut defines a Build with a
 // ClusterBuildStrategy and a short timeout
 const BuildCBSWithShortTimeOut = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -216,7 +216,7 @@ spec:
 // BuildCBSWithWrongURL defines a Build with a
 // ClusterBuildStrategy and a non-existing url
 const BuildCBSWithWrongURL = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   source:
@@ -230,11 +230,11 @@ spec:
 // BuildCBSWithVerifyRepositoryAnnotation defines a Build
 // with the verify repository annotation key
 const BuildCBSWithVerifyRepositoryAnnotation = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   annotations:
-    build.build.dev/verify.repository: ""
+    build.shipwright.io/verify.repository: ""
 spec:
   strategy:
     kind: ClusterBuildStrategy
@@ -245,7 +245,7 @@ spec:
 // BuildCBSWithoutVerifyRepositoryAnnotation defines a minimal
 // Build without source url and annotation
 const BuildCBSWithoutVerifyRepositoryAnnotation = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 spec:
   strategy:
@@ -258,11 +258,11 @@ spec:
 // ClusterBuildStrategy and the annotation for automatic BuildRun
 // deletion
 const BuildCBSWithBuildRunDeletion = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   annotations:
-    build.build.dev/build-run-deletion: "true"
+    build.shipwright.io/build-run-deletion: "true"
 spec:
   source:
     url: "https://github.com/qu1queee/taxi"

--- a/test/buildrun_samples.go
+++ b/test/buildrun_samples.go
@@ -7,7 +7,7 @@ package test
 // MinimalBuildahBuildRun defines a simple
 // BuildRun with a referenced Build
 const MinimalBuildahBuildRun = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildah-run
@@ -19,7 +19,7 @@ spec:
 // BuildahBuildRunWithSA defines a BuildRun
 // with a service-account
 const BuildahBuildRunWithSA = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildah-run
@@ -34,7 +34,7 @@ spec:
 // BuildahBuildRunWithSAAndOutput defines a BuildRun
 // with a service-account and output overrides
 const BuildahBuildRunWithSAAndOutput = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildah-run
@@ -51,7 +51,7 @@ spec:
 // BuildpacksBuildRunWithSA defines a BuildRun
 // with a service-account
 const BuildpacksBuildRunWithSA = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpacks-v3-run
@@ -67,7 +67,7 @@ spec:
 // BuildahBuildRunWithTimeOutAndSA defines a BuildRun
 // with a service-account and timeout
 const BuildahBuildRunWithTimeOutAndSA = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildah-run
@@ -83,7 +83,7 @@ spec:
 // MinimalBuildRun defines a minimal BuildRun
 // with a reference to a not existing Build
 const MinimalBuildRun = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 spec:
   buildRef:
@@ -93,7 +93,7 @@ spec:
 // MinimalBuildRunWithSpecifiedServiceAccount defines a minimal BuildRun
 // with a reference to a not existing serviceAccount
 const MinimalBuildRunWithSpecifiedServiceAccount = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 spec:
   buildRef:
@@ -105,7 +105,7 @@ spec:
 // MinimalBuildRunWithSAGeneration defines a minimal BuildRun
 // with a reference to a not existing Build
 const MinimalBuildRunWithSAGeneration = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 spec:
   serviceAccount:
@@ -117,7 +117,7 @@ spec:
 // MinimalBuildRunWithTimeOut defines a BuildRun with
 // an override for the Build Timeout
 const MinimalBuildRunWithTimeOut = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 spec:
   timeout: 1s
@@ -128,7 +128,7 @@ spec:
 // MinimalBuildRunWithOutput defines a BuildRun with
 // an override for the Build Output
 const MinimalBuildRunWithOutput = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 spec:
   output:

--- a/test/buildstrategy_samples.go
+++ b/test/buildstrategy_samples.go
@@ -8,7 +8,7 @@ package test
 // BuildStrategy for Buildah with two steps
 // each of them with different container resources
 const MinimalBuildahBuildStrategy = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildah
@@ -62,12 +62,12 @@ spec:
 // BuildStrategy for Buildah with a single step
 // and container resources
 const BuildahBuildStrategySingleStep = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   annotations:
     kubernetes.io/ingress-bandwidth: 1M
-    clusterbuildstrategy.build.dev/dummy: aValue
+    clusterbuildstrategy.shipwright.io/dummy: aValue
     kubectl.kubernetes.io/last-applied-configuration: anotherValue
     kubernetes.io/egress-bandwidth: 1M
   name: buildah
@@ -102,7 +102,7 @@ spec:
 // BuildStrategy for Buildpacks with a single step
 // and container resources
 const BuildpacksBuildStrategySingleStep = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildpacks-v3

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -511,7 +511,7 @@ func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, n
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
-			Labels:    map[string]string{"buildrun.build.dev/name": buildRunName},
+			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
 		Spec: v1beta1.TaskRunSpec{},
 		Status: v1beta1.TaskRunStatus{
@@ -540,7 +540,7 @@ func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
-			Labels:    map[string]string{"buildrun.build.dev/name": buildRunName},
+			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
 		Spec: v1beta1.TaskRunSpec{},
 		Status: v1beta1.TaskRunStatus{
@@ -573,7 +573,7 @@ func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName stri
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
-			Labels:    map[string]string{"buildrun.build.dev/name": buildRunName},
+			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
 		Spec: v1beta1.TaskRunSpec{},
 		Status: v1beta1.TaskRunStatus{
@@ -615,7 +615,7 @@ func (c *Catalog) DefaultBuild(buildName string, strategyName string, strategyKi
 }
 
 // BuildWithBuildRunDeletions returns a minimal Build object with the
-// build.build.dev/build-run-deletion annotation set to true
+// build.shipwright.io/build-run-deletion annotation set to true
 func (c *Catalog) BuildWithBuildRunDeletions(buildName string, strategyName string, strategyKind build.BuildStrategyKind) *build.Build {
 	return &build.Build{
 		ObjectMeta: metav1.ObjectMeta{
@@ -635,7 +635,7 @@ func (c *Catalog) BuildWithBuildRunDeletions(buildName string, strategyName stri
 }
 
 // BuildWithBuildRunDeletionsAndFakeNS returns a minimal Build object with the
-// build.build.dev/build-run-deletion annotation set to true in a fake namespace
+// build.shipwright.io/build-run-deletion annotation set to true in a fake namespace
 func (c *Catalog) BuildWithBuildRunDeletionsAndFakeNS(buildName string, strategyName string, strategyKind build.BuildStrategyKind) *build.Build {
 	return &build.Build{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -8,7 +8,7 @@ package test
 // BuildStrategy for Buildah with two steps
 // each of them with different container resources
 const MinimalBuildahClusterBuildStrategy = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildStrategy
 metadata:
   name: buildah
@@ -62,7 +62,7 @@ spec:
 // BuildStrategy for Buildah with a single step
 // and container resources
 const ClusterBuildStrategySingleStep = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: buildah
@@ -116,7 +116,7 @@ spec:
 // Kaniko, which is very close to the actual Kaniko build strategy example in
 // the project
 const ClusterBuildStrategySingleStepKaniko = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: kaniko
@@ -165,7 +165,7 @@ spec:
 // strategy that has a configuration error (misspelled command flag) so that
 // it will fail in Tekton
 const ClusterBuildStrategySingleStepKanikoError = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: kaniko
@@ -212,7 +212,7 @@ spec:
 
 // ClusterBuildStrategyNoOp is a strategy that does nothing and has no dependencies
 const ClusterBuildStrategyNoOp = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: noop
@@ -274,12 +274,12 @@ spec:
 
 // ClusterBuildStrategyWithAnnotations is a cluster build strategy that contains annotations
 const ClusterBuildStrategyWithAnnotations = `
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   annotations:
     kubernetes.io/ingress-bandwidth: 1M
-    clusterbuildstrategy.build.dev/dummy: aValue
+    clusterbuildstrategy.shipwright.io/dummy: aValue
     kubectl.kubernetes.io/last-applied-configuration: anotherValue
   name: kaniko
 spec:

--- a/test/data/build_buildah_cr_custom_context+dockerfile.yaml
+++ b/test/data/build_buildah_cr_custom_context+dockerfile.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-custom-context-dockerfile

--- a/test/data/build_buildah_cr_private_github.yaml
+++ b/test/data/build_buildah_cr_private_github.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build

--- a/test/data/build_buildah_cr_private_gitlab.yaml
+++ b/test/data/build_buildah_cr_private_gitlab.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildah-golang-build

--- a/test/data/build_buildpacks-v3-heroku_cr_private_github.yaml
+++ b/test/data/build_buildpacks-v3-heroku_cr_private_github.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build-heroku

--- a/test/data/build_buildpacks-v3_cr_private_github.yaml
+++ b/test/data/build_buildpacks-v3_cr_private_github.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-build

--- a/test/data/build_buildpacks-v3_golang_cr.yaml
+++ b/test/data/build_buildpacks-v3_golang_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-golang-build

--- a/test/data/build_buildpacks-v3_java_cr.yaml
+++ b/test/data/build_buildpacks-v3_java_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-java-build

--- a/test/data/build_buildpacks-v3_nodejs_runtime-image_cr.yaml
+++ b/test/data/build_buildpacks-v3_nodejs_runtime-image_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-nodejs-ex-runtime-image

--- a/test/data/build_buildpacks-v3_php_cr.yaml
+++ b/test/data/build_buildpacks-v3_php_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-php-build

--- a/test/data/build_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/build_buildpacks-v3_ruby_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: buildpack-ruby-build

--- a/test/data/build_kaniko_cr_advanced_dockerfile.yaml
+++ b/test/data/build_kaniko_cr_advanced_dockerfile.yaml
@@ -1,10 +1,10 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: kaniko-advanced-dockerfile
   annotations:
-    build.build.dev/build-run-deletion: "false"
+    build.shipwright.io/build-run-deletion: "false"
 spec:
   source:
     url: https://github.com/SaschaSchwarze0/java-simple

--- a/test/data/build_kaniko_cr_custom_context+dockerfile.yaml
+++ b/test/data/build_kaniko_cr_custom_context+dockerfile.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: kaniko-custom-context-dockerfile

--- a/test/data/build_kaniko_cr_private_github.yaml
+++ b/test/data/build_kaniko_cr_private_github.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: kaniko-golang-build

--- a/test/data/build_kaniko_cr_private_gitlab.yaml
+++ b/test/data/build_kaniko_cr_private_gitlab.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: kaniko-golang-build

--- a/test/data/build_source-to-image_cr_private_github.yaml
+++ b/test/data/build_source-to-image_cr_private_github.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: s2i-nodejs-build

--- a/test/data/build_timeout.yaml
+++ b/test/data/build_timeout.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: build-timeout

--- a/test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml
+++ b/test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildah-custom-context-dockerfile

--- a/test/data/buildrun_buildpacks-v3_golang_cr.yaml
+++ b/test/data/buildrun_buildpacks-v3_golang_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-golang-buildrun

--- a/test/data/buildrun_buildpacks-v3_java_cr.yaml
+++ b/test/data/buildrun_buildpacks-v3_java_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-java-buildrun

--- a/test/data/buildrun_buildpacks-v3_nodejs_runtime-image_cr.yaml
+++ b/test/data/buildrun_buildpacks-v3_nodejs_runtime-image_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-nodejs-buildrun-heroku

--- a/test/data/buildrun_buildpacks-v3_php_cr.yaml
+++ b/test/data/buildrun_buildpacks-v3_php_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-php-buildrun

--- a/test/data/buildrun_buildpacks-v3_ruby_cr.yaml
+++ b/test/data/buildrun_buildpacks-v3_ruby_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildpack-ruby-buildrun

--- a/test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml
+++ b/test/data/buildrun_kaniko_cr_advanced_dockerfile.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: kaniko-advanced-dockerfile

--- a/test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml
+++ b/test/data/buildrun_kaniko_cr_custom_context+dockerfile.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: kaniko-custom-context-dockerfile

--- a/test/data/buildrun_timeout.yaml
+++ b/test/data/buildrun_timeout.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: buildrun-timeout

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 			br, err := tb.GetBR(buildRunObject.Name)
 			Expect(err).To(BeNil())
-			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("Build.build.dev \"%s\" not found", BUILD+tb.Namespace)))
+			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("Build.shipwright.io \"%s\" not found", BUILD+tb.Namespace)))
 			Expect(br.Status.StartTime).To(BeNil())
 			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
 			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("Failed"))
@@ -293,7 +293,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 			Expect(br.Status.CompletionTime).ToNot(BeNil())
 			Expect(br.Status.StartTime).To(BeNil())
-			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("Build.build.dev \"%s\" not found", BUILD+tb.Namespace+"foobar")))
+			Expect(br.Status.Reason).To(Equal(fmt.Sprintf("Build.shipwright.io \"%s\" not found", BUILD+tb.Namespace+"foobar")))
 			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
 			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Reason).To(Equal("Failed"))
 			Expect(br.Status.GetCondition(v1alpha1.Succeeded).Message).To(ContainSubstring("not found"))

--- a/test/integration/build_to_git_test.go
+++ b/test/integration/build_to_git_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "true"
 			buildObject.Spec.Source.URL = "http://github.com/qu1queee/taxi"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
@@ -95,7 +95,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "true"
 			buildObject.Spec.Source.URL = "https://github.com/qu1queee/taxi"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
@@ -145,7 +145,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "true"
 			buildObject.Spec.Source.URL = "foobar"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
@@ -172,7 +172,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "false"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "false"
 			buildObject.Spec.Source.URL = "foobar"
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
@@ -198,7 +198,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "true"
 			buildObject.Spec.Source.URL = "https://github.yourco.com/org/build-fake"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
@@ -224,7 +224,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "true"
 			buildObject.Spec.Source.URL = "https://github.yourco.com/org/build-fake"
 			buildObject.Spec.Source.SecretRef = &corev1.LocalObjectReference{Name: "foobar"}
 
@@ -256,7 +256,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "true"
 			buildObject.Spec.Source.URL = "git@github.com:shipwright-io/build-fake.git"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
@@ -284,7 +284,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			)
 			Expect(err).To(BeNil())
 
-			buildObject.ObjectMeta.Annotations["build.build.dev/verify.repository"] = "true"
+			buildObject.ObjectMeta.Annotations["build.shipwright.io/verify.repository"] = "true"
 			buildObject.Spec.Source.URL = "ssh://github.com/shipwright-io/build-fake.git"
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())

--- a/test/integration/buildstrategy_to_taskruns_test.go
+++ b/test/integration/buildstrategy_to_taskruns_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Integration tests BuildStrategies and TaskRuns", func() {
 
 			Expect(taskRun.Annotations["kubernetes.io/egress-bandwidth"]).To(Equal("1M"))
 			Expect(taskRun.Annotations["kubernetes.io/ingress-bandwidth"]).To(Equal("1M"))
-			_, containsKey := taskRun.Annotations["clusterbuildstrategy.build.dev/dummy"]
+			_, containsKey := taskRun.Annotations["clusterbuildstrategy.shipwright.io/dummy"]
 			Expect(containsKey).To(BeFalse())
 			_, containsKey = taskRun.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 			Expect(containsKey).To(BeFalse())

--- a/test/integration/clusterbuildstrategy_to_taskruns_test.go
+++ b/test/integration/clusterbuildstrategy_to_taskruns_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Integration tests ClusterBuildStrategies and TaskRuns", func()
 			Expect(err).To(BeNil())
 
 			Expect(taskRun.Annotations["kubernetes.io/ingress-bandwidth"]).To(Equal("1M"))
-			_, containsKey := taskRun.Annotations["clusterbuildstrategy.build.dev/dummy"]
+			_, containsKey := taskRun.Annotations["clusterbuildstrategy.shipwright.io/dummy"]
 			Expect(containsKey).To(BeFalse())
 			_, containsKey = taskRun.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 			Expect(containsKey).To(BeFalse())

--- a/test/integration/utils/taskruns.go
+++ b/test/integration/utils/taskruns.go
@@ -20,7 +20,7 @@ import (
 
 // GetTaskRunFromBuildRun retrieves an owned TaskRun based on the BuildRunName
 func (t *TestBuild) GetTaskRunFromBuildRun(buildRunName string) (*v1beta1.TaskRun, error) {
-	taskRunLabelSelector := fmt.Sprintf("buildrun.build.dev/name=%s", buildRunName)
+	taskRunLabelSelector := fmt.Sprintf("buildrun.shipwright.io/name=%s", buildRunName)
 
 	trInterface := t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace)
 


### PR DESCRIPTION
# Changes

This renames references to the `build.dev` API group, replacing them with `shipwright.io`. This change updates code and docs, but doesn't modify anything in `docs/proposals/`.

This constitutes a breaking change for existing users, who will need to modify their Builds/BuildStrategies/BuildRuns to use the new API group. No other changes are expected to be needed. When upgrading, users should delete the old CRD types before installing the new ones, to avoid confusion (`kubectl delete -f deploy/crds/`).

Fixes #563 

# Submitter Checklist

- [y] Includes tests if functionality changed/was added
- [y] Includes docs if changes are user-facing
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
BREAKING: Rename API group from build.dev to shipwright.io
```