### PR TITLE
Re-generate the crds by using line breaking

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -42,10 +42,14 @@ spec:
         description: BuildRun is the Schema representing an instance of build execution
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -65,23 +69,30 @@ spec:
                 - name
                 type: object
               output:
-                description: Output refers to the location where the generated image would be pushed to. It will overwrite the output image in build spec
+                description: Output refers to the location where the generated image
+                  would be pushed to. It will overwrite the output image in build
+                  spec
                 properties:
                   credentials:
-                    description: SecretRef is a reference to the Secret containing the credentials to push the image to the registry
+                    description: SecretRef is a reference to the Secret containing
+                      the credentials to push the image to the registry
                     properties:
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
                   image:
-                    description: ImageURL is the URL where the image will be pushed to.
+                    description: ImageURL is the URL where the image will be pushed
+                      to.
                     type: string
                 required:
                 - image
                 type: object
               serviceAccount:
-                description: ServiceAccount refers to the kubernetes serviceaccount which is used for resource control. Default serviceaccount will be set if it is empty
+                description: ServiceAccount refers to the kubernetes serviceaccount
+                  which is used for resource control. Default serviceaccount will
+                  be set if it is empty
                 properties:
                   generate:
                     description: If generates a new ServiceAccount for the build
@@ -104,44 +115,57 @@ spec:
                 description: BuildSpec is the Build Spec of this BuildRun.
                 properties:
                   builder:
-                    description: BuilderImage refers to the image containing the build tools inside which the source code would be built.
+                    description: BuilderImage refers to the image containing the build
+                      tools inside which the source code would be built.
                     properties:
                       credentials:
-                        description: SecretRef is a reference to the Secret containing the credentials to push the image to the registry
+                        description: SecretRef is a reference to the Secret containing
+                          the credentials to push the image to the registry
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       image:
-                        description: ImageURL is the URL where the image will be pushed to.
+                        description: ImageURL is the URL where the image will be pushed
+                          to.
                         type: string
                     required:
                     - image
                     type: object
                   dockerfile:
-                    description: Dockerfile is the path to the Dockerfile to be used for build strategies which bank on the Dockerfile for building an image.
+                    description: Dockerfile is the path to the Dockerfile to be used
+                      for build strategies which bank on the Dockerfile for building
+                      an image.
                     type: string
                   output:
-                    description: Output refers to the location where the generated image would be pushed to.
+                    description: Output refers to the location where the generated
+                      image would be pushed to.
                     properties:
                       credentials:
-                        description: SecretRef is a reference to the Secret containing the credentials to push the image to the registry
+                        description: SecretRef is a reference to the Secret containing
+                          the credentials to push the image to the registry
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       image:
-                        description: ImageURL is the URL where the image will be pushed to.
+                        description: ImageURL is the URL where the image will be pushed
+                          to.
                         type: string
                     required:
                     - image
                     type: object
                   parameters:
-                    description: Parameters contains name-value that could be used to loosely type parameters in the BuildStrategy.
+                    description: Parameters contains name-value that could be used
+                      to loosely type parameters in the BuildStrategy.
                     items:
-                      description: Parameter defines the data structure that would be used for expressing arbitrary key/value pairs for the execution of a build
+                      description: Parameter defines the data structure that would
+                        be used for expressing arbitrary key/value pairs for the execution
+                        of a build
                       properties:
                         name:
                           type: string
@@ -159,14 +183,18 @@ spec:
                         description: Base runtime base image.
                         properties:
                           credentials:
-                            description: SecretRef is a reference to the Secret containing the credentials to push the image to the registry
+                            description: SecretRef is a reference to the Secret containing
+                              the credentials to push the image to the registry
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                             type: object
                           image:
-                            description: ImageURL is the URL where the image will be pushed to.
+                            description: ImageURL is the URL where the image will
+                              be pushed to.
                             type: string
                         required:
                         - image
@@ -184,15 +212,19 @@ spec:
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels map of additional labels to be applied on image.
+                        description: Labels map of additional labels to be applied
+                          on image.
                         type: object
                       paths:
-                        description: Paths list of directories/files to be copied into runtime-image, using colon ":" to split up source and destination paths.
+                        description: Paths list of directories/files to be copied
+                          into runtime-image, using colon ":" to split up source and
+                          destination paths.
                         items:
                           type: string
                         type: array
                       run:
-                        description: Run arbitrary commands to run before copying data into runtime-image.
+                        description: Run arbitrary commands to run before copying
+                          data into runtime-image.
                         items:
                           type: string
                         type: array
@@ -213,20 +245,25 @@ spec:
                         type: string
                     type: object
                   source:
-                    description: Source refers to the Git repository containing the source code to be built.
+                    description: Source refers to the Git repository containing the
+                      source code to be built.
                     properties:
                       contextDir:
-                        description: ContextDir is a path to subfolder in the repo. Optional.
+                        description: ContextDir is a path to subfolder in the repo.
+                          Optional.
                         type: string
                       credentials:
-                        description: SecretRef refers to the secret that contains credentials to access the git repo. Optional.
+                        description: SecretRef refers to the secret that contains
+                          credentials to access the git repo. Optional.
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       flavor:
-                        description: Flavor of the git provider like github, gitlab, bitbucket, generic, etc. Optional.
+                        description: Flavor of the git provider like github, gitlab,
+                          bitbucket, generic, etc. Optional.
                         type: string
                       httpProxy:
                         description: HTTPProxy is optional.
@@ -235,10 +272,12 @@ spec:
                         description: HTTPSProxy is optional.
                         type: string
                       noProxy:
-                        description: NoProxy can be used to specify domains for which no proxying should be performed. Optional.
+                        description: NoProxy can be used to specify domains for which
+                          no proxying should be performed. Optional.
                         type: string
                       revision:
-                        description: Ref is a git reference. Optional. If not defined, it will fallback to the git repository default branch.
+                        description: Ref is a git reference. Optional. If not defined,
+                          it will fallback to the git repository default branch.
                         type: string
                       url:
                         description: URL of the git repo
@@ -247,13 +286,16 @@ spec:
                     - url
                     type: object
                   strategy:
-                    description: StrategyRef refers to the BuildStrategy to be used to build the container image. There are namespaced scope and cluster scope BuildStrategy
+                    description: StrategyRef refers to the BuildStrategy to be used
+                      to build the container image. There are namespaced scope and
+                      cluster scope BuildStrategy
                     properties:
                       apiVersion:
                         description: API version of the referent
                         type: string
                       kind:
-                        description: BuildStrategyKind indicates the kind of the buildstrategy, namespaced or cluster scoped.
+                        description: BuildStrategyKind indicates the kind of the buildstrategy,
+                          namespaced or cluster scoped.
                         type: string
                       name:
                         description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -277,14 +319,17 @@ spec:
               conditions:
                 description: Conditions
                 items:
-                  description: Condition defines the required fields for populating Build controllers Conditions
+                  description: Condition defines the required fields for populating
+                    Build controllers Conditions
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime last time the condition transit from one status to another.
+                      description: LastTransitionTime last time the condition transit
+                        from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition last transition.
@@ -309,7 +354,8 @@ spec:
                     type: string
                 type: object
               latestTaskRunRef:
-                description: PodName is the name of the pod responsible for executing this task's steps.
+                description: PodName is the name of the pod responsible for executing
+                  this task's steps.
                 type: string
               reason:
                 description: The Succeeded reason of the TaskRun

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -21,7 +21,8 @@ spec:
       jsonPath: .status.registered
       name: Registered
       type: string
-    - description: The reason of the registered Build, either an error or succeed message
+    - description: The reason of the registered Build, either an error or succeed
+        message
       jsonPath: .status.reason
       name: Reason
       type: string
@@ -43,10 +44,14 @@ spec:
         description: Build is the Schema representing a Build definition
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -54,44 +59,56 @@ spec:
             description: BuildSpec defines the desired state of Build
             properties:
               builder:
-                description: BuilderImage refers to the image containing the build tools inside which the source code would be built.
+                description: BuilderImage refers to the image containing the build
+                  tools inside which the source code would be built.
                 properties:
                   credentials:
-                    description: SecretRef is a reference to the Secret containing the credentials to push the image to the registry
+                    description: SecretRef is a reference to the Secret containing
+                      the credentials to push the image to the registry
                     properties:
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
                   image:
-                    description: ImageURL is the URL where the image will be pushed to.
+                    description: ImageURL is the URL where the image will be pushed
+                      to.
                     type: string
                 required:
                 - image
                 type: object
               dockerfile:
-                description: Dockerfile is the path to the Dockerfile to be used for build strategies which bank on the Dockerfile for building an image.
+                description: Dockerfile is the path to the Dockerfile to be used for
+                  build strategies which bank on the Dockerfile for building an image.
                 type: string
               output:
-                description: Output refers to the location where the generated image would be pushed to.
+                description: Output refers to the location where the generated image
+                  would be pushed to.
                 properties:
                   credentials:
-                    description: SecretRef is a reference to the Secret containing the credentials to push the image to the registry
+                    description: SecretRef is a reference to the Secret containing
+                      the credentials to push the image to the registry
                     properties:
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
                   image:
-                    description: ImageURL is the URL where the image will be pushed to.
+                    description: ImageURL is the URL where the image will be pushed
+                      to.
                     type: string
                 required:
                 - image
                 type: object
               parameters:
-                description: Parameters contains name-value that could be used to loosely type parameters in the BuildStrategy.
+                description: Parameters contains name-value that could be used to
+                  loosely type parameters in the BuildStrategy.
                 items:
-                  description: Parameter defines the data structure that would be used for expressing arbitrary key/value pairs for the execution of a build
+                  description: Parameter defines the data structure that would be
+                    used for expressing arbitrary key/value pairs for the execution
+                    of a build
                   properties:
                     name:
                       type: string
@@ -109,14 +126,17 @@ spec:
                     description: Base runtime base image.
                     properties:
                       credentials:
-                        description: SecretRef is a reference to the Secret containing the credentials to push the image to the registry
+                        description: SecretRef is a reference to the Secret containing
+                          the credentials to push the image to the registry
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       image:
-                        description: ImageURL is the URL where the image will be pushed to.
+                        description: ImageURL is the URL where the image will be pushed
+                          to.
                         type: string
                     required:
                     - image
@@ -134,15 +154,19 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels map of additional labels to be applied on image.
+                    description: Labels map of additional labels to be applied on
+                      image.
                     type: object
                   paths:
-                    description: Paths list of directories/files to be copied into runtime-image, using colon ":" to split up source and destination paths.
+                    description: Paths list of directories/files to be copied into
+                      runtime-image, using colon ":" to split up source and destination
+                      paths.
                     items:
                       type: string
                     type: array
                   run:
-                    description: Run arbitrary commands to run before copying data into runtime-image.
+                    description: Run arbitrary commands to run before copying data
+                      into runtime-image.
                     items:
                       type: string
                     type: array
@@ -163,20 +187,24 @@ spec:
                     type: string
                 type: object
               source:
-                description: Source refers to the Git repository containing the source code to be built.
+                description: Source refers to the Git repository containing the source
+                  code to be built.
                 properties:
                   contextDir:
                     description: ContextDir is a path to subfolder in the repo. Optional.
                     type: string
                   credentials:
-                    description: SecretRef refers to the secret that contains credentials to access the git repo. Optional.
+                    description: SecretRef refers to the secret that contains credentials
+                      to access the git repo. Optional.
                     properties:
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
                   flavor:
-                    description: Flavor of the git provider like github, gitlab, bitbucket, generic, etc. Optional.
+                    description: Flavor of the git provider like github, gitlab, bitbucket,
+                      generic, etc. Optional.
                     type: string
                   httpProxy:
                     description: HTTPProxy is optional.
@@ -185,10 +213,12 @@ spec:
                     description: HTTPSProxy is optional.
                     type: string
                   noProxy:
-                    description: NoProxy can be used to specify domains for which no proxying should be performed. Optional.
+                    description: NoProxy can be used to specify domains for which
+                      no proxying should be performed. Optional.
                     type: string
                   revision:
-                    description: Ref is a git reference. Optional. If not defined, it will fallback to the git repository default branch.
+                    description: Ref is a git reference. Optional. If not defined,
+                      it will fallback to the git repository default branch.
                     type: string
                   url:
                     description: URL of the git repo
@@ -197,13 +227,16 @@ spec:
                 - url
                 type: object
               strategy:
-                description: StrategyRef refers to the BuildStrategy to be used to build the container image. There are namespaced scope and cluster scope BuildStrategy
+                description: StrategyRef refers to the BuildStrategy to be used to
+                  build the container image. There are namespaced scope and cluster
+                  scope BuildStrategy
                 properties:
                   apiVersion:
                     description: API version of the referent
                     type: string
                   kind:
-                    description: BuildStrategyKind indicates the kind of the buildstrategy, namespaced or cluster scoped.
+                    description: BuildStrategyKind indicates the kind of the buildstrategy,
+                      namespaced or cluster scoped.
                     type: string
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -224,10 +257,12 @@ spec:
             description: BuildStatus defines the observed state of Build
             properties:
               message:
-                description: The message of the registered Build, either an error or succeed message
+                description: The message of the registered Build, either an error
+                  or succeed message
                 type: string
               reason:
-                description: The reason of the registered Build, it's an one-word camelcase
+                description: The reason of the registered Build, it's an one-word
+                  camelcase
                 type: string
               registered:
                 description: The Register status of the Build

--- a/deploy/crds/shipwright.io_buildstrategies.yaml
+++ b/deploy/crds/shipwright.io_buildstrategies.yaml
@@ -22,13 +22,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BuildStrategy is the Schema representing a strategy in the namespace scope to build images from source code.
+        description: BuildStrategy is the Schema representing a strategy in the namespace
+          scope to build images from source code.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -37,31 +42,57 @@ spec:
             properties:
               buildSteps:
                 items:
-                  description: BuildStep defines a partial step that needs to run in container for building the image.
+                  description: BuildStep defines a partial step that needs to run
+                    in container for building the image.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      description: 'Arguments to the entrypoint. The docker image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                        double $$, ie: $$(VAR_NAME). Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     command:
-                      description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. The $(VAR_NAME) syntax
+                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                        references will never be expanded, regardless of whether the
+                        variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     env:
-                      description: List of environment variables to set in the container. Cannot be updated.
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present in a Container.
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
                                 description: Selects a key of a ConfigMap.
@@ -70,37 +101,52 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, metadata.labels,
+                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                  status.hostIP, status.podIP, status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the specified API version.
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes, optional for env vars'
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
@@ -110,16 +156,22 @@ spec:
                                 - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's namespace
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key must be defined
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -130,28 +182,41 @@ spec:
                         type: object
                       type: array
                     envFrom:
-                      description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be defined
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
                                 description: Specify whether the Secret must be defined
@@ -160,22 +225,41 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
                       type: string
                     imagePullPolicy:
-                      description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                       type: string
                     lifecycle:
-                      description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
                       properties:
                         postStart:
-                          description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
@@ -184,12 +268,16 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -209,38 +297,66 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
-                          description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The reason for termination is passed
+                            to the handler. The Pod''s termination grace period countdown
+                            begins before the PreStop hooked is executed. Regardless
+                            of the outcome of the handler, the container will eventually
+                            terminate within the Pod''s termination grace period.
+                            Other management of the container blocks until the hook
+                            completes or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
@@ -249,12 +365,16 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -274,25 +394,33 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -300,31 +428,47 @@ spec:
                           type: object
                       type: object
                     livenessProbe:
-                      description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -344,71 +488,104 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     name:
-                      description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a single container.
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
-                            description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
                             description: What host IP to bind the external port to.
                             type: string
                           hostPort:
-                            description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
                           name:
-                            description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
                             type: string
                           protocol:
                             default: TCP
-                            description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -419,31 +596,47 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
-                      description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -463,48 +656,65 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     resources:
-                      description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       properties:
                         limits:
                           additionalProperties:
@@ -513,7 +723,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -522,107 +733,187 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     securityContext:
-                      description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      description: 'Security options the pod should run with. More
+                        info: https://kubernetes.io/docs/concepts/policy/security-context/
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                       properties:
                         allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
                           type: boolean
                         capabilities:
-                          description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
                           properties:
                             add:
                               description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                             drop:
                               description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
-                          description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
                           type: boolean
                         procMount:
-                          description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
                           type: string
                         readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem. Default is false.
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
                           type: boolean
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies to the container.
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies to the container.
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies to the container.
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies to the container.
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         windowsOptions:
-                          description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     startupProbe:
-                      description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. This is a beta feature enabled by
+                        the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -642,71 +933,117 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     stdin:
-                      description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
                       type: boolean
                     stdinOnce:
-                      description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
                       type: boolean
                     terminationMessagePath:
-                      description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                       type: string
                     terminationMessagePolicy:
-                      description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
                       type: string
                     tty:
-                      description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be used by the container.
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block device within a container.
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container that the device will be mapped to.
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim in the pod
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -714,27 +1051,40 @@ spec:
                         type: object
                       type: array
                     volumeMounts:
-                      description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume within a container.
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
-                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
-                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
                             type: string
                           name:
                             description: This must match the Name of a Volume.
                             type: string
                           readOnly:
-                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
-                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
-                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -742,7 +1092,9 @@ spec:
                         type: object
                       type: array
                     workingDir:
-                      description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
                       type: string
                   required:
                   - name

--- a/deploy/crds/shipwright.io_clusterbuildstrategies.yaml
+++ b/deploy/crds/shipwright.io_clusterbuildstrategies.yaml
@@ -22,13 +22,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterBuildStrategy is the Schema representing a strategy in the cluster scope to build images from source code.
+        description: ClusterBuildStrategy is the Schema representing a strategy in
+          the cluster scope to build images from source code.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -37,31 +42,57 @@ spec:
             properties:
               buildSteps:
                 items:
-                  description: BuildStep defines a partial step that needs to run in container for building the image.
+                  description: BuildStep defines a partial step that needs to run
+                    in container for building the image.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      description: 'Arguments to the entrypoint. The docker image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                        double $$, ie: $$(VAR_NAME). Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     command:
-                      description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. The $(VAR_NAME) syntax
+                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                        references will never be expanded, regardless of whether the
+                        variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     env:
-                      description: List of environment variables to set in the container. Cannot be updated.
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present in a Container.
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
                                 description: Selects a key of a ConfigMap.
@@ -70,37 +101,52 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, metadata.labels,
+                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                  status.hostIP, status.podIP, status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the specified API version.
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes, optional for env vars'
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
@@ -110,16 +156,22 @@ spec:
                                 - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's namespace
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key must be defined
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -130,28 +182,41 @@ spec:
                         type: object
                       type: array
                     envFrom:
-                      description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be defined
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                 type: string
                               optional:
                                 description: Specify whether the Secret must be defined
@@ -160,22 +225,41 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
                       type: string
                     imagePullPolicy:
-                      description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                       type: string
                     lifecycle:
-                      description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
                       properties:
                         postStart:
-                          description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
@@ -184,12 +268,16 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -209,38 +297,66 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
-                          description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The reason for termination is passed
+                            to the handler. The Pod''s termination grace period countdown
+                            begins before the PreStop hooked is executed. Regardless
+                            of the outcome of the handler, the container will eventually
+                            terminate within the Pod''s termination grace period.
+                            Other management of the container blocks until the hook
+                            completes or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
@@ -249,12 +365,16 @@ spec:
                               description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -274,25 +394,33 @@ spec:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -300,31 +428,47 @@ spec:
                           type: object
                       type: object
                     livenessProbe:
-                      description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -344,71 +488,104 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     name:
-                      description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a single container.
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
-                            description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
                             description: What host IP to bind the external port to.
                             type: string
                           hostPort:
-                            description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
                           name:
-                            description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
                             type: string
                           protocol:
                             default: TCP
-                            description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -419,31 +596,47 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
-                      description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -463,48 +656,65 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     resources:
-                      description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       properties:
                         limits:
                           additionalProperties:
@@ -513,7 +723,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -522,107 +733,187 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     securityContext:
-                      description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      description: 'Security options the pod should run with. More
+                        info: https://kubernetes.io/docs/concepts/policy/security-context/
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                       properties:
                         allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
                           type: boolean
                         capabilities:
-                          description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
                           properties:
                             add:
                               description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                             drop:
                               description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
-                          description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
                           type: boolean
                         procMount:
-                          description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
                           type: string
                         readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root filesystem. Default is false.
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
                           type: boolean
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies to the container.
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies to the container.
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies to the container.
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies to the container.
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         windowsOptions:
-                          description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     startupProbe:
-                      description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. This is a beta feature enabled by
+                        the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -642,71 +933,117 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     stdin:
-                      description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
                       type: boolean
                     stdinOnce:
-                      description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
                       type: boolean
                     terminationMessagePath:
-                      description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                       type: string
                     terminationMessagePolicy:
-                      description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
                       type: string
                     tty:
-                      description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be used by the container.
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block device within a container.
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container that the device will be mapped to.
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim in the pod
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -714,27 +1051,40 @@ spec:
                         type: object
                       type: array
                     volumeMounts:
-                      description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume within a container.
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
-                            description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
-                            description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
                             type: string
                           name:
                             description: This must match the Name of a Volume.
                             type: string
                           readOnly:
-                            description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
-                            description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
-                            description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -742,7 +1092,9 @@ spec:
                         type: object
                       type: array
                     workingDir:
-                      description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
                       type: string
                   required:
                   - name


### PR DESCRIPTION
# Changes

This is a fix PR for the PR: https://github.com/shipwright-io/build/pull/667

I also asked Matt and Zoe to verify, they also generate normally WITH line-breaking, but I tried several ways, all didn't work..... Finally, I gave up, I don't know why there is no `line-breaking` when I ran the `make generate-crds` in my local Mac.

**Maybe because my Mac is more powerful than other ones. :(**

Below is what I tried:
- Ask Matt and Zoe help, they can generate with line-breaking normally on the Mac
- I tried on Ubuntu, can also generate with line-breaking
- Then I tried to upgrade my Golang to 1.15, upgrade/downgrade, my controller-gen, change GOPATH, etc... they all didn't work

Because it is ONLY my Mac problem, so I provide this PR to change to the NORMAL format with line-breaking in this PR.

And I will follow the issue https://github.com/kubernetes-sigs/controller-tools/issues/514#issuecomment-800837188 to see how to solve in future.

Thanks!



/kind misc

# Submitter Checklist

- [ n ] Includes tests if functionality changed/was added
- [ n ] Includes docs if changes are user-facing
- [ y ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ n ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
None