### PR TITLE
Remove unused fields from GitSource

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -261,20 +261,6 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                      flavor:
-                        description: Flavor of the git provider like github, gitlab,
-                          bitbucket, generic, etc. Optional.
-                        type: string
-                      httpProxy:
-                        description: HTTPProxy is optional.
-                        type: string
-                      httpsProxy:
-                        description: HTTPSProxy is optional.
-                        type: string
-                      noProxy:
-                        description: NoProxy can be used to specify domains for which
-                          no proxying should be performed. Optional.
-                        type: string
                       revision:
                         description: Ref is a git reference. Optional. If not defined,
                           it will fallback to the git repository default branch.

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -202,20 +202,6 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                  flavor:
-                    description: Flavor of the git provider like github, gitlab, bitbucket,
-                      generic, etc. Optional.
-                    type: string
-                  httpProxy:
-                    description: HTTPProxy is optional.
-                    type: string
-                  httpsProxy:
-                    description: HTTPSProxy is optional.
-                    type: string
-                  noProxy:
-                    description: NoProxy can be used to specify domains for which
-                      no proxying should be performed. Optional.
-                    type: string
                   revision:
                     description: Ref is a git reference. Optional. If not defined,
                       it will fallback to the git repository default branch.

--- a/pkg/apis/build/v1alpha1/gitsource.go
+++ b/pkg/apis/build/v1alpha1/gitsource.go
@@ -22,18 +22,6 @@ type GitSource struct {
 	// +optional
 	ContextDir *string `json:"contextDir,omitempty"`
 
-	// HTTPProxy is optional.
-	HTTPProxy string `json:"httpProxy,omitempty"`
-
-	// HTTPSProxy is optional.
-	HTTPSProxy string `json:"httpsProxy,omitempty"`
-
-	// NoProxy can be used to specify domains for which no proxying should be performed. Optional.
-	NoProxy string `json:"noProxy,omitempty"`
-
 	// SecretRef refers to the secret that contains credentials to access the git repo. Optional.
 	SecretRef *corev1.LocalObjectReference `json:"credentials,omitempty"`
-
-	// Flavor of the git provider like github, gitlab, bitbucket, generic, etc. Optional.
-	Flavor string `json:"flavor,omitempty"`
 }


### PR DESCRIPTION
Fixes https://github.com/shipwright-io/build/issues/682

# Changes

Remove `HTTPProxy`, `HTTPSProxy`, `NoProxy` and `Flavor`. No other code referenced them, so if users set these fields they wouldn't have any effect.

/kind cleanup
/kind api-change

# Submitter Checklist

- [n] Includes tests if functionality changed/was added
- [n] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-notes
Remove unused fields from GitSource
```

/assign @sbose78 