### PR TITLE
Enhance CI e2e test on logs retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,14 @@ jobs:
             kubectl -n shipwright-build get pod
             PODS=$(kubectl -n shipwright-build get pod -o json)
             POD_NAME=$(echo "${PODS}" | jq -r '.items[] | select(.metadata.name | startswith("shipwright-build-controller-")) | .metadata.name')
-            RESTART_COUNT=$(echo "${PODS}" | jq -r ".items[] | select(.metadata.name == \"${POD_NAME}\") | .status.containerStatuses[0].restartCount")
-            if [ "${RESTART_COUNT}" != "0" ]; then
-              echo "# Previous logs:"
-              kubectl -n shipwright-build logs "${POD_NAME}" --previous || true
+            if [ "${POD_NAME}" != "" ]; then
+              RESTART_COUNT=$(echo "${PODS}" | jq -r ".items[] | select(.metadata.name == \"${POD_NAME}\") | .status.containerStatuses[0].restartCount")
+              if [ "${RESTART_COUNT}" != "0" ]; then
+                echo "# Previous logs:"
+                kubectl -n shipwright-build logs "${POD_NAME}" --previous || true
+              fi
+              echo "# Logs:"
+              kubectl -n shipwright-build logs "${POD_NAME}"
+            else
+              echo "# Pod is missing, there are no logs to retrieve, bailing out..."
             fi
-            echo "# Logs:"
-            kubectl -n shipwright-build logs "${POD_NAME}"


### PR DESCRIPTION
# Changes

When test fails, avoid trying to retrieve pod logs if we know the pod
is not longer there.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
