### PR TITLE
Update Kaniko to v1.5.2

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -302,7 +302,7 @@ Please consider the description of the attributes under `.spec.runtime`:
 > Specifying the runtime section will cause a `BuildRun` to push `spec.output.image` twice. First, the image produced by chosen `BuildStrategy` is pushed, and next it gets reused to construct the runtime-image, which is pushed again, overwriting `BuildStrategy` outcome.
 > Be aware, specially in situations where the image push action triggers automation steps. Since the same tag will be reused, you might need to take this in consideration when using runtime-images.
 
-Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v1.5.1` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build controller deployment](../deploy/controller.yaml).
+Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v1.5.2` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build controller deployment](../deploy/controller.yaml).
 
 ## BuildRun deletion
 

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -165,7 +165,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.1
+      image: gcr.io/kaniko-project/executor:v1.5.2
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -210,7 +210,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.1
+      image: gcr.io/kaniko-project/executor:v1.5.2
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ The following environment variables are available:
 | Environment Variable | Description |
 | --- | --- |
 | `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. |
-| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used for the runtime image build instead of the default, for example `gcr.io/kaniko-project/executor:v1.5.1`. |
+| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used for the runtime image build instead of the default, for example `gcr.io/kaniko-project/executor:v1.5.2`. |
 | `BUILD_CONTROLLER_LEADER_ELECTION_NAMESPACE` |  Set the namespace to be used to store the `shipwright-build-controller` lock, by default it is in the same namespace as the controller itself. |
 | `BUILD_CONTROLLER_LEASE_DURATION` |  Override the `LeaseDuration`, which is the duration that non-leader candidates will wait to force acquire leadership. |
 | `BUILD_CONTROLLER_RENEW_DEADLINE` |  Override the `RenewDeadline`, which is the duration that the acting leader will retry refreshing leadership before giving up. |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ const (
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
 	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
-	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.5.1"
+	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.5.2"
 	kanikoImageEnvVar  = "KANIKO_CONTAINER_IMAGE"
 
 	// environment variable to override the buckets

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.1
+      image: gcr.io/kaniko-project/executor:v1.5.2
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -30,7 +30,7 @@ spec:
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
-      image: gcr.io/kaniko-project/executor:v1.5.1
+      image: gcr.io/kaniko-project/executor:v1.5.2
       name: build-and-push
       securityContext:
         runAsUser: 0

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -123,7 +123,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.1
+      image: gcr.io/kaniko-project/executor:v1.5.2
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -173,7 +173,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.1
+      image: gcr.io/kaniko-project/executor:v1.5.2
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0
@@ -288,7 +288,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.1
+      image: gcr.io/kaniko-project/executor:v1.5.2
       workingDir: /workspace/source
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
# Changes

Kaniko v1.5.2 does not contain any new features beside that its image is now signed. So, should not be breaking anything.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The Kaniko build strategy is updated to use v1.5.2 of Kaniko
```
