### PR TITLE
Let buildrun override output secret

### DIFF
--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -56,6 +56,7 @@ The `BuildRun` definition supports the following fields:
   - `spec.serviceAccount` - Refers to the SA to use when building the image. (_defaults to the `default` SA_)
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example `5m`. The value overwrites the value that is defined in the `Build`.
   - `spec.output.image` - Refers to a custom location where the generated image would be pushed. The value will overwrite the `output.image` value which is defined in `Build`. ( Note: other properties of the output, for example, the credentials cannot be specified in the buildRun spec. )
+  - `spec.output.credentials.name` - Reference an existing secret to get access to the container registry. This secret will be added to the service account along with the ones requested by the `Build`.
 
 ### Defining the BuildRef
 

--- a/pkg/reconciler/buildrun/resources/credentials.go
+++ b/pkg/reconciler/buildrun/resources/credentials.go
@@ -15,7 +15,7 @@ import (
 
 // ApplyCredentials adds all credentials that are referenced by the build and adds them to the service account.
 // The function returns true if the service account was modified.
-func ApplyCredentials(ctx context.Context, build *buildv1alpha1.Build, serviceAccount *corev1.ServiceAccount) bool {
+func ApplyCredentials(ctx context.Context, build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun, serviceAccount *corev1.ServiceAccount) bool {
 
 	modified := false
 
@@ -31,10 +31,17 @@ func ApplyCredentials(ctx context.Context, build *buildv1alpha1.Build, serviceAc
 		modified = updateServiceAccountIfSecretNotLinked(ctx, builderImage.Credentials, serviceAccount) || modified
 	}
 
-	// credentials of the 'output' image registry
-	sourceSecret = build.Spec.Output.Credentials
-	if sourceSecret != nil {
-		modified = updateServiceAccountIfSecretNotLinked(ctx, sourceSecret, serviceAccount) || modified
+	// if output is overridden by buildrun, and if this override has credentials,
+	// it should be added to the sa
+	if buildRun.Spec.Output != nil && buildRun.Spec.Output.Credentials != nil {
+		modified = updateServiceAccountIfSecretNotLinked(ctx, buildRun.Spec.Output.Credentials, serviceAccount) || modified
+	} else {
+		// otherwise, if buildrun does not override the output credentials,
+		// we should use the ones provided by the build
+		sourceSecret = build.Spec.Output.Credentials
+		if sourceSecret != nil {
+			modified = updateServiceAccountIfSecretNotLinked(ctx, sourceSecret, serviceAccount) || modified
+		}
 	}
 
 	return modified

--- a/pkg/reconciler/buildrun/resources/credentials_test.go
+++ b/pkg/reconciler/buildrun/resources/credentials_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Credentials", func() {
 
 	var (
 		build                       *buildv1alpha1.Build
+		buildRun                    *buildv1alpha1.BuildRun
 		beforeServiceAccount        *corev1.ServiceAccount
 		expectedAfterServiceAccount *corev1.ServiceAccount
 	)
@@ -58,16 +59,31 @@ var _ = Describe("Credentials", func() {
 				},
 			}
 
+			buildRun = &buildv1alpha1.BuildRun{
+				Spec: buildv1alpha1.BuildRunSpec{
+					Output: &buildv1alpha1.Image{
+						Image: "quay.io/namespace/brImage",
+						Credentials: &corev1.LocalObjectReference{
+							Name: "secret_buildrun.io",
+						},
+					},
+				},
+			}
+
 			expectedAfterServiceAccount = &corev1.ServiceAccount{
 				Secrets: []corev1.ObjectReference{
-					{Name: "secret_b"}, {Name: "secret_c"}, {Name: "secret_a"}, {Name: "secret_docker.io"}, {Name: "secret_quay.io"},
+					{Name: "secret_b"},
+					{Name: "secret_c"},
+					{Name: "secret_a"},
+					{Name: "secret_docker.io"},
+					{Name: "secret_buildrun.io"},
 				},
 			}
 		})
 
 		It("adds the credentials to the service account", func() {
 			afterServiceAccount := beforeServiceAccount.DeepCopy()
-			modified := resources.ApplyCredentials(context.TODO(), build, afterServiceAccount)
+			modified := resources.ApplyCredentials(context.TODO(), build, buildRun, afterServiceAccount)
 
 			Expect(modified).To(BeTrue())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))
@@ -88,12 +104,22 @@ var _ = Describe("Credentials", func() {
 				},
 			}
 
+			// This is just a placeholder BuildRun with no
+			// SecretRef added to the ones from the Build
+			buildRun = &buildv1alpha1.BuildRun{
+				Spec: buildv1alpha1.BuildRunSpec{
+					Output: &buildv1alpha1.Image{
+						Image: "https://image.url/",
+					},
+				},
+			}
+
 			expectedAfterServiceAccount = beforeServiceAccount
 		})
 
 		It("keeps the service account unchanged", func() {
 			afterServiceAccount := beforeServiceAccount.DeepCopy()
-			modified := resources.ApplyCredentials(context.TODO(), build, afterServiceAccount)
+			modified := resources.ApplyCredentials(context.TODO(), build, buildRun, afterServiceAccount)
 
 			Expect(modified).To(BeFalse())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))
@@ -117,7 +143,7 @@ var _ = Describe("Credentials", func() {
 
 		It("keeps the service account unchanged", func() {
 			afterServiceAccount := beforeServiceAccount.DeepCopy()
-			modified := resources.ApplyCredentials(context.TODO(), build, afterServiceAccount)
+			modified := resources.ApplyCredentials(context.TODO(), build, buildRun, afterServiceAccount)
 
 			Expect(modified).To(BeFalse())
 			Expect(afterServiceAccount).To(Equal(expectedAfterServiceAccount))

--- a/pkg/reconciler/buildrun/resources/service_accounts.go
+++ b/pkg/reconciler/buildrun/resources/service_accounts.go
@@ -70,7 +70,7 @@ func GenerateSA(ctx context.Context, client client.Client, build *buildv1alpha1.
 		ctxlog.Debug(ctx, "automatic generation of service account", namespace, serviceAccount.Namespace, name, serviceAccount.Name)
 
 		// add the secrets references into the new sa
-		ApplyCredentials(ctx, build, serviceAccount)
+		ApplyCredentials(ctx, build, buildRun, serviceAccount)
 
 		// if we didnt have the sa, then create one and ensure the Build secrets are referenced
 		if err := client.Create(ctx, serviceAccount); err != nil {
@@ -143,7 +143,7 @@ func RetrieveServiceAccount(ctx context.Context, client client.Client, build *bu
 	}
 
 	// Add credentials and update the service account
-	if modified := ApplyCredentials(ctx, build, serviceAccount); modified {
+	if modified := ApplyCredentials(ctx, build, buildRun, serviceAccount); modified {
 		ctxlog.Info(ctx, "updating ServiceAccount with secrets from build", namespace, serviceAccount.Namespace, name, serviceAccount.Name)
 		if err := client.Update(ctx, serviceAccount); err != nil {
 			return nil, err


### PR DESCRIPTION
# Changes

Until now, buildrun is allowed to override output image, but not the secret, making this impossible to work with private repos in buildrun overrides.
This commit fixes that behavior, secret setup by buildrun, is also added to the serviceaccount.

Fixes #684 

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```

Note, your release note has to meet the formatting restrictions noted above precisely, or else it will not be included.
To validate its inclusion, run:

```
# export PR_NUM=<your PR number>
wget -q -O- https://api.github.com/repos/shipwright-io/build/issues/${PR_NUM} | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' | grep -avP '\W*(Your release note here|action required: your release note here|NONE)\W*'
```

If you do not see your release note text in the output, your formatting did not conform to the examples above.
-->
