### PR TITLE
Fix nil-pointer dereference of BuildSpec Strategy

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -105,6 +105,16 @@ type BuildSpec struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
+// StrategyName returns the name of the configured strategy, or 'undefined' in
+// case the strategy is nil (not set)
+func (buildSpec *BuildSpec) StrategyName() string {
+	if buildSpec.Strategy == nil {
+		return "undefined (nil strategy)"
+	}
+
+	return buildSpec.Strategy.Name
+}
+
 // Image refers to an container image with credentials
 type Image struct {
 	// Image is the reference of the image.

--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -244,7 +244,21 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(serviceAccount.Name).To(Equal(buildRunSample.Name + "-sa"))
 				Expect(serviceAccount.Namespace).To(Equal(buildRunSample.Namespace))
 			})
+
+			It("should not panic in case the build spec strategy is nil", func() {
+				// As long as the Strategy is a pointer, it can happen that the
+				// field is nil. During processing, the BuildSpec is copied
+				// from the respective Build. In case Strategy is nil, the
+				// controller should not panic.
+				buildRunSample.Status.BuildSpec.Strategy = nil
+				Expect(func() {
+					result, err := reconciler.Reconcile(taskRunRequest)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(result).ToNot(BeNil())
+				}).ShouldNot(Panic())
+			})
 		})
+
 		Context("from an existing TaskRun with Conditions", func() {
 			BeforeEach(func() {
 


### PR DESCRIPTION
# Changes

There were cases in which the Build had a `nil` Strategy, which is copied into
the BuildRun `Status.BuildSpec` and later used internally, for example the
metrics code is using the `Strategy` field. In case it is `nil`, the function
call for the metrics failed with a nil-pointer dereference.

Introduce `BuildSpec` convenience function called `StrategyName` to return the
name of the strategy, which includes a `nil` safety check.

Replace all occurrences of `BuildSpec.Strategy.Name` with the newly introduced
function to avoid panics.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fix nil-pointer dereference with panic in case Build spec Strategy field was not set.
```
