### PR TITLE
Update KinD version to the same v0.10.0

### DIFF
--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -11,7 +11,7 @@
 set -eu
 
 # kind version
-KIND_VERSION="${KIND_VERSION:-v0.8.0}"
+KIND_VERSION="${KIND_VERSION:-v0.10.0}"
 
 if [ ! -f "${GOPATH}/bin/kind" ] ; then
     echo "# Installing KinD..."


### PR DESCRIPTION
Update KinD version to the same v0.10.0

# Changes

Sync the `KinD` version with GitHub Action config: https://github.com/shipwright-io/build/blob/master/.github/workflows/ci.yml#L53

Update to the same version

/kind cleanup

# Submitter Checklist

- [ n ] Includes tests if functionality changed/was added
- [ n ] Includes docs if changes are user-facing
- [ y ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ n ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
```release-note
NONE
```