### PR TITLE
Deprecate .status.succeeded and .status.reason

### DIFF
--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -45,19 +45,27 @@ type BuildRunSpec struct {
 
 // BuildRunStatus defines the observed state of BuildRun
 type BuildRunStatus struct {
-
-	// Conditions
+	// Conditions holds the latest available observations of a resource's current state.
 	Conditions Conditions `json:"conditions,omitempty"`
 
 	// The Succeeded status of the TaskRun
+	//
+	// Deprecated: Use Conditions instead. This will be removed in a future release.
+	//
 	// +optional
 	Succeeded corev1.ConditionStatus `json:"succeeded,omitempty"`
 
 	// The Succeeded reason of the TaskRun
+	//
+	// Deprecated: Use Conditions instead. This will be removed in a future release.
+	//
 	// +optional
 	Reason string `json:"reason,omitempty"`
 
-	// PodName is the name of the pod responsible for executing this task's steps.
+	// LatestTaskRunRef is the name of the TaskRun responsible for executing this BuildRun.
+	//
+	// TODO: This should be called something like "TaskRunName"
+	//
 	// +optional
 	LatestTaskRunRef *string `json:"latestTaskRunRef,omitempty"`
 

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -218,10 +218,13 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 				}
 			}
 
+			//lint:ignore SA1019 should be set until removed
 			buildRun.Status.Succeeded = taskRunStatus
 			if taskRunStatus == corev1.ConditionFalse {
+				//lint:ignore SA1019 should be set until removed
 				buildRun.Status.Reason = trCondition.Message
 			} else {
+				//lint:ignore SA1019 should be set until removed
 				buildRun.Status.Reason = trCondition.Reason
 			}
 
@@ -380,7 +383,9 @@ func (r *ReconcileBuildRun) createTaskRun(ctx context.Context, build *buildv1alp
 // updateBuildRunErrorStatus updates buildRun status fields
 func (r *ReconcileBuildRun) updateBuildRunErrorStatus(ctx context.Context, buildRun *buildv1alpha1.BuildRun, errorMessage string) error {
 	// these two fields are deprecated and will be removed soon
+	//lint:ignore SA1019 should be set until removed
 	buildRun.Status.Succeeded = corev1.ConditionFalse
+	//lint:ignore SA1019 should be set until removed
 	buildRun.Status.Reason = errorMessage
 
 	now := metav1.Now()


### PR DESCRIPTION
A step toward https://github.com/shipwright-io/build/issues/517 -- if people are okay with this we can remove it in the next release (v0.5.0)

# Changes

Marks `.status.succeeded` and `.status.reason` as `Deprecated`, updates some doc comments I noticed while I was in the area.

/kind cleanup

# Submitter Checklist

- [n/a] Includes tests if functionality changed/was added
- [n/a] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
BuildRun .status.succeeded and .status.reason are marked as deprecated in favor of .status.conditions.
```