### PR TITLE
Use imjasonh/setup-ko GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,8 +112,8 @@ jobs:
           run: |
             kubectl apply -f test/data/registry.yaml
             kubectl -n registry rollout status deployment registry --timeout=1m
-        - name: Install ko
-          run: curl -fsL https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_Linux_x86_64.tar.gz | sudo tar xzf - -C /usr/local/bin ko
+        - name: Install Ko
+          uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
         - name: Install Shipwright Build
           run: |
             make install-controller-kind

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,12 +27,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
     - name: Install Ko
-      run: |
-        echo '::group:: install ko'
-        curl -L https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_Linux_x86_64.tar.gz | tar xzf - ko
-        chmod +x ./ko
-        sudo mv ko /usr/local/bin
-        echo '::endgroup::'
+      uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
 
     - name: Ko resolve nightly.yaml
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,12 +44,8 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
     - name: Install Ko
-      run: |
-        echo '::group:: install ko'
-        curl -L https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_Linux_x86_64.tar.gz | tar xzf - ko
-        chmod +x ./ko
-        sudo mv ko /usr/local/bin
-        echo '::endgroup::'
+      uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
+
     - name: Ko resolve release.yaml
       env:
         REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}


### PR DESCRIPTION
See https://github.com/imjasonh/setup-ko

This action installs the latest `ko` release, so we don't need to bump
the version ourselves every time there's a release.

We can also pin to a ko release if we want to, to avoid a breakage or
bad version.

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```