### PR TITLE
Tag nightly releases to avoid quay GC

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -41,7 +41,7 @@ jobs:
         IMAGE_HOST: quay.io
         IMAGE: shipwright/shipwright-operator
       run: |
-        make release
+        TAG="nightly-${{ steps.date.outputs.date }}" make release
         mv release.yaml nightly-${{ steps.date.outputs.date }}.yaml
         mv release-debug.yaml nightly-${{ steps.date.outputs.date }}-debug.yaml
 


### PR DESCRIPTION
# Changes

Update nightly release workflow to add a tag to images it produces, like `:nightly-{date}-{seconds}`

Quay.io aggressively garbage collects untagged manifests, so our nightly release images are no longer available after a few days, for example [`@sha256:a930c8`](https://quay.io/repository/shipwright/shipwright-operator/manifest/sha256:a930c8b8b04f856ce505209aee87d0d938b3f761081ae4811c95ad03881ea491) from our [2021-03-18 nightly release](https://github.com/shipwright-io/build/releases/download/nightly/nightly-2021-03-18-1616044224.yaml).

Applying tags to these images should keep them from getting GCed.

/kind bug

# Submitter Checklist

- [n] Includes tests if functionality changed/was added
- [n] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Tag nightly release images to avoid registry garbage collection
```

/assign @qu1queee 