### PR TITLE
Handle nil buildSpec

### DIFF
--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -108,6 +108,10 @@ type BuildSpec struct {
 // StrategyName returns the name of the configured strategy, or 'undefined' in
 // case the strategy is nil (not set)
 func (buildSpec *BuildSpec) StrategyName() string {
+	if buildSpec == nil {
+		return "undefined (nil buildSpec)"
+	}
+
 	if buildSpec.Strategy == nil {
 		return "undefined (nil strategy)"
 	}


### PR DESCRIPTION
# Changes

We observed a panic over the weekend:

```
Apr 11 15:10:02 shipwright-build-controller-69c6b88498-mc4l9 shipwright-build error E0411 13:10:02.395440       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
Apr 11 15:10:02 shipwright-build-controller-69c6b88498-mc4l9 shipwright-build goroutine 504 [running]:
Apr 11 15:10:02 shipwright-build-controller-69c6b88498-mc4l9 shipwright-build k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1809a00, 0x26b2a90)
	k8s.io/apimachinery@v0.19.7/pkg/util/runtime/runtime.go:74 +0x95
Apr 11 15:10:02 shipwright-build-controller-69c6b88498-mc4l9 shipwright-build k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	k8s.io/apimachinery@v0.19.7/pkg/util/runtime/runtime.go:48 +0x89
Apr 11 15:10:02 shipwright-build-controller-69c6b88498-mc4l9 shipwright-build panic(0x1809a00, 0x26b2a90)
	runtime/panic.go:969 +0x1b9
Apr 11 15:10:02 shipwright-build-controller-69c6b88498-mc4l9 shipwright-build github.com/shipwright-io/build/pkg/apis/build/v1alpha1.(*BuildSpec).StrategyName(...)
	github.com/shipwright-io/build/pkg/apis/build/v1alpha1/build_types.go:111
Apr 11 15:10:02 shipwright-build-controller-69c6b88498-mc4l9 shipwright-build github.com/shipwright-io/build/pkg/reconciler/buildrun.(*ReconcileBuildRun).Reconcile(0xc000a05480, 0xc00a63b780, 0xb, 0xc00f5c3660, 0x20, 0x12f0e073c4e00, 0x0, 0x0, 0x0)
	github.com/shipwright-io/build/pkg/reconciler/buildrun/buildrun.go:282 +0x3724
```

I guess that the buildSpec is `nil`. The root cause why this is so, is not yet clear to me. So far, I am only making a change that I think fixes the panic.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fix a panic while capturing metrics if no buildSpec is set in the BuildRun's status
```
