### PR TITLE
Modify default branch behaviour for git repos

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -83,7 +83,7 @@ The `Build` definition supports the following fields:
 A `Build` resource can specify a Git source, together with other parameters like:
 
 - `source.credentials.name` - For private repositories, the name is a reference to an existing secret on the same namespace containing the `ssh` data.
-- `source.revision` - An specific revision to select from the source repository, this can be a commit or branch name.
+- `source.revision` - An specific revision to select from the source repository, this can be a commit or branch name. If not defined, it will fallback to the git repository default branch.
 - `source.contextDir` - For repositories where the source code is not located at the root folder, you can specify this path here. Currently, only supported by `buildah`, `kaniko` and `buildpacks` build strategies.
 
 By default, the Build controller will validate that the Git repository exists. If the validation is not desired, users can define the `build.shipwright.io/verify.repository` annotation with `false`. For example:

--- a/pkg/reconciler/buildrun/resources/taskrun.go
+++ b/pkg/reconciler/buildrun/resources/taskrun.go
@@ -180,7 +180,10 @@ func GenerateTaskRun(
 	strategy buildv1alpha1.BuilderStrategy,
 ) (*v1beta1.TaskRun, error) {
 
-	revision := "master"
+	// Set revision to empty if the field is not specified in the Build.
+	// This will force Tekton Controller to do a git symbolic-link to HEAD
+	// giving back the default branch of the repository
+	revision := ""
 	if build.Spec.Source.Revision != nil {
 		revision = *build.Spec.Source.Revision
 	}

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -121,7 +121,7 @@ var _ = Describe("GenerateTaskrun", func() {
 
 			namespace = "build-test"
 			contextDir = "src"
-			revision = "master"
+			revision = ""
 			builderImage = &buildv1alpha1.Image{
 				ImageURL: "heroku/buildpacks:18",
 			}


### PR DESCRIPTION
# Changes

The behaviour for a git repo revision was being hardcoded to `master`,
which is incorrect, while github is already creating the default branch
to `main` and also because the default Tekton behaviour was not taking
place if the revision parameter is not specified.

Tekton defaults behaviour triggers a git symbolic-link to HEAD, which
we should allow to happen if the user does not specify a revision in the
Build source.

Fixes #518

Tekton introduced the default behaviour in https://github.com/tektoncd/pipeline/commit/9aff0a076f70c7bf32a6e275762e6097f8f3cb2d


# Submitter Checklist

- [x ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
Ensure default branch of repositories falls to HEAD when revision is not specified in the Build
```
