### PR TITLE
Update Kaniko to v1.5.1, leverage --push-retry

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -301,7 +301,7 @@ Please consider the description of the attributes under `.spec.runtime`:
 > Specifying the runtime section will cause a `BuildRun` to push `spec.output.image` twice. First, the image produced by chosen `BuildStrategy` is pushed, and next it gets reused to construct the runtime-image, which is pushed again, overwriting `BuildStrategy` outcome.
 > Be aware, specially in situations where the image push action triggers automation steps. Since the same tag will be reused, you might need to take this in consideration when using runtime-images.
 
-Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v0.24.0` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build operator deployment](../deploy/operator.yaml).
+Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v1.5.1` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build operator deployment](../deploy/operator.yaml).
 
 ## BuildRun deletion
 

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -32,7 +32,7 @@ A `ClusterBuildStrategy` is available cluster-wide, while a `BuildStrategy` is a
 
 ## Available ClusterBuildStrategies
 
-Well-known strategies can be boostrapped from [here](../samples/buildstrategy). The current supported Cluster BuildStrategy are:
+Well-known strategies can be bootstrapped from [here](../samples/buildstrategy). The current supported Cluster BuildStrategy are:
 
 - [buildah](../samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml)
 - [buildpacks-v3-heroku](../samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml)
@@ -185,7 +185,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.3.0
+      image: gcr.io/kaniko-project/executor:v1.5.1
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -211,6 +211,9 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=/workspace/source/$(build.source.contextDir)
         - --destination=$(build.output.image)
+        - --oci-layout-path=/workspace/output/image
+        - --snapshotMode=redo
+        - --push-retry=3
       resources:
         limits:
           cpu: 250m
@@ -226,7 +229,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.3.0
+      image: gcr.io/kaniko-project/executor:v1.5.1
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -252,6 +255,9 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=/workspace/source/$(build.source.contextDir)
         - --destination=$(build.output.image)
+        - --oci-layout-path=/workspace/output/image
+        - --snapshotMode=redo
+        - --push-retry=3
       resources:
         limits:
           cpu: 500m

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ The following environment variables are available:
 | Environment Variable | Description |
 | --- | --- |
 | `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. |
-| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used instead of the default, for example `gcr.io/kaniko-project/executor:v1.0.1`. |
+| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used for the runtime image build instead of the default, for example `gcr.io/kaniko-project/executor:v1.5.1`. |
 | `BUILD_OPERATOR_LEADER_ELECTION_NAMESPACE` |  Set the namespace to be used to store the `build-operator` lock, by default it is in the same namespace as the operator itself. |
 | `BUILD_OPERATOR_LEASE_DURATION` |  Override the `LeaseDuration`, which is the duration that non-leader candidates will wait to force acquire leadership. |
 | `BUILD_OPERATOR_RENEW_DEADLINE` |  Override the `RenewDeadline`, which is the duration that the acting master will retry refreshing leadership before giving up. |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ const (
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
 	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
-	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.3.0"
+	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.5.1"
 	kanikoImageEnvVar  = "KANIKO_CONTAINER_IMAGE"
 
 	// environment variable to override the buckets

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.3.0
+      image: gcr.io/kaniko-project/executor:v1.5.1
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -34,6 +34,7 @@ spec:
         - --destination=$(build.output.image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
+        - --push-retry=3
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -24,12 +24,13 @@ spec:
         - '--destination=$(build.output.image)'
         - '--oci-layout-path=/workspace/output/image'
         - '--snapshotMode=redo'
+        - '--push-retry=3'
       command:
         - /kaniko/executor
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
-      image: gcr.io/kaniko-project/executor:v1.3.0
+      image: gcr.io/kaniko-project/executor:v1.5.1
       name: build-and-push
       securityContext:
         runAsUser: 0

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -123,7 +123,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.3.0
+      image: gcr.io/kaniko-project/executor:v1.5.1
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -151,6 +151,7 @@ spec:
         - --destination=$(build.output.image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
+        - --push-retry=3
       resources:
         limits:
           cpu: 500m
@@ -171,7 +172,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.3.0
+      image: gcr.io/kaniko-project/executor:v1.5.1
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -199,6 +200,7 @@ spec:
         - --destination=$(build.output.image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
+        - --push-retry=3
       resources:
         limits:
           cpu: 500m
@@ -283,7 +285,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.3.0
+      image: gcr.io/kaniko-project/executor:v1.5.1
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -311,6 +313,7 @@ spec:
         - --destination=$(build.output.image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
+        - --push-retry=3
       resources:
         limits:
           cpu: 500m


### PR DESCRIPTION
# Changes

I am updating the Kaniko dependency to v1.5.1. I am also leveraging the new [--push-retry](https://github.com/GoogleContainerTools/kaniko#--push-retry) flag to circumvent network hickups during the push that we have seen intermittently in our downstream tests.

Fixes #557

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Update Kaniko to v1.5.1 including better retry support for the image push to the container registry
```
