### PR TITLE
Ignore previous logs failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
             RESTART_COUNT=$(echo "${PODS}" | jq -r ".items[] | select(.metadata.name == \"${POD_NAME}\") | .status.containerStatuses[0].restartCount")
             if [ "${RESTART_COUNT}" != "0" ]; then
               echo "# Previous logs:"
-              kubectl -n build-operator logs "${POD_NAME}" --previous
+              kubectl -n build-operator logs "${POD_NAME}" --previous || true
             fi
             echo "# Logs:"
             kubectl -n build-operator logs "${POD_NAME}"


### PR DESCRIPTION
# Changes

I just saw this in a PR log where an e2e test failed:

```
Run echo "# Pods:"
# Pods:
NAME                                                      READY   STATUS      RESTARTS   AGE
build-operator-55f9bbbcfd-rc8sz                           1/1     Running     1          17m
buildah-75xqq-vsfbv-pod-srpmw                             0/5     Completed   0          4m6s
buildah-custom-context-dockerfile-76w89-r7pkx-pod-rh5tt   0/5     Completed   0          4m53s
buildpacks-v3-fxh7r-5z6vr-pod-8s4gp                       0/5     Completed   0          14m
buildpacks-v3-golang-c9g8d-mgqgk-pod-pvdvl                0/5     Completed   0          11m
buildpacks-v3-heroku-namespaced-k9p2d-jnqpk-pod-ht28k     0/5     Completed   0          14m
buildpacks-v3-namespaced-vpdbq-tfs7f-pod-m4jht            0/5     Completed   0          11m
buildpacks-v3-nodejs-ex-runtime-hxvm4-2kjch-pod-9k6nx     0/7     Completed   0          10m
buildpacks-v3-php-8xkt6-49j6j-pod-7r7t4                   0/5     Completed   0          7m18s
buildpacks-v3-ruby-ph47b-wl6h9-pod-xnx9f                  0/5     Completed   0          5m58s
kaniko-custom-context-dockerfile-8nz6f-52kxt-pod-pl9xl    0/4     Completed   0          6m35s
s2i-xqf42-qwr5c-pod-vnczf                                 0/5     Completed   0          9m6s
# Previous logs:
Error from server (BadRequest): previous terminated container "build-operator" in pod "build-operator-55f9bbbcfd-rc8sz" not found
Error: Process completed with exit code 1.
```

I there have code which checks if there was a restart of the pod (happened here, can be seen in the pod list). I then print out the logs of the previous container because this must have been killed and the reason is interesting. But, if those logs are not anymore available, then one cannot retrieve them.

Therefore adding `|| true` to this logs command to make sure that the failure script continues and prints the logs of the current container.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
