### PR TITLE
update PR template for setting kind label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@ Fixes #<insert issue number here>
 
 - [ ] Includes tests if functionality changed/was added
 - [ ] Includes docs if changes are user-facing
+- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
 - [ ] Release notes block has been filled in, or marked NONE
 
 See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
# Changes

Per recent dev list discussion, we will start requiring a kind label on PRs, and per suggestion from @adambkaplan 
the PR template is updated with this PR to facilitate the new requirement.

# Submitter Checklist

- [ n/a ] Includes tests if functionality changed/was added
- [ n/a ] Includes docs if changes are user-facing
- [ y ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

/kind dependency-change