### PR TITLE
Refine the other operator related names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # output directory, where all artifacts will be created and managed
 OUTPUT_DIR ?= build/_output
 # relative path to controller binary
-OPERATOR = $(OUTPUT_DIR)/bin/shipwright-build-controller
+CONTROLLER = $(OUTPUT_DIR)/bin/shipwright-build-controller
 
 # golang cache directory path
 GOCACHE ?= $(shell echo ${PWD})/$(OUTPUT_DIR)/gocache
@@ -62,7 +62,7 @@ TEST_SOURCE_SECRET ?=
 
 # Image settings for building and pushing images
 IMAGE_HOST ?= quay.io
-IMAGE ?= shipwright/shipwright-operator
+IMAGE ?= shipwright/shipwright-build-controller
 TAG ?= latest
 
 # options for generating crds with controller-gen
@@ -78,14 +78,14 @@ vendor: go.mod go.sum
 	go mod vendor
 
 .PHONY: build
-build: $(OPERATOR)
+build: $(CONTROLLER)
 
-$(OPERATOR): vendor
-	go build -trimpath $(GO_FLAGS) -o $(OPERATOR) cmd/manager/main.go
+$(CONTROLLER): vendor
+	go build -trimpath $(GO_FLAGS) -o $(CONTROLLER) cmd/manager/main.go
 
 .PHONY: build-plain
 build-plain: 
-	go build -trimpath $(GO_FLAGS) -o $(OPERATOR) cmd/manager/main.go
+	go build -trimpath $(GO_FLAGS) -o $(CONTROLLER) cmd/manager/main.go
 
 .PHONY: build-image
 build-image:
@@ -219,7 +219,7 @@ test-e2e: install-strategies test-e2e-plain
 .PHONY: test-e2e-plain
 test-e2e-plain: ginkgo
 	GO111MODULE=on \
-	TEST_OPERATOR_NAMESPACE=${TEST_NAMESPACE} \
+	TEST_CONTROLLER_NAMESPACE=${TEST_NAMESPACE} \
 	TEST_WATCH_NAMESPACE=${TEST_NAMESPACE} \
 	TEST_E2E_SERVICEACCOUNT_NAME=${TEST_E2E_SERVICEACCOUNT_NAME} \
 	TEST_E2E_TIMEOUT_MULTIPLIER=${TEST_E2E_TIMEOUT_MULTIPLIER} \
@@ -252,11 +252,11 @@ install-strategies: install-apis
 	kubectl apply -R -f samples/buildstrategy/
 
 local: vendor install-strategies
-	OPERATOR_NAME=shipwright-build-controller \
+	CONTROLLER_NAME=shipwright-build-controller \
 	operator-sdk run local --operator-flags="$(ZAP_FLAGS)"
 
 local-plain: vendor
-	OPERATOR_NAME=shipwright-build-controller \
+	CONTROLLER_NAME=shipwright-build-controller \
 	operator-sdk run local --operator-flags="$(ZAP_FLAGS)"
 
 clean:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,12 +4,12 @@
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-ENV OPERATOR=/usr/local/bin/shipwright-build-controller \
+ENV CONTROLLER=/usr/local/bin/shipwright-build-controller \
     USER_UID=1001 \
     USER_NAME=shipwright-build-controller
 
 # install controller binary
-COPY build/_output/bin/shipwright-build-controller ${OPERATOR}
+COPY build/_output/bin/shipwright-build-controller ${CONTROLLER}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -14,4 +14,4 @@ if ! whoami &>/dev/null; then
   fi
 fi
 
-exec ${OPERATOR} $@
+exec ${CONTROLLER} $@

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -30,12 +30,13 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsHost       = "0.0.0.0"
-	metricsPort int32 = 8383
+	metricsHost        = "0.0.0.0"
+	metricsPort  int32 = 8383
+	versionGiven       = flag.String("version", "devel", "Version of Shipwright build controller running")
 )
 
 func printVersion(ctx context.Context) {
-	ctxlog.Info(ctx, fmt.Sprintf("Operator Version: %s", version.Version))
+	ctxlog.Info(ctx, fmt.Sprintf("Shipwright Build Controller Version: %s", version.Version))
 	ctxlog.Info(ctx, fmt.Sprintf("Go Version: %s", runtime.Version()))
 	ctxlog.Info(ctx, fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 }
@@ -57,13 +58,14 @@ func main() {
 	//
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will
-	// be propagated through the whole operator, generating
+	// be propagated through the whole Shipwright build controller, generating
 	// uniform and structured logs.
 
 	l := ctxlog.NewLogger("build")
 
 	ctx := ctxlog.NewParentContext(l)
 
+	version.SetVersion(*versionGiven)
 	printVersion(ctx)
 
 	// Get a config to talk to the apiserver

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -154,7 +154,7 @@ To install the cluster scope strategy, use:
 kubectl apply -f samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
 ```
 
-**Note**: The build strategy currently uses the `spec.contextDir` of the Build in a different way than this property is designed for: the Git repository must be a Go module with the go.mod file at the root. The `contextDir` specifies the path to the main package. You can check the [example](../samples/build/build_ko_cr.yaml) which is set up to build the Shipwright Build operator. This behavior will eventually be corrected once [Exhaustive list of generalized Build API/CRD attributes #184](https://github.com/shipwright-io/build/issues/184) / [Custom attributes from the Build CR could be used as parameters while defining a BuildStrategy #537](https://github.com/shipwright-io/build/issues/537) are done.
+**Note**: The build strategy currently uses the `spec.contextDir` of the Build in a different way than this property is designed for: the Git repository must be a Go module with the go.mod file at the root. The `contextDir` specifies the path to the main package. You can check the [example](../samples/build/build_ko_cr.yaml) which is set up to build the Shipwright Build controller. This behavior will eventually be corrected once [Exhaustive list of generalized Build API/CRD attributes #184](https://github.com/shipwright-io/build/issues/184) / [Custom attributes from the Build CR could be used as parameters while defining a BuildStrategy #537](https://github.com/shipwright-io/build/issues/537) are done.
 
 ## Source to Image
 

--- a/docs/proposals/dedicated-shipwright-operator.md
+++ b/docs/proposals/dedicated-shipwright-operator.md
@@ -160,8 +160,8 @@ This would be useful if Project Shipwright produces additional components and cl
 
 **Risk**: Manifests uses to deploy Shipwright Builds in the `shipwright-io/operator` are not synchronized with content in `shipwright-io/build`.
 
-*Mitigation*: The operator's CI should include a test suite that runs the e2e tests in `shipwright-io/build`.
-Project maintainers should also ensure that deployment changes to `shipwright-io/build` carry across to the operator.
+*Mitigation*: The Shipwright build controller's CI should include a test suite that runs the e2e tests in `shipwright-io/build`.
+Project maintainers should also ensure that deployment changes to `shipwright-io/build` carry across to the Shipwright build controller.
 
 **Risk**: Operator will require permissions cluster admins will reject (ex - modify CRDs)
 
@@ -177,7 +177,7 @@ Test suites will need to ensure the following:
 
 1. When a `ShipwrightBuild` object is created, the corresponding build controllers are deployed and the Build APIs are added as custom resource definitions.
 2. Changes to the `ShipwrightBuild` spec are correctly reflected in the subsequent deployment.
-3. CI for the operator should include the e2e suite for `shipwright-io/build`, run against the controllers deployed by the operator.
+3. CI for the Shipwright build controller should include the e2e suite for `shipwright-io/build`, run against the controllers deployed by the operator.
 
 ### Graduation Criteria
 
@@ -190,13 +190,13 @@ Test suites will need to ensure the following:
 ##### Tech Preview -> GA
 
 - Configuration API for `ShipwrightBuild` reaches v1 stability.
-- Support for over the air upgrades of the operator _and_ the build controllers.
-- [optional] allow version skews between the operator and deployed version of Shipwright Build.
-- [optional] operator manages the Build API CRDs.
+- Support for over the air upgrades of the Shipwright build controller.
+- [optional] allow version skews between the Shipwright build controller and deployed version of Shipwright Build.
+- [optional] Shipwright build controller manages the Build API CRDs.
 
 ### Upgrade / Downgrade Strategy
 
-The operator should use leader election to ensure that when a new version of the operator is installed, it does not conflict with the existing installation.
+The Shipwright build controller should use leader election to ensure that when a new version of the operator is installed, it does not conflict with the existing installation.
 This is only required for Tech Preview - Dev Preview releases can assume that the operator is uninstalled before the new version is installed.
 
 ## Implementation History

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -12,6 +12,6 @@ echo "$REGISTRY_PASSWORD" | ko login -u "$REGISTRY_USERNAME" --password-stdin "$
 echo "Building container image"
 
 # Using defaults, this pushes to:
-# quay.io/shipwright/shipwright-operator:latest
+# quay.io/shipwright/shipwright-build-controller:latest
 KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS}" ko resolve -t "$TAG" --bare -R -f deploy/ > release.yaml
 KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve -t "$TAG-debug" --bare -R -f deploy/ > release-debug.yaml

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,7 +69,7 @@ type PrometheusConfig struct {
 	EnabledLabels                     []string
 }
 
-// ManagerOptions contains configurable options for the build operator manager
+// ManagerOptions contains configurable options for the Shipwright build controller manager
 type ManagerOptions struct {
 	LeaderElectionNamespace string
 	LeaseDuration           *time.Duration
@@ -152,15 +152,15 @@ func (c *Config) SetConfigFromEnv() error {
 		c.ManagerOptions.LeaderElectionNamespace = leaderElectionNamespace
 	}
 
-	if err := updateBuildOperatorDurationOption(&c.ManagerOptions.LeaseDuration, leaseDurationEnvVar); err != nil {
+	if err := updateBuildControllerDurationOption(&c.ManagerOptions.LeaseDuration, leaseDurationEnvVar); err != nil {
 		return err
 	}
 
-	if err := updateBuildOperatorDurationOption(&c.ManagerOptions.RenewDeadline, renewDeadlineEnvVar); err != nil {
+	if err := updateBuildControllerDurationOption(&c.ManagerOptions.RenewDeadline, renewDeadlineEnvVar); err != nil {
 		return err
 	}
 
-	if err := updateBuildOperatorDurationOption(&c.ManagerOptions.RetryPeriod, retryPeriodEnvVar); err != nil {
+	if err := updateBuildControllerDurationOption(&c.ManagerOptions.RetryPeriod, retryPeriodEnvVar); err != nil {
 		return err
 	}
 
@@ -207,7 +207,7 @@ func updateBucketsConfig(buckets *[]float64, envVarName string) error {
 	return nil
 }
 
-func updateBuildOperatorDurationOption(d **time.Duration, envVarName string) error {
+func updateBuildControllerDurationOption(d **time.Duration, envVarName string) error {
 	if value := os.Getenv(envVarName); value != "" {
 		valueDuration, err := time.ParseDuration(value)
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -56,14 +56,14 @@ var _ = Describe("Config", func() {
 			})
 		})
 
-		It("should allow for an override of the operator leader election namespace using an environment variable", func() {
+		It("should allow for an override of the Shipwright build controller leader election namespace using an environment variable", func() {
 			var overrides = map[string]string{"BUILD_CONTROLLER_LEADER_ELECTION_NAMESPACE": "shipwright-build"}
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
 				Expect(config.ManagerOptions.LeaderElectionNamespace).To(Equal("shipwright-build"))
 			})
 		})
 
-		It("should allow for an override of the operator leader election times using environment variables", func() {
+		It("should allow for an override of the Shipwright build controller leader election times using environment variables", func() {
 			var overrides = map[string]string{
 				"BUILD_CONTROLLER_LEASE_DURATION": "42s",
 				"BUILD_CONTROLLER_RENEW_DEADLINE": "32s",

--- a/pkg/reconciler/buildrun/resources/runtime_image.go
+++ b/pkg/reconciler/buildrun/resources/runtime_image.go
@@ -158,7 +158,7 @@ func runtimeDockerfileStep(b *buildv1alpha1.Build) (*v1beta1.Step, error) {
 	if err != nil {
 		return nil, err
 	}
-	// appling known transformation to dockerfile payload, therefore operator variables are
+	// appling known transformation to dockerfile payload, therefore the Shipwright build controller variables are
 	// applicable to all parts of the runtime Dockerfile as well
 	dockerfileTransformed := runtimeDockerfileTransformations(b, dockerfile.String())
 

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -40,26 +40,26 @@ var _ = BeforeEach(func() {
 
 	deleteNSList = append(deleteNSList, tb.Namespace)
 
-	// We store a channel for each Build operator instance we start,
+	// We store a channel for each Build controller instance we start,
 	// so that we can nuke the instance later inside the AfterEach Ginkgo
 	// block
-	tb.StopBuildOperator, err = tb.StartBuildOperator()
+	tb.StopBuildControllers, err = tb.StartBuildControllers()
 	if err != nil {
-		fmt.Println("fail to start the Build powerful operator", err)
+		fmt.Println("fail to start the powerful Build controllers", err)
 	}
 })
 
 var _ = AfterEach(func() {
 	// Close the channel, meaning we nuke an instance of the Build
 	// operator
-	if tb.StopBuildOperator != nil {
-		close(tb.StopBuildOperator)
+	if tb.StopBuildControllers != nil {
+		close(tb.StopBuildControllers)
 	}
 
-	if CurrentGinkgoTestDescription().Failed && tb.BuildOperatorLogBuffer != nil {
+	if CurrentGinkgoTestDescription().Failed && tb.BuildControllerLogBuffer != nil {
 		// print operator logs
 		fmt.Println("\nLogs of the operator:")
-		fmt.Printf("%v\n", tb.BuildOperatorLogBuffer)
+		fmt.Printf("%v\n", tb.BuildControllerLogBuffer)
 	}
 })
 

--- a/test/utils/controllers.go
+++ b/test/utils/controllers.go
@@ -11,10 +11,10 @@ import (
 	"github.com/shipwright-io/build/pkg/controller"
 )
 
-// StartBuildOperator initialize an operator as if being call from main,
+// StartBuildControllers initialize an operator as if being call from main,
 // but it disables the prometheus metrics and leader election. This intended
 // to for testing.
-func (t *TestBuild) StartBuildOperator() (chan struct{}, error) {
+func (t *TestBuild) StartBuildControllers() (chan struct{}, error) {
 	c := buildconfig.NewDefaultConfig()
 
 	mgr, err := controller.NewManager(t.Context, c, t.KubeConfig, manager.Options{

--- a/test/utils/environment.go
+++ b/test/utils/environment.go
@@ -38,17 +38,17 @@ type TestBuild struct {
 	// TODO: Adding specific field for polling here, interval and timeout
 	// but I think we need a small refactoring to make them global for all
 	// tests under /test dir
-	Interval               time.Duration
-	TimeOut                time.Duration
-	KubeConfig             *rest.Config
-	Clientset              *kubernetes.Clientset
-	Namespace              string
-	StopBuildOperator      chan struct{}
-	BuildClientSet         *buildClient.Clientset
-	PipelineClientSet      *tektonClient.Clientset
-	Catalog                test.Catalog
-	Context                context.Context
-	BuildOperatorLogBuffer *bytes.Buffer
+	Interval                 time.Duration
+	TimeOut                  time.Duration
+	KubeConfig               *rest.Config
+	Clientset                *kubernetes.Clientset
+	Namespace                string
+	StopBuildControllers     chan struct{}
+	BuildClientSet           *buildClient.Clientset
+	PipelineClientSet        *tektonClient.Clientset
+	Catalog                  test.Catalog
+	Context                  context.Context
+	BuildControllerLogBuffer *bytes.Buffer
 }
 
 // NewTestBuild returns an initialized instance of TestBuild
@@ -80,15 +80,15 @@ func NewTestBuild() (*TestBuild, error) {
 
 	return &TestBuild{
 		// TODO: interval and timeout can be configured via ENV vars
-		Interval:               time.Second * 3,
-		TimeOut:                time.Second * 180,
-		KubeConfig:             restConfig,
-		Clientset:              kubeConfig,
-		Namespace:              testNamespace,
-		BuildClientSet:         buildClientSet,
-		PipelineClientSet:      pipelineClientSet,
-		Context:                ctx,
-		BuildOperatorLogBuffer: logBuffer,
+		Interval:                 time.Second * 3,
+		TimeOut:                  time.Second * 180,
+		KubeConfig:               restConfig,
+		Clientset:                kubeConfig,
+		Namespace:                testNamespace,
+		BuildClientSet:           buildClientSet,
+		PipelineClientSet:        pipelineClientSet,
+		Context:                  ctx,
+		BuildControllerLogBuffer: logBuffer,
 	}, nil
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -4,5 +4,10 @@
 
 package version
 
-// Version describes the version of build
-var Version = "0.0.1"
+// Version describes the version of Shipwright build controller
+var Version = ""
+
+// SetVersion sets the version of Shipwright build controller from go flags
+func SetVersion(version string) {
+	Version = version
+}


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

After the PR `Rename Shipwright components away from "operator"`: https://github.com/shipwright-io/build/pull/610

There are still some codes and comments which uses `operator` which may make end user or new developer confusion.
If we decide to swtich `build operator` to `Shipwright build controller`, we should review all codes and switch them all.

- Still keep `operator-sdk` related words as before
- Modify the code and related properties, etc ...
- Modify in the documents
- Modify in the test codes
- Update the version of the Shipwright build controller from `0.0.1` to `0.3.0`

/kind cleanup


# Submitter Checklist

- [ n ] Includes tests if functionality changed/was added
- [ n ] Includes docs if changes are user-facing
- [ y ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ y ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Renamed "build operator" to "build controller" in code and documentation.
```

