### PR TITLE
Removing PR template block on notes verification

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,14 +49,4 @@ For pull requests that don't need to be mentioned at release time, use the `/rel
 ```release-note
 NONE
 ```
-
-Note, your release note has to meet the formatting restrictions noted above precisely, or else it will not be included.
-To validate its inclusion, run:
-
-```
-# export PR_NUM=<your PR number>
-wget -q -O- https://api.github.com/repos/shipwright-io/build/issues/${PR_NUM} | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' | grep -avP '\W*(Your release note here|action required: your release note here|NONE)\W*'
-```
-
-If you do not see your release note text in the output, your formatting did not conform to the examples above.
 -->


### PR DESCRIPTION
# Changes

Having this in the template consumes a lot of time when opening the pr,
mainly because one needs to manually remove this.

The current instruction on the three flavors of release notes ( none,
notes or notes with action ) are already very clear.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```
