### PR TITLE
Change to main branch in the internal flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Fixes #<insert issue number here>
 - [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
 - [ ] Release notes block has been filled in, or marked NONE
 
-See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
+See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
 for details on coding conventions, github and prow interactions, and the code review process.
 
 # Release Notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 on: 
     pull_request:
-      branches: [ main ]
+      branches:
+      - main
+      - master
     push:
-      branches: [ main ]
+      branches: 
+      - main
+      - master
 name: Unit, Integration, and E2E Tests
 jobs:
     unit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 on: 
     pull_request:
-      branches: [ master ]
+      branches: [ main ]
     push:
-      branches: [ master ]
+      branches: [ main ]
 name: Unit, Integration, and E2E Tests
 jobs:
     unit:

--- a/.github/workflows/sanity-checks.yaml
+++ b/.github/workflows/sanity-checks.yaml
@@ -6,10 +6,10 @@ on:
     tags-ignore:
       - '**'
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/sanity-checks.yaml
+++ b/.github/workflows/sanity-checks.yaml
@@ -7,9 +7,11 @@ on:
       - '**'
     branches:
       - main
+      - master
   pull_request:
     branches:
       - main
+      - master
 
 jobs:
   build:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -67,7 +67,7 @@ Unit tests are designed based on the following:
 - Unit tests must pass in different OS distributions( e.g. linux, macOS ).
 - Unit tests should be run in parallel.
 
-Because we use Ginkgo for this, each controller [package](https://github.com/shipwright-io/build/tree/master/pkg/reconciler) requires a `suite_test.go` file and a relative controller test file. You can generate a suite by running `ginkgo bootstrap` under the package directory. For testing an specific controller class, you can generate the testing class by running `ginkgo generate` under the package directory.
+Because we use Ginkgo for this, each controller [package](https://github.com/shipwright-io/build/tree/main/pkg/reconciler) requires a `suite_test.go` file and a relative controller test file. You can generate a suite by running `ginkgo bootstrap` under the package directory. For testing an specific controller class, you can generate the testing class by running `ginkgo generate` under the package directory.
 
 When building unit-tests, try to follow:
 
@@ -96,8 +96,8 @@ Integration tests are designed based on the following:
 
 Before running these tests, ensure you have:
 
-- A running cluster. You can use Kind, see [installation](https://github.com/shipwright-io/build/blob/master/hack/install-kind.sh)
-- Tekton controllers installed, see [installation](https://github.com/shipwright-io/build/blob/master/hack/install-tekton.sh)
+- A running cluster. You can use Kind, see [installation](https://github.com/shipwright-io/build/blob/main/hack/install-kind.sh)
+- Tekton controllers installed, see [installation](https://github.com/shipwright-io/build/blob/main/hack/install-tekton.sh)
 
 ```sh
 make test-integration


### PR DESCRIPTION
# Changes

As we discussed in the issue: https://github.com/shipwright-io/build/issues/666

We plan to switch the default branch from `master` to `main` branch.

I already provide PR (https://github.com/shipwright-io/build/pull/667) to change the external link to main branch.

This PR is used to change the branch in the internal flow and document:
- Change to use main branch in github action flow
- Change the internal documents to use the link of main instead of master

I have not created the `main` branch now (To avoid the new PR merge problem).

**We should do some preparation actions BEFORE merge this PR!!!**
- Create a `main` branch
- Switch all PRs to main branch: https://github.com/shipwright-io/build/pulls
- Switch the default branch from `master` to `main` in the repo settings

So please the reviewer or admin review this PR and help do the above actions.

Thanks!

/kind cleanup

# Submitter Checklist

- [ n ] Includes tests if functionality changed/was added
- [ n ] Includes docs if changes are user-facing
- [ y ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ y ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Switch the default branch from master to main
```
