### PR TITLE
Add make target to run unit tests with ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,20 @@ test-unit-coverage: test-unit gocov
 	$(GOCOV) convert build/coverage/coverprofile > build/coverage/coverprofile.json
 	$(GOCOV) report build/coverage/coverprofile.json
 
+.PHONY: test-unit-ginkgo
+test-unit-ginkgo: ginkgo
+	GO111MODULE=on $(GINKGO) \
+		-randomizeAllSpecs \
+		-randomizeSuites \
+		-failOnPending \
+		-p \
+		-compilers=2 \
+		-slowSpecThreshold=240 \
+		-race \
+		-trace \
+		internal/... \
+		pkg/...
+
 # Based on https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/integration-tests.md
 .PHONY: test-integration
 test-integration: install-apis ginkgo


### PR DESCRIPTION
# Changes

We recently changed to using `go test` to run the unit tests to not be required to install Ginkgo in prow I think as this sometimes failed and takes some time.

For local tests, I still prefer Ginkgo as its output is having a better readability. Adding a target that does this.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
