### PR TITLE
Fix API version of ko objects

### DIFF
--- a/samples/build/build_ko_cr.yaml
+++ b/samples/build/build_ko_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: ko-build

--- a/samples/buildrun/buildrun_ko_cr.yaml
+++ b/samples/buildrun/buildrun_ko_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: BuildRun
 metadata:
   name: ko-buildrun

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: build.dev/v1alpha1
+apiVersion: shipwright.io/v1alpha1
 kind: ClusterBuildStrategy
 metadata:
   name: ko


### PR DESCRIPTION
# Changes

@sbose78 merged my [ko PR](https://github.com/shipwright-io/build/pull/603) after the [API rename](https://github.com/shipwright-io/build/pull/609). The sample files therefore contain an incorrect API version. That's why our master build is currently red.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
