### PR TITLE
Add missing log labels

### DIFF
--- a/pkg/validate/sourceurl.go
+++ b/pkg/validate/sourceurl.go
@@ -34,7 +34,7 @@ func (s SourceURLRef) ValidatePath(ctx context.Context) error {
 			}
 			return err
 		case "", "false":
-			ctxlog.Info(ctx, fmt.Sprintf("the annotation %s is set to %s, nothing to do", build.AnnotationBuildVerifyRepository, s.Build.GetAnnotations()[build.AnnotationBuildVerifyRepository]))
+			ctxlog.Info(ctx, fmt.Sprintf("the annotation %s is set to %s, nothing to do", build.AnnotationBuildVerifyRepository, s.Build.GetAnnotations()[build.AnnotationBuildVerifyRepository]), namespace, s.Build.Namespace, name, s.Build.Name)
 			return nil
 		default:
 			var annoErr = fmt.Errorf("the annotation %s was not properly defined, supported values are true or false", build.AnnotationBuildVerifyRepository)

--- a/pkg/validate/strategies.go
+++ b/pkg/validate/strategies.go
@@ -41,7 +41,7 @@ func (s Strategy) ValidatePath(ctx context.Context) error {
 				return fmt.Errorf("unknown strategy kind: %v", *s.Build.Spec.Strategy.Kind)
 			}
 		} else {
-			ctxlog.Info(ctx, "buildStrategy kind is nil, use default NamespacedBuildStrategyKind")
+			ctxlog.Info(ctx, "buildStrategy kind is nil, use default NamespacedBuildStrategyKind", namespace, s.Build.Namespace, name, s.Build.Name)
 			if err := s.validateBuildStrategy(ctx, s.Build.Spec.Strategy.Name, s.Build); err != nil {
 				return err
 			}


### PR DESCRIPTION
# Changes

While looking at some logs of our controller, I noticed that some labels were missing on the `the annotation build.shipwright.io/verify.repository is set to , nothing to do`. Adding them, also checked other build-related validation code.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
