### PR TITLE
Pin buildah version

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -412,7 +412,7 @@ If we will apply the following resources:
 
   ```yaml
     - name: buildah-bud
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -434,7 +434,7 @@ If we will apply the following resources:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       securityContext:
         privileged: true
       command:

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -74,7 +74,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			It("should ensure IMAGE is replaced by builder image when needed.", func() {
-				Expect(got.Steps[0].Container.Image).To(Equal("quay.io/buildah/stable:latest"))
+				Expect(got.Steps[0].Container.Image).To(Equal("quay.io/containers/buildah:v1.20.1"))
 			})
 
 			It("should ensure command replacements happen when needed", func() {

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: buildah-bud
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -28,7 +28,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       securityContext:
         privileged: true
       command:

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -18,7 +18,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah-bud
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       workingDir: /s2i
       securityContext:
         privileged: true
@@ -33,7 +33,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       securityContext:
         privileged: true
       command:

--- a/test/buildstrategy_samples.go
+++ b/test/buildstrategy_samples.go
@@ -15,7 +15,7 @@ metadata:
 spec:
   buildSteps:
     - name: buildah-bud
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -37,7 +37,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       securityContext:
         privileged: true
       command:

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -15,7 +15,7 @@ metadata:
 spec:
   buildSteps:
     - name: buildah-bud
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -37,7 +37,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       securityContext:
         privileged: true
       command:
@@ -69,7 +69,7 @@ metadata:
 spec:
   buildSteps:
     - name: buildah-bud
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -91,7 +91,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/buildah/stable:latest
+      image: quay.io/containers/buildah:v1.20.1
       securityContext:
         privileged: true
       command:


### PR DESCRIPTION
# Changes

Our builds started failing during e2e with this failure in the buildah BuildRun:

```
Logs of container step-buildah-bud:
STEP 1: FROM golang:1.16 AS build
STEP 2: FROM scratch
error creating build container: short-name resolution enforced but cannot prompt without a TTY
```

Using v1.20.1 seems to work, though I have not found some commit in buildah yet that is problematic.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Use buildah v1.20.1 in the sample build strategies
```