### PR TITLE
Use GitHub action for e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
           matrix:
             go-version: [1.15.x]
             os: [ubuntu-latest]
+            kubernetes:
+              - v1.17.17
+              - v1.18.15
+              - v1.19.7
+              - v1.20.2
         runs-on: ${{ matrix.os }}
         steps:
         - name: Install Go
@@ -38,12 +43,12 @@ jobs:
         - name: Install kubectl
           uses: azure/setup-kubectl@v1
           with:
-            version: v1.18.2
+            version: ${{ matrix.kubernetes }}
         - name: Create kind cluster
           uses: helm/kind-action@v1.1.0
           with:
-            version: v0.8.0
-            node_image: kindest/node:v1.18.2
+            version: v0.10.0
+            node_image: kindest/node:${{ matrix.kubernetes }}
             cluster_name: kind
             wait: 120s
         - name: Verify kind cluster
@@ -57,3 +62,60 @@ jobs:
             make kind-tekton
         - name: Test
           run: make test-integration
+    e2e:
+        strategy:
+          matrix:
+            go-version: [1.15.x]
+            os: [ubuntu-latest]
+            kubernetes:
+              - v1.17.17
+              - v1.18.15
+              - v1.19.7
+              - v1.20.2
+        runs-on: ${{ matrix.os }}
+        steps:
+        - name: Install Go
+          uses: actions/setup-go@v2
+          with:
+            go-version: ${{ matrix.go-version }}
+        - name: Check out code
+          uses: actions/checkout@v2
+        - name: Install kubectl
+          uses: azure/setup-kubectl@v1
+          with:
+            version: ${{ matrix.kubernetes }}
+        - name: Create kind cluster
+          uses: helm/kind-action@v1.1.0
+          with:
+            version: v0.10.0
+            node_image: kindest/node:${{ matrix.kubernetes }}
+            cluster_name: kind
+            wait: 120s
+        - name: Verify kind cluster
+          run: |
+            echo "# Using KinD context..."
+            kubectl config use-context "kind-kind"
+            echo "# KinD nodes:"
+            kubectl get nodes
+        - name: Install Tekton
+          run: |
+            make kind-tekton
+            kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-controller --timeout=1m
+            kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-webhook --timeout=1m
+        - name: Install Registry
+          run: |
+            kubectl apply -f test/data/registry.yaml
+            kubectl -n registry rollout status deployment registry --timeout=1m
+        - name: Install ko
+          run: curl -fsL https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
+        - name: Install Shipwright Build
+          run: |
+            make install-operator-kind
+            kubectl -n build-operator rollout status deployment build-operator --timeout=1m || true
+        - name: Test
+          run: TEST_E2E_OPERATOR=managed_outside TEST_NAMESPACE=build-operator TEST_IMAGE_REPO=registry.registry.svc.cluster.local:32222/shipwright-io/build-e2e make test-e2e
+        - name: Build operator logs
+          if: ${{ failure() }}
+          run: |
+            POD_NAME=$(kubectl -n build-operator get pod -o json | jq -r '.items[0].metadata.name')
+            kubectl -n build-operator logs "${POD_NAME}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,10 @@ go:
 services:
   - docker
 install:
-  - make travis
   - |
     # Install ko
-    curl -L https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | tar xzf - ko
-    chmod +x ./ko
-    sudo mv ko /usr/local/bin
+    curl -fsL https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
 
-script:
-  - set -e
-  - make
-  - make test-e2e TEST_IMAGE_REPO="$(./hack/install-registry.sh show):5000/shipwright-io/build-e2e"
-  - set +e
 deploy:
   - provider: script
     script: make release TAG=latest

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,9 @@ install-apis:
 install-operator: install-apis
 	KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE)" GOFLAGS="$(GO_FLAGS)" ko apply --bare -f deploy/
 
+install-operator-kind: install-apis
+	KO_DOCKER_REPO=kind.local GOFLAGS="$(GO_FLAGS)" ko apply -f deploy/
+
 install-strategies: install-apis
 	kubectl apply -R -f samples/buildstrategy/
 
@@ -276,7 +279,3 @@ kind-tekton:
 kind:
 	./hack/install-kind.sh
 	./hack/install-registry.sh
-
-travis: install-counterfeiter ginkgo gocov kubectl kind
-	./hack/install-tekton.sh
-	./hack/install-operator-sdk.sh

--- a/hack/install-tekton.sh
+++ b/hack/install-tekton.sh
@@ -15,8 +15,6 @@ TEKTON_VERSION="${TEKTON_VERSION:-v0.20.1}"
 TEKTON_HOST="github.com"
 TEKTON_HOST_PATH="tektoncd/pipeline/releases/download"
 
-echo "# Deploying Tekton Pipelines Operator '${TEKTON_VERSION}'"
+echo "# Deploying Tekton Pipelines '${TEKTON_VERSION}'"
 
-kubectl apply \
-    --filename="https://${TEKTON_HOST}/${TEKTON_HOST_PATH}/${TEKTON_VERSION}/release.yaml" \
-    --output="yaml"
+kubectl apply -f "https://${TEKTON_HOST}/${TEKTON_HOST_PATH}/${TEKTON_VERSION}/release.yaml"

--- a/test/data/registry.yaml
+++ b/test/data/registry.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: registry
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+        - image: registry:2
+          name: registry
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128M
+            limits:
+              cpu: 100m
+              memory: 128M
+ 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: registry
+  name: registry
+  namespace: registry
+spec:
+  ports:
+  - port: 32222
+    nodePort: 32222
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: registry
+  type: NodePort


### PR DESCRIPTION
# Changes

Changing the e2e tests to run as a GitHub action instead of in Travis. I am also changing both the integration as well as e2e test to run with Kubernetes 1.17, 1.18, 1.19 and 1.20.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
