### PR TITLE
Update generated CRDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
             kubernetes:
               # Only v1.18 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
               #- v1.17.17
-              - v1.18.15
-              #- v1.19.7
+              #- v1.18.15
+              - v1.19.7
               #- v1.20.2
           max-parallel: 1
         runs-on: ${{ matrix.os }}
@@ -74,8 +74,8 @@ jobs:
             kubernetes:
               # Only v1.18 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
               #- v1.17.17
-              - v1.18.15
-              #- v1.19.7
+              #- v1.18.15
+              - v1.19.7
               #- v1.20.2
           max-parallel: 2
         runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ as [Kaniko](https://github.com/GoogleContainerTools/kaniko),
 
 ## Dependencies
 
-| Dependency                                | Supported versions                     |
-| ----------------------------------------- | -------------------------------------- |
-| [Kubernetes](https://kubernetes.io/)      | v1.15.\*, v1.16.\*, v1.17.\*, v1.18.\* |
-| [Tekton](https://tekton.dev) | v0.21.0                                |
+| Dependency                           | Supported versions           |
+| -------------------------------------| ---------------------------- |
+| [Kubernetes](https://kubernetes.io/) | v1.17.\*, v1.18.\*, v1.19.\* |
+| [Tekton](https://tekton.dev)         | v0.21.0                      |
 
 ## Build Strategies
 

--- a/deploy/crds/shipwright.io_buildstrategies.yaml
+++ b/deploy/crds/shipwright.io_buildstrategies.yaml
@@ -115,9 +115,10 @@ spec:
                                 type: object
                               fieldRef:
                                 description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, metadata.labels,
-                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
-                                  status.hostIP, status.podIP, status.podIPs.'
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
                                     description: Version of the schema the FieldPath
@@ -839,6 +840,30 @@ spec:
                               description: User is a SELinux user label that applies
                                 to the container.
                               type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
+                              type: string
+                          required:
+                          - type
                           type: object
                         windowsOptions:
                           description: The Windows specific settings applied to all

--- a/deploy/crds/shipwright.io_clusterbuildstrategies.yaml
+++ b/deploy/crds/shipwright.io_clusterbuildstrategies.yaml
@@ -115,9 +115,10 @@ spec:
                                 type: object
                               fieldRef:
                                 description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, metadata.labels,
-                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
-                                  status.hostIP, status.podIP, status.podIPs.'
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
                                     description: Version of the schema the FieldPath
@@ -839,6 +840,30 @@ spec:
                               description: User is a SELinux user label that applies
                                 to the container.
                               type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
+                              type: string
+                          required:
+                          - type
                           type: object
                         windowsOptions:
                           description: The Windows specific settings applied to all

--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -25,7 +25,7 @@ kind --version
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
 # kind cluster version
-KIND_CLUSTER_VERSION="${KIND_CLUSTER_VERSION:-v1.18.2}"
+KIND_CLUSTER_VERSION="${KIND_CLUSTER_VERSION:-v1.19.7}"
 
 echo "# Creating a new Kubernetes cluster..."
 kind create cluster --quiet --name="${KIND_CLUSTER_NAME}" --image="kindest/node:${KIND_CLUSTER_VERSION}" --wait=120s


### PR DESCRIPTION
# Changes

With the recent Tekton and Kube API update, we now have the 1.19 versions of Kubernetes. But, it seems the CRDs were not regenerated as the new seccompProfile field in the securityContext is not yet there. I ran `make generate-crds` to get the changes.

I am also changing our tests to run with Kubernetes 1.19 and the README to mention this version. Also removing old versions that as far as I remember do not work (not remembering the detail though) when I tried to run multiple versions in our CI tests.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

Setting release note none because the original change and this fix will go in the same release.

# Release Notes

```release-note
NONE
```
