### PR TITLE
Add make target for generating crds through controller-gen

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -145,6 +145,10 @@ As you make changes to the code, you can redeploy your controller with:
    ```sh
    ko apply -P -R -f deploy/
    ```
+You may use the following command to re-generate CRDs of build and buildrun if you change their spec:
+   ```sh
+   make generate-crds
+   ```
 
 ### Tear it down
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ IMAGE_HOST ?= quay.io
 IMAGE ?= shipwright/shipwright-operator
 TAG ?= latest
 
+# options for generating crds with controller-gen
+CONTROLLER_GEN="${GOBIN}/controller-gen"
+CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+
 .EXPORT_ALL_VARIABLES:
 
 default: build
@@ -279,3 +283,7 @@ kind-tekton:
 kind:
 	./hack/install-kind.sh
 	./hack/install-registry.sh
+
+generate-crds:
+	./hack/install-controller-gen.sh
+	"$(CONTROLLER_GEN)" "$(CRD_OPTIONS)" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=deploy/crds

--- a/hack/install-controller-gen.sh
+++ b/hack/install-controller-gen.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright The Shipwright Contributors
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Installs controller-gen utility via "go get".
+#
+
+set -eu
+
+# controller-gen version
+CONTROLLER_GEN_VERSION="${CONTROLLER_GEN_VERSION:-v0.4.1}"
+
+if [ ! -f "${GOPATH}/bin/controller-gen" ] ; then
+    echo "# Installing controller-gen..."
+    pushd "$(mktemp -d)" >/dev/null 2>&1
+    GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@"${CONTROLLER_GEN_VERSION}"
+    popd >/dev/null 2>&1
+fi
+
+# print controller-gen version
+controller-gen --version


### PR DESCRIPTION
# Changes

This PR is for changing to use [controller-gen tool](https://github.com/kubernetes-sigs/controller-tools) from kubebuilder to generate CRDs 

Fixes https://github.com/shipwright-io/build/issues/579

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
Added a script and make target to install controller-gen tool and generate CRDs with this tool

<!--

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
