### PR TITLE
Improve test stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,17 @@ jobs:
           run: make test-unit-coverage
     integration:
         strategy:
+          fail-fast: false
           matrix:
             go-version: [1.15.x]
             os: [ubuntu-latest]
             kubernetes:
-              - v1.17.17
+              # Only v1.18 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
+              #- v1.17.17
               - v1.18.15
-              - v1.19.7
-              - v1.20.2
+              #- v1.19.7
+              #- v1.20.2
+          max-parallel: 1
         runs-on: ${{ matrix.os }}
         steps:
         - name: Install Go
@@ -64,14 +67,17 @@ jobs:
           run: make test-integration
     e2e:
         strategy:
+          fail-fast: false
           matrix:
             go-version: [1.15.x]
             os: [ubuntu-latest]
             kubernetes:
-              - v1.17.17
+              # Only v1.18 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
+              #- v1.17.17
               - v1.18.15
-              - v1.19.7
-              - v1.20.2
+              #- v1.19.7
+              #- v1.20.2
+          max-parallel: 2
         runs-on: ${{ matrix.os }}
         steps:
         - name: Install Go
@@ -107,7 +113,7 @@ jobs:
             kubectl apply -f test/data/registry.yaml
             kubectl -n registry rollout status deployment registry --timeout=1m
         - name: Install ko
-          run: curl -fsL https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
+          run: curl -fsL https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
         - name: Install Shipwright Build
           run: |
             make install-operator-kind
@@ -117,5 +123,14 @@ jobs:
         - name: Build operator logs
           if: ${{ failure() }}
           run: |
-            POD_NAME=$(kubectl -n build-operator get pod -o json | jq -r '.items[0].metadata.name')
+            echo "# Pods:"
+            kubectl -n build-operator get pod
+            PODS=$(kubectl -n build-operator get pod -o json)
+            POD_NAME=$(echo "${PODS}" | jq -r '.items[] | select(.metadata.name | startswith("build-operator-")) | .metadata.name')
+            RESTART_COUNT=$(echo "${PODS}" | jq -r ".items[] | select(.metadata.name == \"${POD_NAME}\") | .status.containerStatuses[0].restartCount")
+            if [ "${RESTART_COUNT}" != "0" ]; then
+              echo "# Previous logs:"
+              kubectl -n build-operator logs "${POD_NAME}" --previous
+            fi
+            echo "# Logs:"
             kubectl -n build-operator logs "${POD_NAME}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 install:
   - |
     # Install ko
-    curl -fsL https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
+    curl -fsL https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
 
 deploy:
   - provider: script

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -247,6 +247,29 @@ spec:
         memory: 128Mi
 `
 
+// ClusterBuildStrategySleep30s is a strategy that does only sleep 30 seconds
+const ClusterBuildStrategySleep30s = `
+apiVersion: build.dev/v1alpha1
+kind: ClusterBuildStrategy
+metadata:
+  name: noop
+spec:
+  buildSteps:
+  - name: sleep30
+    image: alpine:latest
+    command:
+    - sleep
+    args:
+    - "30s"
+    resources:
+      limits:
+        cpu: 250m
+        memory: 128Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+`
+
 // ClusterBuildStrategyWithAnnotations is a cluster build strategy that contains annotations
 const ClusterBuildStrategyWithAnnotations = `
 apiVersion: build.dev/v1alpha1

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -82,6 +82,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
@@ -104,6 +107,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
@@ -117,6 +123,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 		It("should be able to override the build output", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			buildRun, err := tb.Catalog.LoadBRWithNameAndRef(
 				BUILDRUN+tb.Namespace,
@@ -149,6 +158,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			// Wait for BR to get an Starttime
@@ -175,6 +187,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 
 			Expect(tb.CreateBuild(build)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
@@ -237,6 +252,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
@@ -258,6 +276,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 		It("fails the buildrun with a not found Reason", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			buildRun, err := tb.Catalog.LoadBRWithNameAndRef(
 				BUILDRUN+tb.Namespace,
@@ -287,6 +308,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 		It("creates one tr per buildrun with the original build data", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			buildRun01, err := tb.Catalog.LoadBRWithNameAndRef(
 				BUILDRUN+tb.Namespace+"01",
@@ -340,6 +364,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			autoDeleteBuildRun, err := tb.Catalog.LoadBRWithNameAndRef(
 				BUILDRUN+tb.Namespace,
 				BUILD+tb.Namespace,
@@ -352,7 +379,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			_, err = tb.GetBRTillStartTime(autoDeleteBuildRun.Name)
 			Expect(err).To(BeNil())
 
-			br, err := tb.GetBR(BUILDRUN + tb.Namespace)
+			br, err := tb.GetBRTillOwner(BUILDRUN+tb.Namespace, buildObject.Name)
 			Expect(err).To(BeNil())
 			Expect(ownerReferenceNames(br.OwnerReferences)).Should(ContainElement(buildObject.Name))
 
@@ -368,6 +395,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 		It("does not deletes the buildrun if the annotation is changed", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			autoDeleteBuildRun, err := tb.Catalog.LoadBRWithNameAndRef(
 				BUILDRUN+tb.Namespace,
@@ -389,7 +419,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			err = tb.DeleteBuild(BUILD + tb.Namespace)
 			Expect(err).To(BeNil())
 
-			br, err := tb.GetBR(BUILDRUN + tb.Namespace)
+			br, err := tb.GetBRTillNotOwner(BUILDRUN+tb.Namespace, buildObject.Name)
 			Expect(err).To(BeNil())
 			Expect(ownerReferenceNames(br.OwnerReferences)).ShouldNot(ContainElement(buildObject.Name))
 
@@ -397,6 +427,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 		It("does not deletes the buildrun if the annotation is removed", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			autoDeleteBuildRun, err := tb.Catalog.LoadBRWithNameAndRef(
 				BUILDRUN+tb.Namespace,
@@ -418,7 +451,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			err = tb.DeleteBuild(BUILD + tb.Namespace)
 			Expect(err).To(BeNil())
 
-			br, err := tb.GetBR(BUILDRUN + tb.Namespace)
+			br, err := tb.GetBRTillNotOwner(BUILDRUN+tb.Namespace, buildObject.Name)
 			Expect(err).To(BeNil())
 			Expect(ownerReferenceNames(br.OwnerReferences)).ShouldNot(ContainElement(buildObject.Name))
 
@@ -426,6 +459,9 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 		It("does delete the buildrun after several modifications of the annotation", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			autoDeleteBuildRun, err := tb.Catalog.LoadBRWithNameAndRef(
 				BUILDRUN+tb.Namespace,
@@ -457,7 +493,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 			Expect(patchedBuild.Annotations[v1alpha1.AnnotationBuildRunDeletion]).To(Equal("true"))
 
-			br, err := tb.GetBR(BUILDRUN + tb.Namespace)
+			br, err := tb.GetBRTillOwner(BUILDRUN+tb.Namespace, buildObject.Name)
 			Expect(err).To(BeNil())
 			Expect(ownerReferenceNames(br.OwnerReferences)).Should(ContainElement(buildObject.Name))
 

--- a/test/integration/buildruns_to_sa_test.go
+++ b/test/integration/buildruns_to_sa_test.go
@@ -6,6 +6,7 @@ package integration_test
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -71,6 +72,9 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			_, err = tb.GetBRTillStartTime(buildRunObject.Name)
@@ -99,6 +103,9 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			_, err = tb.GetBRTillStartTime(buildRunObject.Name)
@@ -115,6 +122,9 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 				expectedServiceAccount = "pipeline"
 			}
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
@@ -137,6 +147,9 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 		It("it fails and updates buildrun conditions if the specified serviceaccount doesn't exist", func() {
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
@@ -149,4 +162,3 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 		})
 	})
 })
-

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -28,6 +28,40 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 		buildRunSample []byte
 	)
 
+	var setupBuildAndBuildRun = func(buildDef []byte, buildRunDef []byte, strategy ...string) (watch.Interface, *v1alpha1.Build, *v1alpha1.BuildRun) {
+
+		var strategyName = STRATEGY + tb.Namespace
+		if len(strategy) > 0 {
+			strategyName = strategy[0]
+		}
+
+		buildRunWitcher, err := tb.BuildClientSet.BuildV1alpha1().BuildRuns(tb.Namespace).Watch(context.TODO(), metav1.ListOptions{})
+		Expect(err).To(BeNil())
+
+		buildObject, err = tb.Catalog.LoadBuildWithNameAndStrategy(BUILD+tb.Namespace, strategyName, buildDef)
+		Expect(err).To(BeNil())
+		Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+		buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+		Expect(err).To(BeNil())
+
+		buildRunObject, err = tb.Catalog.LoadBRWithNameAndRef(BUILDRUN+tb.Namespace, BUILD+tb.Namespace, buildRunDef)
+		Expect(err).To(BeNil())
+		Expect(tb.CreateBR(buildRunObject)).To(BeNil())
+
+		//TODO: consider how to deal with buildObject or buildRunObject
+		return buildRunWitcher, buildObject, buildRunObject
+	}
+
+	var WithCustomClusterBuildStrategy = func(data []byte, f func()) {
+		customClusterBuildStrategy, err := tb.Catalog.LoadCBSWithName(STRATEGY+tb.Namespace+"custom", data)
+		Expect(err).To(BeNil())
+
+		Expect(tb.CreateClusterBuildStrategy(customClusterBuildStrategy)).To(BeNil())
+		f()
+		Expect(tb.DeleteClusterBuildStrategy(customClusterBuildStrategy.Name)).To(BeNil())
+	}
+
 	// Load the ClusterBuildStrategies before each test case
 	BeforeEach(func() {
 		cbsObject, err = tb.Catalog.LoadCBSWithName(STRATEGY+tb.Namespace, []byte(test.ClusterBuildStrategySingleStepKaniko))
@@ -64,37 +98,6 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 	})
 
 	Context("when buildrun uses conditions", func() {
-		var setupBuildAndBuildRun = func(buildDef []byte, buildRunDef []byte, strategy ...string) (watch.Interface, *v1alpha1.Build, *v1alpha1.BuildRun) {
-
-			var strategyName = STRATEGY + tb.Namespace
-			if len(strategy) > 0 {
-				strategyName = strategy[0]
-			}
-
-			buildRunWitcher, err := tb.BuildClientSet.BuildV1alpha1().BuildRuns(tb.Namespace).Watch(context.TODO(), metav1.ListOptions{})
-			Expect(err).To(BeNil())
-
-			buildObject, err = tb.Catalog.LoadBuildWithNameAndStrategy(BUILD+tb.Namespace, strategyName, buildDef)
-			Expect(err).To(BeNil())
-			Expect(tb.CreateBuild(buildObject)).To(BeNil())
-
-			buildRunObject, err = tb.Catalog.LoadBRWithNameAndRef(BUILDRUN+tb.Namespace, BUILD+tb.Namespace, buildRunDef)
-			Expect(err).To(BeNil())
-			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
-
-			//TODO: consider how to deal with buildObject or buildRunObject
-			return buildRunWitcher, buildObject, buildRunObject
-		}
-
-		var WithCustomClusterBuildStrategy = func(data []byte, f func()) {
-			customClusterBuildStrategy, err := tb.Catalog.LoadCBSWithName(STRATEGY+tb.Namespace+"custom", data)
-			Expect(err).To(BeNil())
-
-			Expect(tb.CreateClusterBuildStrategy(customClusterBuildStrategy)).To(BeNil())
-			f()
-			Expect(tb.DeleteClusterBuildStrategy(customClusterBuildStrategy.Name)).To(BeNil())
-		}
-
 		Context("when condition status unknown", func() {
 			It("reflects a change from pending to running reason", func() {
 				buildRunWitcher, _, _ := setupBuildAndBuildRun([]byte(test.BuildCBSMinimal), []byte(test.MinimalBuildRun))
@@ -251,36 +254,35 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 	})
 
 	Context("when a buildrun is created", func() {
-
-		BeforeEach(func() {
-			buildSample = []byte(test.BuildCBSMinimal)
-			buildRunSample = []byte(test.MinimalBuildRun)
-		})
-
 		It("should reflect a Pending and Running reason", func() {
+			// use a custom strategy here that just sleeps 30 seconds to prevent it from completing too fast so that we do not get the Running state
+			WithCustomClusterBuildStrategy([]byte(test.ClusterBuildStrategySleep30s), func() {
+				_, _, buildRunObject := setupBuildAndBuildRun([]byte(test.BuildCBSMinimal), []byte(test.MinimalBuildRun), STRATEGY+tb.Namespace+"custom")
 
-			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+				_, err = tb.GetBRTillStartTime(buildRunObject.Name)
+				Expect(err).To(BeNil())
 
-			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
+				// Pending is an intermediate state where a certain amount of luck is needed to capture it with a polling interval of 3s.
+				// Also, if the build-operator is not reconciling on this TaskRun status quick enough, a BuildRun might never be in Pending
+				// but rather directly go to Running.
+				/*
+					expectedReason := "Pending"
+					actualReason, err := tb.GetTRTillDesiredReason(buildRunObject.Name, expectedReason)
+					Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
 
-			_, err = tb.GetBRTillStartTime(buildRunObject.Name)
-			Expect(err).To(BeNil())
+					expectedReason = "Pending"
+					actualReason, err = tb.GetBRTillDesiredReason(buildRunObject.Name, expectedReason)
+					Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
+				*/
 
-			expectedReason := "Pending"
-			actualReason, err := tb.GetTRTillDesiredReason(buildRunObject.Name, expectedReason)
-			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
+				expectedReason := "Running"
+				actualReason, err := tb.GetTRTillDesiredReason(buildRunObject.Name, expectedReason)
+				Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
 
-			expectedReason = "Pending"
-			actualReason, err = tb.GetBRTillDesiredReason(buildRunObject.Name, expectedReason)
-			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
-
-			expectedReason = "Running"
-			actualReason, err = tb.GetTRTillDesiredReason(buildRunObject.Name, expectedReason)
-			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
-
-			expectedReason = "Running"
-			actualReason, err = tb.GetBRTillDesiredReason(buildRunObject.Name, expectedReason)
-			Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
+				expectedReason = "Running"
+				actualReason, err = tb.GetBRTillDesiredReason(buildRunObject.Name, expectedReason)
+				Expect(err).To(BeNil(), fmt.Sprintf("failed to get desired reason; expected %s, got %s", expectedReason, actualReason))
+			})
 		})
 	})
 
@@ -294,6 +296,9 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 		It("should reflect a TaskRunTimeout reason and Completion time on timeout", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
@@ -328,6 +333,9 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			b, err := tb.GetBuildTillRegistration(buildObject.Name, corev1.ConditionFalse)
@@ -359,6 +367,9 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 		It("should reflect a TaskRunCancelled reason and no completionTime", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
 
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 

--- a/test/integration/buildstrategy_to_taskruns_test.go
+++ b/test/integration/buildstrategy_to_taskruns_test.go
@@ -67,6 +67,9 @@ var _ = Describe("Integration tests BuildStrategies and TaskRuns", func() {
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			_, err = tb.GetBRTillStartTime(buildRunObject.Name)

--- a/test/integration/clusterbuildstrategy_to_taskruns_test.go
+++ b/test/integration/clusterbuildstrategy_to_taskruns_test.go
@@ -67,6 +67,9 @@ var _ = Describe("Integration tests ClusterBuildStrategies and TaskRuns", func()
 
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
 			_, err = tb.GetBRTillStartTime(buildRunObject.Name)


### PR DESCRIPTION
# Changes

PR [Use GitHub action for e2e test #611](https://github.com/shipwright-io/build/pull/611) should not have been merged by the robot. It had an approval, but the tests were not successful.

Basically, after having added the fourth Kubernetes version to the test matrix, the actions became unstable. Statements in the documentation like [this](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel) leave room for interpretation, but I assume there is some resource limit and CPU is becoming the bottleneck.

I am therefore trying to limit the parallelism.

In addition, I am making changes to remove race conditions:

* in e2e, I am waiting for the Build to be registered before creating a BuildRun
* in integration, I am waiting for the Build to have a registration before creating a BuildRun
* in integration, after creating a namespace, I am waiting for the default service account to exist and contain the token secret
* in integration, I added a polling to wait for the owner updates to happen
* in integration, I commented our a part where a test case assumed to see a Pending TaskRun and BuildRun

Finally, I have to disable the runs with more than one Kubernetes version. The reason is that I see intermittent API calls (performed by the test code) failing with `etcdserver: request timed out`. We have some retry behavior for them for get calls in e2e, but not for creations and updates. And we have no retry as of now in integration. I am mainly seeing it for creations (namespace, clusterbuildstrategy) in integration.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```