### PR TITLE
Take 2: Publish nightly release assets

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,66 @@
+name: Nightly Release
+
+on:
+  workflow_dispatch:  # Manual trigger
+
+  schedule:
+  - cron: '0 5 * * *' # 5 AM UTC = Midnight EST
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%s')"
+
+    - name: Get latest nightly release upload_url
+      id: get_release
+      run: |
+        UPLOAD_URL=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases | jq -r '.[] | select(.name | startswith("Nightly Releases")).upload_url' | tail -n 1 | cut -d"{" -f1)
+        echo "Latest nightly release upload URL is ${UPLOAD_URL}"
+        echo "::set-output name=upload_url::${UPLOAD_URL}"
+
+    - name: Install Go
+      uses: actions/setup-go@v2
+    - name: Install Ko
+      run: |
+        echo '::group:: install ko'
+        curl -L https://github.com/google/ko/releases/download/v0.8.0/ko_0.8.0_Linux_x86_64.tar.gz | tar xzf - ko
+        chmod +x ./ko
+        sudo mv ko /usr/local/bin
+        echo '::endgroup::'
+
+    - name: Ko resolve nightly.yaml
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+        IMAGE_HOST: quay.io
+        IMAGE: shipwright/shipwright-operator
+      run: |
+        make release
+        mv release.yaml nightly-${{ steps.date.outputs.date }}.yaml
+        mv release-debug.yaml nightly-${{ steps.date.outputs.date }}-debug.yaml
+
+    - name: Upload Release Asset
+      id: upload_release_asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}?name=nightly-${{ steps.date.outputs.date }}.yaml
+        asset_path: ./nightly-${{ steps.date.outputs.date }}.yaml
+        asset_name: nightly-${{ steps.date.outputs.date}}.yaml
+        asset_content_type: application/x-yaml
+    - name: Upload Release Asset
+      id: upload_release_asset-debug
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release.outputs.upload_url }}?name=nightly-${{ steps.date.outputs.date }}-debug.yaml
+        asset_path: ./nightly-${{ steps.date.outputs.date }}-debug.yaml
+        asset_name: nightly-${{ steps.date.outputs.date}}-debug.yaml
+        asset_content_type: application/x-yaml


### PR DESCRIPTION
# Changes

This builds on #600 and, instead of creating a new release each night, simply appends release assets to an existing release, the newest release named like "Nightly Releases *" -- this release would have to be created manually, once. This also allows us to periodically, manually archive a batch of nightly releases and create a new umbrella release.

Every night at midnight EST, the release would build and push images to quay.io and produce two YAMLs, `nightly-${date}.yaml` and `nightly-${date}-debug.yaml`, where `${date}` is `YYYY-MM-DD-SSSSSSSSSSS` in case we want to produce multiple nightly releases in a day.

You can see an example of this in action at https://github.com/ImJasonH/build-1/releases/tag/nightly

Installing from a nightly release:
```
$ kubectl apply -f https://github.com/ImJasonH/build-1/releases/download/nightly/nightly-2021-02-26-1614360772.yaml
namespace/shipwright-build unchanged
clusterrole.rbac.authorization.k8s.io/shipwright-build-controller unchanged
clusterrolebinding.rbac.authorization.k8s.io/shipwright-build-controller unchanged
serviceaccount/shipwright-build-controller unchanged
deployment.apps/shipwright-build-controller unchanged
customresourcedefinition.apiextensions.k8s.io/buildruns.build.dev unchanged
customresourcedefinition.apiextensions.k8s.io/builds.build.dev unchanged
customresourcedefinition.apiextensions.k8s.io/buildstrategies.build.dev unchanged
customresourcedefinition.apiextensions.k8s.io/clusterbuildstrategies.build.dev unchanged
```

/kind feature

# Submitter Checklist

- [n] Includes tests if functionality changed/was added
- [n] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```