### PR TITLE
Update Kaniko to 1.6.0, update ko to 0.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
             kubectl apply -f test/data/registry.yaml
             kubectl -n registry rollout status deployment registry --timeout=1m
         - name: Install ko
-          run: curl -fsL https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
+          run: curl -fsL https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
         - name: Install Shipwright Build
           run: |
             make install-controller-kind

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Ko
       run: |
         echo '::group:: install ko'
-        curl -L https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | tar xzf - ko
+        curl -L https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_Linux_x86_64.tar.gz | tar xzf - ko
         chmod +x ./ko
         sudo mv ko /usr/local/bin
         echo '::endgroup::'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Ko
       run: |
         echo '::group:: install ko'
-        curl -L https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | tar xzf - ko
+        curl -L https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_Linux_x86_64.tar.gz | tar xzf - ko
         chmod +x ./ko
         sudo mv ko /usr/local/bin
         echo '::endgroup::'

--- a/docs/build.md
+++ b/docs/build.md
@@ -330,7 +330,7 @@ Please consider the description of the attributes under `.spec.runtime`:
 > Specifying the runtime section will cause a `BuildRun` to push `spec.output.image` twice. First, the image produced by chosen `BuildStrategy` is pushed, and next it gets reused to construct the runtime-image, which is pushed again, overwriting `BuildStrategy` outcome.
 > Be aware, specially in situations where the image push action triggers automation steps. Since the same tag will be reused, you might need to take this in consideration when using runtime-images.
 
-Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v1.5.2` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build controller deployment](../deploy/controller.yaml).
+Under the cover, the runtime image will be an additional step in the generated Task spec of the TaskRun. It uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to run a container build using the `gcr.io/kaniko-project/executor:v1.6.0` image. You can overwrite this image by adding the environment variable `KANIKO_CONTAINER_IMAGE` to the [build controller deployment](../deploy/controller.yaml).
 
 ## BuildRun deletion
 

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -214,7 +214,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.2
+      image: gcr.io/kaniko-project/executor:v1.6.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -259,7 +259,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.2
+      image: gcr.io/kaniko-project/executor:v1.6.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ The following environment variables are available:
 | Environment Variable | Description |
 | --- | --- |
 | `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. |
-| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used for the runtime image build instead of the default, for example `gcr.io/kaniko-project/executor:v1.5.2`. |
+| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used for the runtime image build instead of the default, for example `gcr.io/kaniko-project/executor:v1.6.0`. |
 | `REMOTE_ARTIFACTS_CONTAINER_IMAGE` | Specify the container image used for the `.spec.sources` remote artifacts download, by default it uses `busybox:latest`. |
 | `BUILD_CONTROLLER_LEADER_ELECTION_NAMESPACE` |  Set the namespace to be used to store the `shipwright-build-controller` lock, by default it is in the same namespace as the controller itself. |
 | `BUILD_CONTROLLER_LEASE_DURATION` |  Override the `LeaseDuration`, which is the duration that non-leader candidates will wait to force acquire leadership. |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ const (
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
 	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
-	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.5.2"
+	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.6.0"
 	kanikoImageEnvVar  = "KANIKO_CONTAINER_IMAGE"
 
 	remoteArtifactsDefaultImage = "quay.io/quay/busybox:latest"

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.2
+      image: gcr.io/kaniko-project/executor:v1.6.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -72,7 +72,7 @@ spec:
 
           # Download ko
           pushd /tmp > /dev/null
-            curl -f -s -L https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz | tar xzf - ko
+            curl -f -s -L https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz | tar xzf - ko
           popd > /dev/null
 
           # Run ko

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -30,7 +30,7 @@ spec:
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
-      image: gcr.io/kaniko-project/executor:v1.5.2
+      image: gcr.io/kaniko-project/executor:v1.6.0
       name: build-and-push
       securityContext:
         runAsUser: 0

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -123,7 +123,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.2
+      image: gcr.io/kaniko-project/executor:v1.6.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -173,7 +173,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.2
+      image: gcr.io/kaniko-project/executor:v1.6.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -288,7 +288,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.5.2
+      image: gcr.io/kaniko-project/executor:v1.6.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
# Changes

Just dependency updates. Updating Kaniko to [v1.6.0](https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.6.0) and ko to [v0.8.2](https://github.com/google/ko/releases/tag/v0.8.2).

Did not see anything relevant for us in the release notes.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Updating build tool versions: Kaniko to v1.6.0 and ko to v0.8.2
```
