### PR TITLE
Rename `SpecRuntimeSecretRefNotFound` -> `SpecBuilderSecretRefNotFound`

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -52,7 +52,7 @@ In order to prevent users from triggering `BuildRuns` (_execution of a Build_) t
 | SetOwnerReferenceFailed   | Setting ownerreferences between a Build and a BuildRun failed. This is triggered when making use of the `build.shipwright.io/build-run-deletion` annotation in a Build. |
 | SpecSourceSecretNotFound | The secret used to authenticate to git doesn´t exist. |
 | SpecOutputSecretRefNotFound | The secret used to authenticate to the container registry doesn´t exist. |
-| SpecRuntimeSecretRefNotFound | The secret used to authenticate to the container registry doesn´t exist.|
+| SpecBuilderSecretRefNotFound | The secret used to authenticate to the container registry doesn´t exist.|
 | MultipleSecretRefNotFound | More than one secret is missing. At the moment, only three paths on a Build can specify a secret. |
 | RuntimePathsCanNotBeEmpty | The Runtime feature is used, but the runtime path was not defined. This is mandatory. |
 | RemoteRepositoryUnreachable | The defined `spec.source.url` was not found. This validation only take place for http/https protocols. |

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -26,8 +26,8 @@ const (
 	SpecSourceSecretRefNotFound BuildReason = "SpecSourceSecretRefNotFound"
 	// SpecOutputSecretRefNotFound indicates the referenced secret in output is missing
 	SpecOutputSecretRefNotFound BuildReason = "SpecOutputSecretRefNotFound"
-	// SpecRuntimeSecretRefNotFound indicates the referenced secret in runtime is missing
-	SpecRuntimeSecretRefNotFound BuildReason = "SpecRuntimeSecretRefNotFound"
+	// SpecBuilderSecretRefNotFound indicates the referenced secret in builder is missing
+	SpecBuilderSecretRefNotFound BuildReason = "SpecBuilderSecretRefNotFound"
 	// MultipleSecretRefNotFound indicates that multiple secrets are missing
 	MultipleSecretRefNotFound BuildReason = "MultipleSecretRefNotFound"
 	// RuntimePathsCanNotBeEmpty indicates that the spec.runtime feature is used but the paths were not specified

--- a/pkg/reconciler/build/build_test.go
+++ b/pkg/reconciler/build/build_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Reconcile Build", func() {
 				}
 				buildSample.Spec.Output.SecretRef = nil
 
-				statusCall := ctl.StubFunc(corev1.ConditionFalse, build.SpecRuntimeSecretRefNotFound, "referenced secret non-existing not found")
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, build.SpecBuilderSecretRefNotFound, "referenced secret non-existing not found")
 				statusWriter.UpdateCalls(statusCall)
 
 				_, err := reconciler.Reconcile(request)

--- a/pkg/validate/secrets.go
+++ b/pkg/validate/secrets.go
@@ -62,7 +62,7 @@ func (s SecretRef) buildSecretReferences() map[string]build.BuildReason {
 		secretRefMap[s.Build.Spec.Source.SecretRef.Name] = build.SpecSourceSecretRefNotFound
 	}
 	if s.Build.Spec.BuilderImage != nil && s.Build.Spec.BuilderImage.SecretRef != nil && s.Build.Spec.BuilderImage.SecretRef.Name != "" {
-		secretRefMap[s.Build.Spec.BuilderImage.SecretRef.Name] = build.SpecRuntimeSecretRefNotFound
+		secretRefMap[s.Build.Spec.BuilderImage.SecretRef.Name] = build.SpecBuilderSecretRefNotFound
 	}
 	return secretRefMap
 }

--- a/test/integration/build_to_secrets_test.go
+++ b/test/integration/build_to_secrets_test.go
@@ -309,7 +309,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err = tb.GetBuildTillRegistration(buildName, corev1.ConditionFalse)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecRuntimeSecretRefNotFound))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecBuilderSecretRefNotFound))
 			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.BuilderImage.SecretRef.Name)))
 
 		})
@@ -330,7 +330,7 @@ var _ = Describe("Integration tests Build and referenced Secrets", func() {
 			buildObject, err := tb.GetBuildTillValidation(buildName)
 			Expect(err).To(BeNil())
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecRuntimeSecretRefNotFound))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.SpecBuilderSecretRefNotFound))
 			Expect(buildObject.Status.Message).To(Equal(fmt.Sprintf("referenced secret %s not found", buildObject.Spec.BuilderImage.SecretRef.Name)))
 
 			sampleSecret := tb.Catalog.SecretWithAnnotation(buildObject.Spec.BuilderImage.SecretRef.Name, buildObject.Namespace)


### PR DESCRIPTION
# Changes

The status seems to be misnamed, since it only applies when the `builder` image's secretRef isn't found, and isn't related to the runtime-image feature as far as I can tell.

This was mainly a scripted change:

```
git grep -l "SpecRuntimeSecretRefNotFound" | xargs sed -i '' -e 's/SpecRuntimeSecretRefNotFound/SpecBuilderSecretRefNotFound/g'
```

... with one manual change in a doc comment.

/kind cleanup

# Submitter Checklist

- [y] Includes tests if functionality changed/was added
- [y] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Status reason "SpecRuntimeSecretRefNotFound" changed to "SpecBuilderSecretRefNotFound" to accurately reflect its use.
```

/assign @qu1queee 