### PR TITLE
Git validation is disabled by default

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -86,9 +86,9 @@ A `Build` resource can specify a Git source, together with other parameters like
 - `source.revision` - An specific revision to select from the source repository, this can be a commit or branch name. If not defined, it will fallback to the git repository default branch.
 - `source.contextDir` - For repositories where the source code is not located at the root folder, you can specify this path here. Currently, only supported by `buildah`, `kaniko` and `buildpacks` build strategies.
 
-By default, the Build controller will validate that the Git repository exists. If the validation is not desired, users can define the `build.shipwright.io/verify.repository` annotation with `false`. For example:
+By default, the Build controller won't validate that the Git repository exists. If the validation is desired, users can define the `build.shipwright.io/verify.repository` annotation with `true` explicitly. For example:
 
-Example of a `Build` with the **build.shipwright.io/verify.repository** annotation, in order to disable the `spec.source.url` validation.
+Example of a `Build` with the **build.shipwright.io/verify.repository** annotation, in order to enable the `spec.source.url` validation.
 
 ```yaml
 apiVersion: shipwright.io/v1alpha1
@@ -96,7 +96,7 @@ kind: Build
 metadata:
   name: buildah-golang-build
   annotations:
-    build.shipwright.io/verify.repository: "false"
+    build.shipwright.io/verify.repository: "true"
 spec:
   source:
     url: https://github.com/shipwright-io/sample-go

--- a/pkg/validate/sourceurl.go
+++ b/pkg/validate/sourceurl.go
@@ -27,13 +27,13 @@ type SourceURLRef struct {
 func (s SourceURLRef) ValidatePath(ctx context.Context) error {
 	if s.Build.Spec.Source.SecretRef == nil {
 		switch s.Build.GetAnnotations()[build.AnnotationBuildVerifyRepository] {
-		case "", "true":
+		case "true":
 			err := git.ValidateGitURLExists(s.Build.Spec.Source.URL)
 			if err != nil {
 				s.MarkBuildStatus(s.Build, build.RemoteRepositoryUnreachable, err.Error())
 			}
 			return err
-		case "false":
+		case "", "false":
 			ctxlog.Info(ctx, fmt.Sprintf("the annotation %s is set to %s, nothing to do", build.AnnotationBuildVerifyRepository, s.Build.GetAnnotations()[build.AnnotationBuildVerifyRepository]))
 			return nil
 		default:

--- a/test/build_samples.go
+++ b/test/build_samples.go
@@ -218,6 +218,9 @@ spec:
 const BuildCBSWithWrongURL = `
 apiVersion: shipwright.io/v1alpha1
 kind: Build
+metadata:
+  annotations:
+    build.shipwright.io/verify.repository: "true"
 spec:
   source:
     url: "https://github.foobar.com/sbose78/taxi"

--- a/test/integration/build_to_git_test.go
+++ b/test/integration/build_to_git_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 	})
 
 	Context("when the build source url protocol is a fake http without the verify annotation", func() {
-		It("should validate source url by default", func() {
+		It("should not validate source url by default", func() {
 
 			// populate Build related vars
 			buildName := BUILD + tb.Namespace
@@ -75,11 +75,12 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
 			// wait until the Build finish the validation
-			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
+			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
-			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
-			Expect(buildObject.Status.Message).To(Equal("remote repository unreachable"))
+			// skip validation due to empty annotation
+			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 
@@ -110,7 +111,7 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 	})
 
 	Context("when the build source url protocol is a fake https without the verify annotation", func() {
-		It("should validate source url by default", func() {
+		It("should not validate source url by default", func() {
 
 			// populate Build related vars
 			buildName := BUILD + tb.Namespace
@@ -125,11 +126,12 @@ var _ = Describe("Integration tests Build and referenced Source url", func() {
 			Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
 			// wait until the Build finish the validation
-			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
+			buildObject, err := tb.GetBuildTillRegistration(buildName, corev1.ConditionTrue)
 			Expect(err).To(BeNil())
-			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.RemoteRepositoryUnreachable))
-			Expect(buildObject.Status.Message).To(Equal("remote repository unreachable"))
+			// skip validation due to empty annotation
+			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionTrue))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SucceedStatus))
+			Expect(buildObject.Status.Message).To(Equal(v1alpha1.AllValidationsSucceeded))
 		})
 	})
 


### PR DESCRIPTION
# Changes

Fix issue: https://github.com/shipwright-io/build/issues/659

Default, build controller won't check sourceURL unless `build.shipwright.io/verify.repository` annotation is true.
- Switch to don't validate sourceURL by default.
- Update related unit tests and integration tests.
- Update related docs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

- Git validation behaviour changes
```release-note
sourceURL validation is disabled by default.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
