### PR TITLE
Remove double-quotes arount reference to ZAP_FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,11 +247,11 @@ install-strategies: install-apis
 
 local: vendor install-strategies
 	CONTROLLER_NAME=shipwright-build-controller \
-	go run cmd/manager/main.go "$(ZAP_FLAGS)"
+	go run cmd/manager/main.go $(ZAP_FLAGS)
 
 local-plain: vendor
 	CONTROLLER_NAME=shipwright-build-controller \
-	go run cmd/manager/main.go "$(ZAP_FLAGS)"
+	go run cmd/manager/main.go $(ZAP_FLAGS)
 
 clean:
 	rm -rf $(OUTPUT_DIR)


### PR DESCRIPTION
# Changes

`make local` did not work anymore. The reason were the double-quotes around the references to the ZAP_FLAGS variable. Its value contains multiple flags, with doublequotes it therefore failed:

```
invalid argument "debug --zap-encoder=console" for "--zap-log-level" flag: invalid log level "debug --zap-encoder=console"
```

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
