### PR TITLE
Add support for Buildkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 
 - [Kaniko](https://github.com/GoogleContainerTools/kaniko)
 - [Cloud Native Buildpacks](https://buildpacks.io/)
+- [BuildKit](https://github.com/moby/buildkit)
 - [Buildah](https://buildah.io/)
 
 ## Try It!

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -16,6 +16,10 @@ SPDX-License-Identifier: Apache-2.0
   - [Try it](#try-it)
 - [Kaniko](#kaniko)
   - [Installing Kaniko Strategy](#installing-kaniko-strategy)
+- [BuildKit](#buildkit)
+  - [Cache Exporters](#cache-exporters)
+  - [Known Limitations](#known-limitations)
+  - [Installing BuildKit Strategy](#installing-buildkit-strategy)
 - [ko](#ko)
   - [Installing ko Strategy](#installing-ko-strategy)
 - [Source to Image](#source-to-image)
@@ -102,6 +106,34 @@ To install the cluster scope strategy, use:
 
 ```sh
 kubectl apply -f samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+```
+
+---
+
+## BuildKit
+
+[BuildKit](https://github.com/moby/buildkit) is composed of the `buildctl` client and the `buildkitd` daemon. For the `buildkit` ClusterBuildStrategy, it runs on a [daemonless](https://github.com/moby/buildkit#daemonless) mode, where both client and ephemeral daemon run in a single container. In addition, it runs without privileges ( _[rootless](https://github.com/moby/buildkit/blob/master/docs/rootless.md)_ ).
+
+The `buildkit-insecure` ClusterBuildStrategy exists to support users pushing to an insecure HTTP registry. We use this strategy at the moment only for testing purposes against a local in-cluster registry. In the future, this strategy will be removed in favor of a single one where users can parameterize the secure/insecure behaviour.
+
+### Cache Exporters
+
+By default, the `buildkit` ClusterBuildStrategy will use caching to optimize the build times. When pushing an image to a registry, it will use the `inline` export cache, which pushes the image and cache together. Please refer to [export-cache docs](https://github.com/moby/buildkit#export-cache) for more information.
+
+### Known Limitations
+
+The `buildkit` ClusterBuildStrategy currently locks the following parameters:
+
+- A `Dockerfile` name needs to be `Dockerfile`, this is currently not configurable.
+- Exporter caches are enable by default, this is currently not configurable.
+- To allow running rootless, it requires both [AppArmor](https://kubernetes.io/docs/tutorials/clusters/apparmor/) as well as [SecComp](https://kubernetes.io/docs/tutorials/clusters/seccomp/) to be disabled using the `unconfined` profile.
+
+### Installing BuildKit Strategy
+
+To install the cluster scope strategy, use:
+
+```sh
+kubectl apply -f samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
 ```
 
 ---

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -34,6 +34,7 @@ The default installation includes these [buildstrategies](/docs/buildstrategies.
 
 * [Buildpacks-v3](docs/buildstrategies.md#buildpacks-v3)
 * [Kaniko](docs/buildstrategies.md#kaniko)
+* [BuildKit](docs/buildstrategies.md#buildkit)
 * [Source-to-Image](docs/buildstrategies.md#source-to-image)
 * [Buildah](docs/buildstrategies.md#buildah)
 * [ko](docs/buildstrategies.md#ko)
@@ -46,15 +47,17 @@ For more information about strategies see the related [docs](/docs/buildstrategi
 
 * [Example with Buildpacks](/docs/tutorials/building_with_buildpacks.md)
 
+* [Example with BuildKit](/docs/tutorials/building_with_buildkit.md)
+
 Depending on your source code you might want to try a specific example. The following table serves as a guide to help you understand which
 strategy to choose:
 
 | Sample code | Repository | ContextDir | Strategy Type | Strategy to use |
 | ----------- | ----------- | ------------- | ------------- | ------------- |
-| A go app with a Dockerfile | [shipwright-io/sample-go](https://github.com/shipwright-io/sample-go) | `/docker-build` | Dockerfile-based | Kaniko, Buildah |
+| A go app with a Dockerfile | [shipwright-io/sample-go](https://github.com/shipwright-io/sample-go) | `/docker-build` | Dockerfile-based | Kaniko, BuildKit, Buildah |
 | A go app | [shipwright-io/sample-go](https://github.com/shipwright-io/sample-go) | `/source-build` | Dockerfile-less | buildpacks-v3, buildpacks-v3-heroku |
 | A ruby app | [shipwright-io/sample-ruby](https://github.com/shipwright-io/sample-ruby) | `/source-build` | Dockerfile-less | buildpacks-v3, buildpacks-v3-heroku |
-| A java app with a Dockerfile | [hipwright-io/sample-jave](https://github.com/shipwright-io/sample-java) | `/docker-build` | Dockerfile-based | Kaniko, Buildah |
+| A java app with a Dockerfile | [shipwright-io/sample-java](https://github.com/shipwright-io/sample-java) | `/docker-build` | Dockerfile-based | Kaniko, BuildKit, Buildah |
 | Shipwright/Build | [shipwright-io/build](https://github.com/shipwright-io/build) |  `/cmd/manager` | Dockerfile-less | ko |
 
 _Note_: `ContextDir` is the path under the repository where the source code is located.

--- a/docs/tutorials/building_with_buildkit.md
+++ b/docs/tutorials/building_with_buildkit.md
@@ -1,0 +1,129 @@
+
+# Building with BuildKit
+
+Before starting, make sure you have Tekton and Shipwright Build installed.
+
+See the [Try It!](../../README.md#try-it) section for more information.
+
+## Getting Started
+
+### Registry Authentication
+
+For this tutorial, we will require to create a `tutorial-secret` Kubernetes secret to access a [DockerHub](https://hub.docker.com/) registry, as follows:
+
+```sh
+$ REGISTRY_SERVER=https://index.docker.io/v1/ REGISTRY_USER=<your_registry_user> REGISTRY_PASSWORD=<your_registry_password>
+$ kubectl create secret docker-registry tutorial-secret --docker-server=$REGISTRY_SERVER --docker-username=$REGISTRY_USER --docker-password=$REGISTRY_PASSWORD  --docker-email=me@here.com
+```
+
+_Note_: For more information about authentication, please refer to the related [docs](/docs/development/authentication.md).
+
+## Create the strategy
+
+Ensure all strategies are in place, see the [Try It!](../../README.md#try-it) section for more information.
+
+```sh
+$ kubectl get cbs
+NAME              AGE
+buildah           96s
+buildkit          78s
+buildkit-insecure 78s
+buildpacks-v3     96s
+kaniko            96s
+ko                96s
+source-to-image   96s
+```
+
+_Note_: For more information about strategies, please refer to the related [docs](/docs/buildstrategies.md).
+
+## Creating a Build
+
+For the Build definition, we will require the following:
+
+- A GitHub repository containing a Go [application](https://github.com/shipwright-io/sample-go/tree/main/docker-build) that requires a `Dockerfile`.
+- The `tutorial-secret` we just created.
+- The `buildkit` ClusterBuildStrategy.
+
+Let's apply our Build and wait for it to be ready:
+
+```bash
+$ export REGISTRY_ORG=<your_registry_org>
+$ cat <<EOF | kubectl apply -f -
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: go-tutorial-buildkit
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-go
+    contextDir: docker-build/
+  dockerfile: docker-build/
+  strategy:
+    name: buildkit
+    kind: ClusterBuildStrategy
+  output:
+    image: docker.io/${REGISTRY_ORG}/go-tutorial:latest
+    credentials:
+      name: tutorial-secret
+EOF
+```
+
+_Note_: Pay attention to the definition under `spec.source.dockerfile`. The `buildkit` expects a path to where your `Dockerfile` is located.
+
+Verify that the `go-tutorial` Build was created successfully:
+
+```sh
+$ kubectl get build
+NAME                         REGISTERED   REASON      BUILDSTRATEGYKIND      BUILDSTRATEGYNAME   CREATIONTIME
+go-tutorial-buildkit         True         Succeeded   ClusterBuildStrategy   buildkit            4s
+```
+
+_Note_: For more information about Build resources, please refer to the related [docs](/docs/build.md).
+
+## Creating a BuildRun
+
+Second, we will create a `BuildRun` resource that references our previous `go-tutorial` Build:
+
+```sh
+$ cat <<EOF | kubectl create -f -
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+metadata:
+  name: a-buildkit-buildrun
+spec:
+  buildRef:
+    name: go-tutorial-buildkit
+EOF
+```
+
+Wait until your `go-tutorial-buildrun` buildrun is completed:
+
+```sh
+$ kubectl get buildrun
+NAME                  SUCCEEDED   REASON    STARTTIME   COMPLETIONTIME
+a-buildkit-buildrun   Unknown     Pending   4s
+```
+
+To know more about the state of the BuildRun, the `.Status.Conditions` fields provide more data:
+
+```sh
+$ kubectl get buildrun a-buildkit-buildrun -o json | jq '.status.conditions[]'
+{
+  "lastTransitionTime": "2021-04-01T09:15:13Z",
+  "message": "All Steps have completed executing",
+  "reason": "Succeeded",
+  "status": "True",
+  "type": "Succeeded"
+}
+```
+
+_Note_: A BuildRun is a resource that runs to completion. The `REASON` column reflects the state of the resource. If the BuildRun ran to completion successfully,
+a `Succeeded` `REASON` is expected.
+
+_Note_: For more information about BuildRun resources, please refer to the related [docs](/docs/buildrun.md).
+
+## Closing
+
+Congratulations! You just created a container image from https://github.com/shipwright-io/sample-go using [BuildKit](https://github.com/moby/buildkit).
+
+The new container image should now be available in your container registry.

--- a/samples/build/build_buildkit_cr.yaml
+++ b/samples/build/build_buildkit_cr.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: buildkit-build
+  annotations:
+    build.build.dev/build-run-deletion: "true"
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-go
+    contextDir: docker-build/
+  # Note: This needs to be a path to where the Dockerfile is located, it cannot contain the file name
+  dockerfile: docker-build/
+  strategy:
+    name: buildkit
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app
+

--- a/samples/buildrun/buildrun_buildkit_cr.yaml
+++ b/samples/buildrun/buildrun_buildkit_cr.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+metadata:
+  name: buildkit-buildrun
+spec:
+  buildRef:
+    name: buildkit-build
+  serviceAccount:
+    generate: true

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: shipwright.io/v1alpha1
+kind: ClusterBuildStrategy
+metadata:
+  name: buildkit
+  annotations:
+    # See https://github.com/moby/buildkit/blob/master/docs/rootless.md#about---oci-worker-no-process-sandbox for more information
+    container.apparmor.security.beta.kubernetes.io/step-build-and-push: unconfined
+    # The usage of seccomp annotation will be deprecate in k8s v1.22.0, see
+    # https://kubernetes.io/docs/tutorials/clusters/seccomp/#create-a-pod-with-a-seccomp-profile-for-syscall-auditing for more information
+    container.seccomp.security.alpha.kubernetes.io/step-build-and-push: unconfined
+spec:
+  buildSteps:
+    - name: prepare
+      image: alpine:latest
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add:
+            - CHOWN
+      command:
+        - /bin/sh
+      args:
+        - -c
+        - |
+          set -exuo pipefail
+          whoami
+          chown -R 1000:1000 /tekton/home
+    - name: build-and-push
+      image: moby/buildkit:master-rootless
+      workingDir: /workspace/source/
+      env:
+      - name: DOCKER_CONFIG
+        value: /tekton/home/.docker
+      # See https://github.com/moby/buildkit/blob/master/docs/rootless.md#about---oci-worker-no-process-sandbox for more information
+      - name: BUILDKITD_FLAGS
+        value: --oci-worker-no-process-sandbox
+      command:
+        - buildctl-daemonless.sh
+      args:
+        - build
+        - --progress=plain
+        - --frontend=dockerfile.v0
+        - --local
+        - context=/workspace/source/$(build.source.contextDir)
+        - --local
+        - dockerfile=/workspace/source/$(build.dockerfile)
+        - --output
+        - type=image,name=$(build.output.image),push=true,registry.insecure=false
+        - --export-cache
+        - type=inline
+        - --import-cache
+        - type=registry,ref=$(build.output.image)

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: shipwright.io/v1alpha1
+kind: ClusterBuildStrategy
+metadata:
+  name: buildkit-insecure
+  annotations:
+    # See https://github.com/moby/buildkit/blob/master/docs/rootless.md#about---oci-worker-no-process-sandbox for more information
+    container.apparmor.security.beta.kubernetes.io/step-build-and-push: unconfined
+    # The usage of seccomp annotation will be deprecate in k8s v1.22.0, see
+    # https://kubernetes.io/docs/tutorials/clusters/seccomp/#create-a-pod-with-a-seccomp-profile-for-syscall-auditing for more information
+    container.seccomp.security.alpha.kubernetes.io/step-build-and-push: unconfined
+spec:
+  buildSteps:
+    - name: prepare
+      image: alpine:latest
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add:
+            - CHOWN
+      command:
+        - /bin/sh
+      args:
+        - -c
+        - |
+          set -exuo pipefail
+          whoami
+          chown -R 1000:1000 /tekton/home
+    - name: build-and-push
+      image: moby/buildkit:master-rootless
+      workingDir: /workspace/source/
+      env:
+      - name: DOCKER_CONFIG
+        value: /tekton/home/.docker
+      # See https://github.com/moby/buildkit/blob/master/docs/rootless.md#about---oci-worker-no-process-sandbox for more information
+      - name: BUILDKITD_FLAGS
+        value: --oci-worker-no-process-sandbox
+      command:
+        - buildctl-daemonless.sh
+      args:
+        - build
+        - --progress=plain
+        - --frontend=dockerfile.v0
+        - --local
+        - context=/workspace/source/$(build.source.contextDir)
+        - --local
+        - dockerfile=/workspace/source/$(build.dockerfile)
+        - --output
+        - type=image,name=$(build.output.image),push=true,registry.insecure=true
+        - --export-cache
+        - type=inline
+        - --import-cache
+        - type=registry,ref=$(build.output.image)

--- a/test/data/build_buildkit_cr_insecure_registry.yaml
+++ b/test/data/build_buildkit_cr_insecure_registry.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: buildkit-build
+  annotations:
+    build.build.dev/build-run-deletion: "true"
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-go
+    contextDir: docker-build/
+  # Note: This needs to be a path to where the Dockerfile is located, it cannot contain the file name
+  dockerfile: docker-build/
+  strategy:
+    # Use the insecure strategy to push to an insecure HTTP registry
+    name: buildkit-insecure
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app
+

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -358,6 +358,27 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
+	Context("when a Buildkit build with a contextDir and a path to a Dockerfile is defined", func() {
+
+		BeforeEach(func() {
+			testID = generateTestID("buildkit-custom-context")
+
+			// create the build definition
+			build = createBuild(
+				testBuild,
+				testID,
+				"test/data/build_buildkit_cr_insecure_registry.yaml",
+			)
+		})
+
+		It("successfully runs a build", func() {
+			buildRun, err = buildRunTestData(testBuild.Namespace, testID, "samples/buildrun/buildrun_buildkit_cr.yaml")
+			Expect(err).ToNot(HaveOccurred())
+
+			validateBuildRunToSucceed(testBuild, buildRun)
+		})
+	})
+
 	Context("when a s2i build is defined", func() {
 
 		BeforeEach(func() {


### PR DESCRIPTION
# Changes

Fixes #407 

This adds support for rootless buildkit.

Some of the key things from using buildkit are:
- The cache on subsequent pushes to the same image in a registry, also known as export_cache and import_cache makes the building experience incredible fast.
- It runs as rootless, without any privileges.
- It have a better way to handle where the source code is located and where is the dockerfile located (_e.g. compared to Kaniko_), however we will need to extend our strategy params to support a new one. At the moment, some of the configs for running it are not configurable, but with the upcoming params support, this will change. I documented this limitations in the related document.
- Latest Docker versions come with the option to opt-in for a backend Buildkit, therefore its very popular and we should provide support for it.


This adds an `insecure` strategy, so that we can push to the insecure local in-cluster HTTP registry in e2e tests, otherwise it will not work with a secure one.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Provide support for rootless Buildkit as a new Build Strategy.
```
