### PR TITLE
Change GitHub Action name to be more readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
       branches: [ master ]
     push:
       branches: [ master ]
-name: ci/github
+name: Unit, Integration, and E2E Tests
 jobs:
     unit:
         strategy:


### PR DESCRIPTION
# Changes

The name `ci/github` is a bit generic.

Set it to `Unit, Integration, and E2E Tests` to reflect that this part of the
automation runs the unit tests, integration tests and E2E tests together.

![image](https://user-images.githubusercontent.com/1979133/110101822-53dc7f00-7da4-11eb-94d0-fbba4cf22780.png)

/kind enhancement

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
