### PR TITLE
Introduce Git step command

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,4 @@
 defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal
+
+baseImageOverrides:
+  github.com/shipwright-io/build/cmd/git: quay.io/shipwright/base-git

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ test-unit-ginkgo: ginkgo
 		-slowSpecThreshold=240 \
 		-race \
 		-trace \
-		internal/... \
+		cmd/... \
 		pkg/...
 
 # Based on https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/integration-tests.md

--- a/cmd/git/README.md
+++ b/cmd/git/README.md
@@ -1,0 +1,37 @@
+# Git Clone Wrapper
+
+**TL;DR:** As part of the build, the sources need to be retrieved. One option is to use `git` to clone the source to the container filesystem. This was used to be done by a Tekton Git Resource. This package contains Shipwright Build owned Git retrieval code, which is wrapping around the `git` CLI in a minimal container setup.
+
+## Features
+
+- SSH private key based access to Git repositories
+- Basic Auth username/password access to Git repositories
+- Git Large File Storage (LFS) based Git repositories
+- Recursive Submodule update
+- Cloning using default remote branch
+- Cloning using specific branch name
+- Cloning using specific tag
+- Cloning using specific commit SHA
+- Does not interfere with local SSH config
+
+## Development
+
+- Run it locally:
+
+  ```sh
+  go run cmd/git/main.go \
+  --url https://github.com/shipwright-io/sample-go \
+  --revision 0e0583421a5e4bf562ffe33f3651e16ba0c78591 \
+  --target /tmp/workspace/source
+  ```
+
+- Run it using `ko` (base image defined in `.ko.yaml`)
+
+  ```sh
+  docker run \
+    --rm \
+    --volume /tmp/workspace:/workspace \
+    $(KO_DOCKER_REPO=ko.local ko publish --bare ./cmd/git) \
+      --url https://github.com/shipwright-io/sample-lfs \
+      --target /workspace/source
+  ```

--- a/cmd/git/README.md
+++ b/cmd/git/README.md
@@ -7,7 +7,7 @@
 - SSH private key based access to Git repositories
 - Basic Auth username/password access to Git repositories
 - Git Large File Storage (LFS) based Git repositories
-- Recursive Submodule update
+- Recursive sub-module update
 - Cloning using default remote branch
 - Cloning using specific branch name
 - Cloning using specific tag
@@ -15,6 +15,16 @@
 - Does not interfere with local SSH config
 
 ## Development
+
+### Base image
+
+The Git Clone Wrapper wraps around command line tools to serve as convenience layer. Therefore, it requires the respective binaries to be in the path. If you want to build your own base image for the wrapper CLI, make sure the following dependencies are met:
+
+- **SSH** - version `OpenSSH_8.0p1, OpenSSL 1.1.1g FIPS  21 Apr 2020` is known to work, older versions are very likely to work as well
+- **Git** - version `2.27.0` is known to work, older versions are very likely to work as well
+- **Git Large File Storage (LFS)** - version `2.11.0` is known to be working
+
+### Run the CLI code
 
 - Run it locally:
 

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -1,0 +1,339 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/shipwright-io/build/pkg/ctxlog"
+	"github.com/spf13/pflag"
+)
+
+// CLI tool flag names
+const (
+	FlagURL                 = "url"
+	FlagRevision            = "revision"
+	FlagTarget              = "target"
+	FlagResultFileCommitSHA = "result-file-commit-sha"
+	FlagSecretPath          = "secret-path"
+)
+
+type credentialType int
+
+const (
+	typeUndef credentialType = iota
+	typePrivateKey
+	typeUsernamePassword
+)
+
+// ExitError is an error which has an exit code to be used in os.Exit() to
+// return both an exit code and an error message
+type ExitError struct {
+	Code    int
+	Message string
+	Cause   error
+}
+
+func (e ExitError) Error() string {
+	return fmt.Sprintf("%s (exit code %d)", e.Message, e.Code)
+}
+
+type settings struct {
+	url                 string
+	revision            string
+	target              string
+	resultFileCommitSha string
+	secretPath          string
+}
+
+var flagValues settings
+
+var (
+	sshGitURLRegEx = regexp.MustCompile(`^(git@|ssh:\/\/).+$`)
+	commitShaRegEx = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+)
+
+func init() {
+	// Add the zap logger flag set to the CLI. The flag set must
+	// be added before calling pflag.Parse().
+	pflag.CommandLine.AddGoFlagSet(ctxlog.CustomZapFlagSet())
+
+	pflag.StringVar(&flagValues.url, FlagURL, "", "The URL of the Git repository")
+	pflag.StringVar(&flagValues.revision, FlagRevision, "", "The revision of the Git repository to be cloned. Optional, defaults to the default branch.")
+	pflag.StringVar(&flagValues.target, FlagTarget, "", "The target directory of the clone operation")
+	pflag.StringVar(&flagValues.resultFileCommitSha, FlagResultFileCommitSHA, "", "A file to write the commit sha to.")
+	pflag.StringVar(&flagValues.secretPath, FlagSecretPath, "", "A directory that contains a secret. Either username and password for basic authentication. Or a SSH private key and optionally a known hosts file. Optional.")
+}
+
+func main() {
+	if err := Execute(); err != nil {
+		var exitcode = 1
+		switch err := err.(type) {
+		case *ExitError:
+			exitcode = err.Code
+		}
+
+		os.Exit(exitcode)
+	}
+}
+
+// Execute performs flag parsing, input validation and the Git clone
+func Execute() error {
+	flagValues = settings{}
+	pflag.Parse()
+
+	// create logger and context
+	l := ctxlog.NewLogger("git")
+	ctx := ctxlog.NewParentContext(l)
+
+	err := runGitClone(ctx)
+	if err != nil {
+		ctxlog.Error(ctx, err, "program failed with an error")
+	}
+
+	return err
+}
+
+func runGitClone(ctx context.Context) error {
+	if flagValues.url == "" {
+		return &ExitError{Code: 100, Message: "the 'url' argument must not be empty"}
+	}
+
+	if flagValues.target == "" {
+		return &ExitError{Code: 101, Message: "the 'target' argument must not be empty"}
+	}
+
+	if err := checkEnvironment(ctx); err != nil {
+		return err
+	}
+
+	if err := clone(ctx); err != nil {
+		return err
+	}
+
+	if flagValues.resultFileCommitSha != "" {
+		output, err := git(ctx, "-C", flagValues.target, "rev-parse", "--verify", "HEAD")
+		if err != nil {
+			return err
+		}
+
+		if err := ioutil.WriteFile(flagValues.resultFileCommitSha, []byte(output), 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkEnvironment(ctx context.Context) error {
+	var checks = []struct{ toolName, versionArg string }{
+		{toolName: "ssh", versionArg: "-V"},
+		{toolName: "git", versionArg: "version"},
+		{toolName: "git-lfs", versionArg: "version"},
+	}
+
+	for _, check := range checks {
+		path, err := exec.LookPath(check.toolName)
+		if err != nil {
+			return &ExitError{Code: 120, Message: err.Error(), Cause: err}
+		}
+
+		out, err := exec.CommandContext(ctx, path, check.versionArg).CombinedOutput()
+		if err != nil {
+			return err
+		}
+
+		ctxlog.Info(ctx, check.toolName,
+			"path", path,
+			"version", strings.TrimRight(string(out), "\n"),
+		)
+	}
+
+	return nil
+}
+
+func clone(ctx context.Context) error {
+	args := []string{
+		"clone",
+		"--quiet",
+		"--no-tags",
+	}
+
+	var commitSha string
+	switch {
+	case commitShaRegEx.MatchString(flagValues.revision):
+		commitSha = flagValues.revision
+		args = append(args,
+			"--no-checkout",
+		)
+
+	case flagValues.revision != "":
+		args = append(args,
+			"--branch", flagValues.revision,
+			"--depth", "1",
+			"--single-branch",
+		)
+
+	default:
+		args = append(args,
+			"--depth", "1",
+			"--single-branch",
+		)
+	}
+
+	if flagValues.secretPath != "" {
+		credType, err := checkCredentials()
+		if err != nil {
+			return err
+		}
+
+		switch credType {
+		case typePrivateKey:
+			var sshCmd = []string{"ssh",
+				"-i",
+				filepath.Join(flagValues.secretPath, "ssh-privatekey"),
+			}
+
+			var knownHostsFile = filepath.Join(flagValues.secretPath, "known_hosts")
+			if hasFile(knownHostsFile) {
+				sshCmd = append(sshCmd,
+					"-o", "GlobalKnownHostsFile=/dev/null",
+					"-o", fmt.Sprintf("UserKnownHostsFile=%s", knownHostsFile),
+				)
+			} else {
+				sshCmd = append(sshCmd,
+					"-o", "StrictHostKeyChecking=accept-new",
+				)
+			}
+
+			args = append(args,
+				"--config",
+				fmt.Sprintf(`core.sshCommand=%s`, strings.Join(sshCmd, " ")),
+			)
+
+		case typeUsernamePassword:
+			repoURL, err := url.Parse(flagValues.url)
+			if err != nil {
+				return err
+			}
+
+			username, err := ioutil.ReadFile(filepath.Join(flagValues.secretPath, "username"))
+			if err != nil {
+				return err
+			}
+
+			password, err := ioutil.ReadFile(filepath.Join(flagValues.secretPath, "password"))
+			if err != nil {
+				return err
+			}
+
+			repoURL.User = url.UserPassword(string(username), string(password))
+
+			credHelperFile, err := ioutil.TempFile(os.TempDir(), "cred-helper-file")
+			if err != nil {
+				return err
+			}
+
+			defer os.Remove(credHelperFile.Name())
+
+			if err := ioutil.WriteFile(credHelperFile.Name(), []byte(repoURL.String()), 0400); err != nil {
+				return err
+			}
+
+			if _, err := git(ctx, "config", "--global", "credential.helper", fmt.Sprintf("store --file %s", credHelperFile.Name())); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := git(ctx, append(args, "--", flagValues.url, flagValues.target)...); err != nil {
+		return err
+	}
+
+	if commitSha != "" {
+		_, err := git(ctx, "-C", flagValues.target, "checkout", commitSha)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := git(ctx, "-C", flagValues.target, "submodule", "update", "--init", "--recursive")
+	return err
+}
+
+func git(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	ctxlog.Debug(ctx, cmd.String())
+
+	out, err := cmd.CombinedOutput()
+
+	var output string
+	if out != nil {
+		output = strings.TrimRight(string(out), "\n")
+	}
+
+	if err != nil {
+		// In case the command fails, it is very likely to be an ExitCode error
+		// which contains the exit code of the command. Create a custom exit
+		// error where the command output is placed into the error to be more
+		// readable to the end-user.
+		switch terr := err.(type) {
+		case *exec.ExitError:
+			err = &ExitError{
+				Code:    terr.ExitCode(),
+				Message: output,
+				Cause:   err,
+			}
+		}
+
+		ctxlog.Error(ctx, err, "git command failed",
+			"command", cmd.String(),
+			"output", output,
+		)
+	}
+
+	return output, err
+}
+
+func hasFile(elem ...string) bool {
+	_, err := os.Stat(filepath.Join(elem...))
+	return !os.IsNotExist(err)
+}
+
+func checkCredentials() (credentialType, error) {
+	hasPrivateKey := hasFile(flagValues.secretPath, "ssh-privatekey")
+	isSSHGitURL := sshGitURLRegEx.MatchString(flagValues.url)
+	switch {
+	case hasPrivateKey && !isSSHGitURL:
+		return typeUndef, &ExitError{Code: 110, Message: "Credential/URL inconsistency: SSH credentials provided, but URL is not a SSH Git URL"}
+
+	case !hasPrivateKey && isSSHGitURL:
+		return typeUndef, &ExitError{Code: 110, Message: "Credential/URL inconsistency: No SSH credentials provided, but URL is a SSH Git URL"}
+
+	case hasPrivateKey && isSSHGitURL:
+		return typePrivateKey, nil
+	}
+
+	hasUsername := hasFile(flagValues.secretPath, "username")
+	hasPassword := hasFile(flagValues.secretPath, "password")
+	isHTTPSURL := strings.HasPrefix(flagValues.url, "https")
+	switch {
+	case hasUsername && !hasPassword || !hasUsername && hasPassword:
+		return typeUndef, &ExitError{Code: 110, Message: "Basic Auth incomplete: Both username and password need to be configured"}
+
+	case hasUsername && hasPassword && isHTTPSURL:
+		return typeUsernamePassword, nil
+	}
+
+	return typeUndef, &ExitError{Code: 110, Message: "Unsupported type of credentials provided, either SSH private key or username/password is supported"}
+}

--- a/cmd/git/main_suite_test.go
+++ b/cmd/git/main_suite_test.go
@@ -1,0 +1,17 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGitCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Git Command Suite")
+}

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -1,0 +1,324 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/shipwright-io/build/cmd/git"
+)
+
+var _ = Describe("Git Resource", func() {
+	var run = func(args ...string) error {
+		os.Args = append([]string{"tool", "--zap-log-level", "fatal"}, args...)
+		return Execute()
+	}
+
+	var withTempDir = func(f func(target string)) {
+		path, err := ioutil.TempDir(os.TempDir(), "git")
+		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(path)
+
+		f(path)
+	}
+
+	var withTempFile = func(pattern string, f func(filename string)) {
+		file, err := ioutil.TempFile(os.TempDir(), pattern)
+		Expect(err).ToNot(HaveOccurred())
+		defer os.Remove(file.Name())
+
+		f(file.Name())
+	}
+
+	var filecontent = func(path string) string {
+		data, err := ioutil.ReadFile(path)
+		Expect(err).ToNot(HaveOccurred())
+		return string(data)
+	}
+
+	var file = func(path string, mode os.FileMode, data []byte) {
+		Expect(ioutil.WriteFile(path, data, mode)).ToNot(HaveOccurred())
+	}
+
+	Context("validations and error cases", func() {
+		It("should fail in case mandatory arguments are missing", func() {
+			Expect(run()).To(HaveOccurred())
+		})
+
+		It("should fail in case --url is empty", func() {
+			Expect(run(
+				"--url", "",
+				"--target", "/workspace/source",
+			)).To(HaveOccurred())
+		})
+
+		It("should fail in case --target is empty", func() {
+			Expect(run(
+				"--url", "https://github.com/foo/bar",
+				"--target", "",
+			)).To(HaveOccurred())
+		})
+
+		It("should fail in case url does not exist", func() {
+			withTempDir(func(target string) {
+				Expect(run(
+					"--url", "http://github.com/feqlQoDIHc/bcfHFHHXYF",
+					"--target", target,
+				)).To(HaveOccurred())
+			})
+		})
+
+		It("should fail in case secret path content is not recognized", func() {
+			withTempDir(func(secret string) {
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", "https://github.com/foo/bar",
+						"--target", target,
+						"--secret-path", secret,
+					)).To(HaveOccurred())
+				})
+			})
+		})
+	})
+
+	Context("cloning publically available repositories", func() {
+		const exampleRepo = "https://github.com/shipwright-io/sample-go"
+
+		It("should Git clone a repository to the specified target directory", func() {
+			withTempDir(func(target string) {
+				Expect(run(
+					"--url", exampleRepo,
+					"--target", target,
+				)).ToNot(HaveOccurred())
+
+				Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+			})
+		})
+
+		It("should Git clone a repository to the specified target directory using a specified branch", func() {
+			withTempDir(func(target string) {
+				Expect(run(
+					"--url", exampleRepo,
+					"--target", target,
+					"--revision", "main",
+				)).ToNot(HaveOccurred())
+
+				Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+			})
+		})
+
+		It("should Git clone a repository to the specified target directory using a specified tag", func() {
+			withTempFile("commit-sha", func(filename string) {
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--target", target,
+						"--revision", "v0.1.0",
+						"--result-file-commit-sha", filename,
+					)).ToNot(HaveOccurred())
+
+					Expect(filecontent(filename)).To(Equal("8016b0437a7a09079f961e5003e81e5ad54e6c26"))
+				})
+			})
+		})
+
+		It("should Git clone a repository to the specified target directory using a specified commit-sha (long)", func() {
+			withTempFile("commit-sha", func(filename string) {
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--target", target,
+						"--revision", "0e0583421a5e4bf562ffe33f3651e16ba0c78591",
+						"--result-file-commit-sha", filename,
+					)).ToNot(HaveOccurred())
+
+					Expect(filecontent(filename)).To(Equal("0e0583421a5e4bf562ffe33f3651e16ba0c78591"))
+				})
+			})
+		})
+
+		It("should Git clone a repository to the specified target directory using a specified commit-sha (short)", func() {
+			withTempFile("commit-sha", func(filename string) {
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--target", target,
+						"--revision", "0e05834",
+						"--result-file-commit-sha", filename,
+					)).ToNot(HaveOccurred())
+
+					Expect(filecontent(filename)).To(Equal("0e0583421a5e4bf562ffe33f3651e16ba0c78591"))
+				})
+			})
+		})
+	})
+
+	Context("cloning private repositories using SSH keys", func() {
+		const exampleRepo = "git@github.com:shipwright-io/sample-nodejs-private.git"
+
+		var sshPrivateKey string
+
+		BeforeEach(func() {
+			if sshPrivateKey = os.Getenv("TEST_GIT_PRIVATE_SSH_KEY"); sshPrivateKey == "" {
+				Skip("Skipping private repository tests since TEST_GIT_PRIVATE_SSH_KEY environment variable is not set")
+			}
+		})
+
+		It("should fail in case a private key is provided but no SSH Git URL", func() {
+			withTempDir(func(secret string) {
+				// Mock the filesystem state of `kubernetes.io/ssh-auth` type secret volume mount
+				file(filepath.Join(secret, "ssh-privatekey"), 0400, []byte(sshPrivateKey))
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", "https://github.com/foo/bar",
+						"--secret-path", secret,
+						"--target", target,
+					)).To(HaveOccurred())
+				})
+			})
+		})
+
+		It("should fail in case a SSH Git URL is provided but no private key", func() {
+			withTempDir(func(target string) {
+				Expect(run(
+					"--url", exampleRepo,
+					"--secret-path", "/tmp/foobar",
+					"--target", target,
+				)).To(HaveOccurred())
+			})
+		})
+
+		It("should Git clone a private repository using a SSH private key and known hosts file provided via a secret", func() {
+			var knownHosts string
+			if knownHosts = os.Getenv("TEST_GIT_KNOWN_HOSTS"); knownHosts == "" {
+				Skip("Skipping private repository test since TEST_GIT_KNOWN_HOSTS environment variable is not set")
+			}
+
+			withTempDir(func(secret string) {
+				// Mock the filesystem state of `kubernetes.io/ssh-auth` type secret volume mount
+				file(filepath.Join(secret, "ssh-privatekey"), 0400, []byte(sshPrivateKey))
+				file(filepath.Join(secret, "known_hosts"), 0600, []byte(knownHosts))
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--secret-path", secret,
+						"--target", target,
+					)).ToNot(HaveOccurred())
+
+					Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+				})
+			})
+		})
+
+		It("should Git clone a private repository using a SSH private key provided via a secret", func() {
+			withTempDir(func(secret string) {
+				// Mock the filesystem state of `kubernetes.io/ssh-auth` type secret volume mount
+				file(filepath.Join(secret, "ssh-privatekey"), 0400, []byte(sshPrivateKey))
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--secret-path", secret,
+						"--target", target,
+					)).ToNot(HaveOccurred())
+
+					Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+				})
+			})
+		})
+	})
+
+	Context("cloning private repositories using basic auth", func() {
+		const exampleRepo = "https://github.com/shipwright-io/sample-nodejs-private"
+
+		var username string
+		var password string
+
+		BeforeEach(func() {
+			username = os.Getenv("TEST_GIT_PRIVATE_USERNAME")
+			password = os.Getenv("TEST_GIT_PRIVATE_PASSWORD")
+			if username == "" || password == "" {
+				Skip("Skipping private repository tests since TEST_GIT_PRIVATE_USERNAME and/or TEST_GIT_PRIVATE_PASSWORD environment variables are not set")
+			}
+		})
+
+		It("should fail in case only username or password is provided", func() {
+			withTempDir(func(secret string) {
+				// Mock the filesystem state of `kubernetes.io/basic-auth` type secret volume mount
+				file(filepath.Join(secret, "password"), 0400, []byte(password))
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--secret-path", secret,
+						"--target", target,
+					)).To(HaveOccurred())
+				})
+			})
+		})
+
+		It("should Git clone a private repository using basic auth credentials provided via a secret", func() {
+			withTempDir(func(secret string) {
+				// Mock the filesystem state of `kubernetes.io/basic-auth` type secret volume mount
+				file(filepath.Join(secret, "username"), 0400, []byte(username))
+				file(filepath.Join(secret, "password"), 0400, []byte(password))
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--secret-path", secret,
+						"--target", target,
+					)).ToNot(HaveOccurred())
+
+					Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+				})
+			})
+		})
+	})
+
+	Context("cloning repositories with Git Large File Storage", func() {
+		const exampleRepo = "https://github.com/shipwright-io/sample-lfs"
+
+		It("should Git clone a repository to the specified target directory", func() {
+			withTempDir(func(target string) {
+				Expect(run(
+					"--url", exampleRepo,
+					"--target", target,
+				)).ToNot(HaveOccurred())
+
+				lfsFile := filepath.Join(target, "assets", "shipwright-logo-lightbg-512.png")
+				Expect(lfsFile).To(BeAnExistingFile())
+
+				data, err := ioutil.ReadFile(lfsFile)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(http.DetectContentType(data)).To(Equal("image/png"))
+			})
+		})
+	})
+
+	Context("cloning repositories with submodules", func() {
+		const exampleRepo = "https://github.com/shipwright-io/website"
+
+		It("should Git clone a repository with a submodule", func() {
+			withTempDir(func(target string) {
+				Expect(run(
+					"--url", exampleRepo,
+					"--target", target,
+				)).ToNot(HaveOccurred())
+
+				Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+				Expect(filepath.Join(target, "themes", "docsy", "README.md")).To(BeAnExistingFile())
+			})
+		})
+	})
+})


### PR DESCRIPTION
# Changes

In order to replace Tekton Git resource, a replacement container image
is required that performs a Git clone.

Add Git step command which wraps `git` CLI to clone user repositories
with different authentication options.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Added Git command as a replacement for the Tekton Git Resource.
```
