### PR TITLE
Provide well-documented parameters for source and image for the build strategy author

### DIFF
--- a/pkg/reconciler/buildrun/resources/remote_artifacts.go
+++ b/pkg/reconciler/buildrun/resources/remote_artifacts.go
@@ -31,7 +31,7 @@ func remoteArtifactStep(b *buildv1alpha1.Build, image string) v1beta1.Step {
 	container := v1.Container{
 		Name:       "remote-artifacts",
 		Image:      image,
-		WorkingDir: workspaceDir,
+		WorkingDir: fmt.Sprintf("$(params.%s%s)", prefixParamsResults, paramSourceRoot),
 		Command:    []string{"/bin/sh"},
 		Args:       append([]string{"-e", "-x", "-c"}, strings.Join(script, " ; ")),
 	}

--- a/pkg/reconciler/buildrun/resources/runtime_image_test.go
+++ b/pkg/reconciler/buildrun/resources/runtime_image_test.go
@@ -92,7 +92,7 @@ var _ = Describe("runtime-image", func() {
 			Expect(dockerfile).ToNot(BeNil())
 
 			Expect(fmt.Sprintf("\n%s", dockerfile)).To(Equal(`
-FROM test/output-image:latest as builder
+FROM $(params.shp-output-image) as builder
 
 FROM test/base-image:latest
 ENV ENVIRONMENT_VARIABLE="VALUE"

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -7,16 +7,16 @@ spec:
   buildSteps:
     - name: buildah-bud
       image: quay.io/buildah/stable:latest
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
       command:
         - /usr/bin/buildah
       args:
         - bud
-        - --tag=$(build.output.image)
+        - --tag=$(params.shp-output-image)
         - --file=$(build.dockerfile)
-        - $(build.source.contextDir)
+        - $(params.shp-source-context)
       resources:
         limits:
           cpu: 500m
@@ -36,8 +36,8 @@ spec:
       args:
         - push
         - --tls-verify=false
-        - $(build.output.image)
-        - docker://$(build.output.image)
+        - $(params.shp-output-image)
+        - docker://$(params.shp-output-image)
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -28,7 +28,7 @@ spec:
           chown -R 1000:1000 /tekton/home
     - name: build-and-push
       image: moby/buildkit:master-rootless
-      workingDir: /workspace/source/
+      workingDir: $(params.shp-source-root)
       env:
       - name: DOCKER_CONFIG
         value: /tekton/home/.docker
@@ -42,12 +42,12 @@ spec:
         - --progress=plain
         - --frontend=dockerfile.v0
         - --local
-        - context=/workspace/source/$(build.source.contextDir)
+        - context=$(params.shp-source-context)
         - --local
-        - dockerfile=/workspace/source/$(build.dockerfile)
+        - dockerfile=$(params.shp-source-root)/$(build.dockerfile)
         - --output
-        - type=image,name=$(build.output.image),push=true,registry.insecure=false
+        - type=image,name=$(params.shp-output-image),push=true,registry.insecure=false
         - --export-cache
         - type=inline
         - --import-cache
-        - type=registry,ref=$(build.output.image)
+        - type=registry,ref=$(params.shp-output-image)

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
@@ -28,7 +28,7 @@ spec:
           chown -R 1000:1000 /tekton/home
     - name: build-and-push
       image: moby/buildkit:master-rootless
-      workingDir: /workspace/source/
+      workingDir: $(params.shp-source-root)
       env:
       - name: DOCKER_CONFIG
         value: /tekton/home/.docker
@@ -42,12 +42,12 @@ spec:
         - --progress=plain
         - --frontend=dockerfile.v0
         - --local
-        - context=/workspace/source/$(build.source.contextDir)
+        - context=$(params.shp-source-context)
         - --local
-        - dockerfile=/workspace/source/$(build.dockerfile)
+        - dockerfile=$(params.shp-source-root)/$(build.dockerfile)
         - --output
-        - type=image,name=$(build.output.image),push=true,registry.insecure=true
+        - type=image,name=$(params.shp-output-image),push=true,registry.insecure=true
         - --export-cache
         - type=inline
         - --import-cache
-        - type=registry,ref=$(build.output.image)
+        - type=registry,ref=$(params.shp-output-image)

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -17,7 +17,7 @@ spec:
       args:
         - -c
         - >
-          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" "$(params.shp-source-root)" &&
           chown -R "1000:1000" /tekton/home &&
           chown -R "1000:1000" /cache &&
           chown -R "1000:1000" /layers
@@ -41,10 +41,10 @@ spec:
       command:
         - /cnb/lifecycle/creator
       args:
-        - -app=/workspace/source/$(build.source.contextDir)
+        - -app=$(params.shp-source-context)
         - -cache-dir=/cache
         - -layers=/layers
-        - $(build.output.image)
+        - $(params.shp-output-image)
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -17,7 +17,7 @@ spec:
       args:
         - -c
         - >
-          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" "$(params.shp-source-root)" &&
           chown -R "1000:1000" /tekton/home &&
           chown -R "1000:1000" /cache &&
           chown -R "1000:1000" /layers
@@ -41,10 +41,10 @@ spec:
       command:
         - /cnb/lifecycle/creator
       args:
-        - -app=/workspace/source/$(build.source.contextDir)
+        - -app=$(params.shp-source-context)
         - -cache-dir=/cache
         - -layers=/layers
-        - $(build.output.image)
+        - $(params.shp-output-image)
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -17,7 +17,7 @@ spec:
       args:
         - -c
         - >
-          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" "$(params.shp-source-root)" &&
           chown -R "1000:1000" /tekton/home &&
           chown -R "1000:1000" /cache &&
           chown -R "1000:1000" /layers
@@ -41,10 +41,10 @@ spec:
       command:
         - /cnb/lifecycle/creator
       args:
-        - -app=/workspace/source/$(build.source.contextDir)
+        - -app=$(params.shp-source-context)
         - -cache-dir=/cache
         - -layers=/layers
-        - $(build.output.image)
+        - $(params.shp-output-image)
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -17,7 +17,7 @@ spec:
       args:
         - -c
         - >
-          chown -R "1000:1000" /workspace/source &&
+          chown -R "1000:1000" "$(params.shp-source-root)" &&
           chown -R "1000:1000" /tekton/home &&
           chown -R "1000:1000" /cache &&
           chown -R "1000:1000" /layers
@@ -41,10 +41,10 @@ spec:
       command:
         - /cnb/lifecycle/creator
       args:
-        - -app=/workspace/source/$(build.source.contextDir)
+        - -app=$(params.shp-source-context)
         - -cache-dir=/cache
         - -layers=/layers
-        - $(build.output.image)
+        - $(params.shp-output-image)
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -7,7 +7,7 @@ spec:
   buildSteps:
     - name: build-and-push
       image: gcr.io/kaniko-project/executor:v1.5.2
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
         capabilities:
@@ -31,8 +31,8 @@ spec:
       args:
         - --skip-tls-verify=true
         - --dockerfile=$(build.dockerfile)
-        - --context=/workspace/source/$(build.source.contextDir)
-        - --destination=$(build.output.image)
+        - --context=$(params.shp-source-context)
+        - --destination=$(params.shp-output-image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
         - --push-retry=3

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -20,7 +20,7 @@ spec:
           set -euo pipefail
 
           chown -R 1000:1000 /workspace/output
-          chown -R 1000:1000 /workspace/source
+          chown -R 1000:1000 "$(params.shp-source-root)"
           chown -R 1000:1000 /tekton/home
       resources:
         limits:
@@ -31,7 +31,7 @@ spec:
           memory: 128Mi
     - name: build-and-push
       image: golang:1.15
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -51,7 +51,7 @@ spec:
           # - a URL with a tag but without a port: registry/image:tag
           # - a URL with both a tag and a port: registry:port/image:tag
 
-          IMAGE=$(build.output.image)
+          IMAGE=$(params.shp-output-image)
 
           REPO=
           TAG=

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -7,12 +7,12 @@ spec:
   buildSteps:
     - name: s2i-generate
       image: registry.redhat.io/ocp-tools-43-tech-preview/source-to-image-rhel8:latest
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       args:
         - build
         - .
         - $(build.builder.image)
-        - $(build.output.image)
+        - $(params.shp-output-image)
         - --as-dockerfile=/s2i/Dockerfile
       volumeMounts:
         - name: s2i
@@ -26,7 +26,7 @@ spec:
         - /usr/bin/buildah
       args:
         - bud
-        - --tag=$(build.output.image)
+        - --tag=$(params.shp-output-image)
       volumeMounts:
         - name: s2i
           mountPath: /s2i
@@ -41,7 +41,7 @@ spec:
       args:
         - push
         - --tls-verify=false
-        - docker://$(build.output.image)
+        - docker://$(params.shp-output-image)
       volumeMounts:
         - name: buildah-images
           mountPath: /var/lib/containers/storage

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -16,12 +16,12 @@ spec:
       volumeMounts:
         - mountPath: /gen-source
           name: gen-source
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
     - args:
         - '--skip-tls-verify=true'
         - '--dockerfile=/gen-source/Dockerfile.gen'
         - '--context=/gen-source'
-        - '--destination=$(build.output.image)'
+        - '--destination=$(params.shp-output-image)'
         - '--oci-layout-path=/workspace/output/image'
         - '--snapshotMode=redo'
         - '--push-retry=3'

--- a/test/buildstrategy_samples.go
+++ b/test/buildstrategy_samples.go
@@ -16,16 +16,16 @@ spec:
   buildSteps:
     - name: buildah-bud
       image: quay.io/buildah/stable:latest
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
       command:
         - /usr/bin/buildah
       args:
         - bud
-        - --tag=$(build.output.image)
+        - --tag=$(params.shp-output-image)
         - --file=$(build.dockerfile)
-        - $(build.source.contextDir)
+        - $(params.shp-source-context)
       resources:
         limits:
           cpu: 500m
@@ -45,7 +45,7 @@ spec:
       args:
         - push
         - --tls-verify=false
-        - docker://$(build.output.image)
+        - docker://$(params.shp-output-image)
       resources:
         limits:
           cpu: 100m
@@ -75,7 +75,7 @@ spec:
   buildSteps:
     - name: build
       image: "$(build.builder.image)"
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       command:
         - buildah
         - bud
@@ -84,8 +84,8 @@ spec:
         - -f
         - $(build.dockerfile)
         - -t
-        - $(build.output.image)
-        - $(build.source.contextDir)
+        - $(params.shp-output-image)
+        - $(params.shp-source-context)
       resources:
         limits:
           cpu: 500m
@@ -110,11 +110,11 @@ spec:
   buildSteps:
     - name: build
       image: "$(build.builder.image)"
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       command:
         - /cnb/lifecycle/builder
         - -app
-        - /workspace/source
+        - $(params.shp-source-context)
         - -layers
         - /layers
         - -group

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -16,16 +16,16 @@ spec:
   buildSteps:
     - name: buildah-bud
       image: quay.io/buildah/stable:latest
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
       command:
         - /usr/bin/buildah
       args:
         - bud
-        - --tag=$(build.output.image)
+        - --tag=$(params.shp-output-image)
         - --file=$(build.dockerfile)
-        - $(build.source.contextDir)
+        - $(params.shp-source-context)
       resources:
         limits:
           cpu: 500m
@@ -45,7 +45,7 @@ spec:
       args:
         - push
         - --tls-verify=false
-        - docker://$(build.output.image)
+        - docker://$(params.shp-output-image)
       resources:
         limits:
           cpu: 100m
@@ -70,16 +70,16 @@ spec:
   buildSteps:
     - name: buildah-bud
       image: quay.io/buildah/stable:latest
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
       command:
         - /usr/bin/buildah
       args:
         - bud
-        - --tag=$(build.output.image)
+        - --tag=$(params.shp-output-image)
         - --file=$(build.dockerfile)
-        - $(build.source.contextDir)
+        - $(params.shp-source-context)
       resources:
         limits:
           cpu: 500m
@@ -99,7 +99,7 @@ spec:
       args:
         - push
         - --tls-verify=false
-        - docker://$(build.output.image)
+        - docker://$(params.shp-output-image)
       resources:
         limits:
           cpu: 500m
@@ -124,7 +124,7 @@ spec:
   buildSteps:
     - name: step-build-and-push
       image: gcr.io/kaniko-project/executor:v1.5.2
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
         capabilities:
@@ -148,8 +148,8 @@ spec:
       args:
         - --skip-tls-verify=true
         - --dockerfile=$(build.dockerfile)
-        - --context=/workspace/source/$(build.source.contextDir)
-        - --destination=$(build.output.image)
+        - --context=$(params.shp-source-context)
+        - --destination=$(params.shp-output-image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
         - --push-retry=3
@@ -174,7 +174,7 @@ spec:
   buildSteps:
     - name: step-build-and-push
       image: gcr.io/kaniko-project/executor:v1.5.2
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
         capabilities:
@@ -198,8 +198,8 @@ spec:
       args:
         - --skips-tlss-verifys=true
         - --dockerfile=$(build.dockerfile)
-        - --context=/workspace/source/$(build.source.contextDir)
-        - --destination=$(build.output.image)
+        - --context=$(params.shp-source-context)
+        - --destination=$(params.shp-output-image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
         - --push-retry=3
@@ -222,7 +222,7 @@ spec:
   buildSteps:
   - name: step-no-and-op
     image: alpine:latest
-    workingDir: /workspace/source
+    workingDir: $(params.shp-source-root)
     securityContext:
       runAsUser: 0
       capabilities:
@@ -289,7 +289,7 @@ spec:
   buildSteps:
     - name: step-build-and-push
       image: gcr.io/kaniko-project/executor:v1.5.2
-      workingDir: /workspace/source
+      workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
         capabilities:
@@ -313,8 +313,8 @@ spec:
       args:
         - --skip-tls-verify=true
         - --dockerfile=$(build.dockerfile)
-        - --context=/workspace/source/$(build.source.contextDir)
-        - --destination=$(build.output.image)
+        - --context=$(params.shp-source-root)
+        - --destination=$(params.shp-output-image)
         - --oci-layout-path=/workspace/output/image
         - --snapshotMode=redo
         - --push-retry=3


### PR DESCRIPTION
# Changes

First part for the [Tekton parameter replacement](https://github.com/shipwright-io/build/blob/master/docs/proposals/removal-tekton-resources.md#risks-and-mitigations) / [Remove usage of Tekton resources #696](https://github.com/shipwright-io/build/issues/696): introducing our own parameters for the output image and source directory. From the longer list in the referenced EP, this is 3 and a part of 1.

Notes:

* for runtime images, there was actually a bug as the rendered runtime image always used the build's output image. This would have failed if the BuildRun specified a different one.
* also related to runtime images, in the `runtimeBuildAndPushStep` function, I intentionally removed the `--context` argument because the generated Dockerfile.runtime does not contain any `COPY` or `ADD` commands that take from the context, but rather always from the first stage
* in the TaskRun generation, I retained the old string transformation, like `$(build.output.image)` although no sample build strategy uses it anymore. As this is kind of a break of a (non-documented) API, we can do the removal in a later release

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
action required: Introduce system-provided parameters: shp-output-image, shp-source-root, and shp-source-context. Sample build strategies are adopted. If you have your own build strategies, ensure they are updated to use these parameters.
```