### PR TITLE
Build multi-arch base image for git container

### DIFF
--- a/.github/workflows/base-images.yaml
+++ b/.github/workflows/base-images.yaml
@@ -1,0 +1,31 @@
+name: Base images build
+
+on:
+  schedule:
+  - cron: '0 3 * * *' # 3 AM UTC = before the nightly build
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to container registry
+        run: echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login -u "${{ secrets.REGISTRY_USERNAME }}" --password-stdin quay.io
+
+      - name: Build Git
+        run: |
+          pushd images/git
+            IMAGE=quay.io/shipwright/base-git docker buildx bake --push -f ../docker-bake.hcl
+          popd

--- a/images/docker-bake.hcl
+++ b/images/docker-bake.hcl
@@ -1,0 +1,11 @@
+variable "IMAGE" {
+}
+
+group "default" {
+	targets = ["all"]
+}
+
+target "all" {
+	tags = ["${IMAGE}:latest"]
+	platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+}

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi8-minimal:latest
+
+RUN \
+  microdnf update && \
+  microdnf install git git-lfs && \
+  microdnf clean all && \
+  rm -rf /var/cache/yum && \
+  echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
+  echo 'nonroot:x:1000:' > /etc/group
+
+USER 1000:1000


### PR DESCRIPTION
# Changes

For our effort to [replace the git resource](https://github.com/shipwright-io/build/blob/master/docs/proposals/removal-tekton-resources.md#4-own-containers-that-perform-step-logic), we need to build our own container that performs the `git clone`. Unfortunately, go-git does not have support for lfs. We therefore need to build a wrapper that runs `git` commands.

This PR introduces the base image for this which is based on ubi-minimal, adding the git and git-lfs packages and a nonroot user.

The GitHub action is setup to run nightly to ensure that the base image is up-to-date.

I tested this in my own repository: here is the workflow run: [Build and push](https://github.com/SaschaSchwarze0/shipwright-base-images/runs/2446768688?check_suite_focus=true). Here is the pushed test image: [saschaschwarze/git](https://hub.docker.com/repository/registry-1.docker.io/saschaschwarze/git/tags?page=1&ordering=last_updated).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
