### PR TITLE
Add KILL capability for Kaniko executor to allow it to kill non-root processes

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -213,6 +213,7 @@ spec:
             - SETGID
             - SETUID
             - SETFCAP
+            - KILL
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
@@ -257,6 +258,7 @@ spec:
             - SETGID
             - SETUID
             - SETFCAP
+            - KILL
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker

--- a/pkg/reconciler/buildrun/resources/runtime_image.go
+++ b/pkg/reconciler/buildrun/resources/runtime_image.go
@@ -202,6 +202,7 @@ func runtimeBuildAndPushStep(b *buildv1alpha1.Build, kanikoImage string) *v1beta
 					v1.Capability("SETGID"),
 					v1.Capability("SETUID"),
 					v1.Capability("SETFCAP"),
+					v1.Capability("KILL"),
 				},
 			},
 		},

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -18,6 +18,7 @@ spec:
             - SETGID
             - SETUID
             - SETFCAP
+            - KILL
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -43,6 +43,7 @@ spec:
             - SETGID
             - SETUID
             - SETFCAP
+            - KILL
       volumeMounts:
         - mountPath: /gen-source
           name: gen-source

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -135,6 +135,7 @@ spec:
             - SETGID
             - SETUID
             - SETFCAP
+            - KILL
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
@@ -184,6 +185,7 @@ spec:
             - SETGID
             - SETUID
             - SETFCAP
+            - KILL
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
@@ -231,6 +233,7 @@ spec:
         - SETGID
         - SETUID
         - SETFCAP
+        - KILL
     env:
     - name: DOCKER_CONFIG
       value: /tekton/home/.docker
@@ -297,6 +300,7 @@ spec:
             - SETGID
             - SETUID
             - SETFCAP
+            - KILL
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker


### PR DESCRIPTION
# Changes

For a `RUN something` command, Kaniko triggers a process for `something`. In case `something` triggers a daemon process, Kaniko must kill this once the main process is terminated. The reason is that the daemon could otherwise continue to make changes to the file system that will fail the layer creation. See [`RUN <process>` can leave processes running in the background #247](https://github.com/GoogleContainerTools/kaniko/issues/247) for more information.

Kaniko is running as root. If the daemon process runs as a different user, for example because thee is a `USER nonroot` statement in the Dockerfile before the `RUN` command, then the `KILL` capability is necessary.

The Kaniko kill logic is here: [run.go](https://github.com/GoogleContainerTools/kaniko/blob/v1.5.1/pkg/commands/run.go#L130).

The [Secure Your Containers with this One Weird Trick ](https://www.redhat.com/en/blog/secure-your-containers-one-weird-trick) blog post assesses `KILL` *on the danger scale, this one is on the low end*.

A sample Dockerfile that needs this is the Java sample that I added here: [sample-java/docker-build](https://github.com/shipwright-io/sample-java/tree/main/docker-build).  The `RUN configure.sh` command seems to cause some background process that Kaniko requires the `KILL` capability because it runs as user 1001. With a PSP in place enforcing the capabilities, the container will fail at this point.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Adding the KILL capability to the Kaniko executor to allow it to kill daemon processes started by non-root
```