### PR TITLE
Add missing rename for new ns syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,12 @@ jobs:
           run: |
             echo "# Pods:"
             kubectl -n shipwright-build get pod
-            PODS=$(kubectl -n build-operator get pod -o json)
+            PODS=$(kubectl -n shipwright-build get pod -o json)
             POD_NAME=$(echo "${PODS}" | jq -r '.items[] | select(.metadata.name | startswith("shipwright-build-controller-")) | .metadata.name')
             RESTART_COUNT=$(echo "${PODS}" | jq -r ".items[] | select(.metadata.name == \"${POD_NAME}\") | .status.containerStatuses[0].restartCount")
             if [ "${RESTART_COUNT}" != "0" ]; then
               echo "# Previous logs:"
-              kubectl -n build-operator logs "${POD_NAME}" --previous || true
+              kubectl -n shipwright-build logs "${POD_NAME}" --previous || true
             fi
             echo "# Logs:"
             kubectl -n shipwright-build logs "${POD_NAME}"

--- a/samples/build/build_ko_cr.yaml
+++ b/samples/build/build_ko_cr.yaml
@@ -14,4 +14,4 @@ spec:
     name: ko
     kind: ClusterBuildStrategy
   output:
-    image: image-registry.openshift-image-registry.svc:5000/build-examples/build-operator
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/shipwright-build


### PR DESCRIPTION
# Changes

Fixes a reference to the old namespace inside the CI definition.
Fixes an old reference to the build-operator in a sample file.

# Release Notes

```release-note
NONE
```

