### PR TITLE
Correct and optimize reconciliation on deletion

### DIFF
--- a/pkg/reconciler/build/controller.go
+++ b/pkg/reconciler/build/controller.go
@@ -74,8 +74,8 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration() || buildRunDeletionAnnotation
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			// Evaluates to false if the object has been confirmed deleted.
-			return !e.DeleteStateUnknown
+			// Never reconcile on deletion, there is nothing we have to do
+			return false
 		},
 	}
 

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -307,7 +307,7 @@ func (r *ReconcileBuildRun) GetBuildRunObject(ctx context.Context, objectName st
 }
 
 // VerifyRequestName parse a Reconcile request name and looks for an associated BuildRun name
-// If the BuildRun object exists, it will update it with an error.
+// If the BuildRun object exists and is not yet completed, it will update it with an error.
 func (r *ReconcileBuildRun) VerifyRequestName(ctx context.Context, request reconcile.Request, buildRun *buildv1alpha1.BuildRun) {
 
 	regxBuildRun, _ := regexp.Compile(generatedNameRegex)
@@ -319,11 +319,11 @@ func (r *ReconcileBuildRun) VerifyRequestName(ctx context.Context, request recon
 		if split := regxBuildRun.Split(request.Name, 2); len(split) > 0 {
 			// Update the related BuildRun
 			err := r.GetBuildRunObject(ctx, split[0], request.Namespace, buildRun)
-			if err == nil {
+			if err == nil && buildRun.Status.CompletionTime == nil {
 				// We ignore the errors from the following call, because the parent call of this function will always
 				// return back a reconcile.Result{}, nil. This is done to avoid infinite reconcile loops when a BuildRun
 				// does not longer exists
-				r.updateBuildRunErrorStatus(ctx, buildRun, fmt.Sprintf("taskRun %s doesn´t exist", request.Name))
+				r.updateBuildRunErrorStatus(ctx, buildRun, fmt.Sprintf("taskRun %s doesn't exist", request.Name))
 			}
 		}
 	}

--- a/pkg/reconciler/buildrun/controller.go
+++ b/pkg/reconciler/buildrun/controller.go
@@ -65,8 +65,8 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration()
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			// Evaluates to false if the object has been confirmed deleted.
-			return !e.DeleteStateUnknown
+			// Never reconcile on deletion, there is nothing we have to do
+			return false
 		},
 	}
 
@@ -90,8 +90,10 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler) error
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			// Evaluates to false if the object has been confirmed deleted.
-			return !e.DeleteStateUnknown
+			o := e.Object.(*v1beta1.TaskRun)
+
+			// If the TaskRun was deleted before completion, then we reconcile to update the BuildRun to a Failed status
+			return o.Status.CompletionTime == nil
 		},
 	}
 

--- a/test/integration/utils/taskruns.go
+++ b/test/integration/utils/taskruns.go
@@ -79,3 +79,14 @@ func (t *TestBuild) GetTRTillDesiredReason(buildRunName string, reason string) (
 
 	return
 }
+
+// DeleteTR deletes a TaskRun from a desired namespace
+func (t *TestBuild) DeleteTR(name string) error {
+	trInterface := t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace)
+
+	if err := trInterface.Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Changes

While testing something, I noticed that deleting a build caused a reconciliation on the build:

```
Feb 24 13:55:02 build-operator-dbbb6b95-272vf build-operator debug {"level":"debug","ts":1614171301.8459392,"logger":"build.build-controller","msg":"start reconciling Build","namespace":"default","name":"test-kaniko-xlarge-97"}
Feb 24 13:55:02 build-operator-dbbb6b95-272vf build-operator debug {"level":"debug","ts":1614171301.8459957,"logger":"build.build-controller","msg":"finish reconciling build. build was not found","namespace":"default","name":"test-kaniko-xlarge-97"}
```

That caused me to look into the reconciliations on delete. For Builds, I simply always return false in the predicate function because there is nothing we need to do when a Build is deleted since we do not have any finalizers.

The same applies for BuildRuns.

For TaskRuns, I am fixing a bug. When a TaskRun got deleted, we unconditionally changed the BuildRun to Failed state stating that the TaskRun doesn't exist. This imo makes sense as long as the TaskRun is not completed, but if the TaskRun is completed, then we also updated the BuildRun to a (final) Success or Failed state already for the Update event. I am therefore only reconciling on TaskRun deletion when the CompletionTime is `nil`. Also added integration tests.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Fixing the predicate functions for delete operations so that unnecessary reconciliations are omitted and a completed BuildRun does not get updated if the TaskRun gets deleted.
```