### PR TITLE
Add security context to BuildKit strategy sample

### DIFF
--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -19,15 +19,17 @@ spec:
           add:
             - CHOWN
       command:
-        - /bin/sh
+        - /bin/chown
       args:
-        - -c
-        - |
-          set -exuo pipefail
-          whoami
-          chown -R 1000:1000 /tekton/home
+        - -R
+        - 1000:1000
+        - /tekton/home
     - name: build-and-push
       image: moby/buildkit:master-rootless
+      securityContext:
+        allowPrivilegeEscalation: true
+        runAsUser: 1000
+        runAsGroup: 1000
       workingDir: $(params.shp-source-root)
       env:
       - name: DOCKER_CONFIG
@@ -41,13 +43,8 @@ spec:
         - build
         - --progress=plain
         - --frontend=dockerfile.v0
-        - --local
-        - context=$(params.shp-source-context)
-        - --local
-        - dockerfile=$(params.shp-source-root)/$(build.dockerfile)
-        - --output
-        - type=image,name=$(params.shp-output-image),push=true,registry.insecure=false
-        - --export-cache
-        - type=inline
-        - --import-cache
-        - type=registry,ref=$(params.shp-output-image)
+        - --local=context=$(params.shp-source-context)
+        - --local=dockerfile=$(params.shp-source-root)/$(build.dockerfile)
+        - --output=type=image,name=$(params.shp-output-image),push=true,registry.insecure=false
+        - --export-cache=type=inline
+        - --import-cache=type=registry,ref=$(params.shp-output-image)

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
@@ -19,15 +19,17 @@ spec:
           add:
             - CHOWN
       command:
-        - /bin/sh
+        - /bin/chown
       args:
-        - -c
-        - |
-          set -exuo pipefail
-          whoami
-          chown -R 1000:1000 /tekton/home
+        - -R
+        - 1000:1000
+        - /tekton/home
     - name: build-and-push
       image: moby/buildkit:master-rootless
+      securityContext:
+        allowPrivilegeEscalation: true
+        runAsUser: 1000
+        runAsGroup: 1000
       workingDir: $(params.shp-source-root)
       env:
       - name: DOCKER_CONFIG
@@ -41,13 +43,8 @@ spec:
         - build
         - --progress=plain
         - --frontend=dockerfile.v0
-        - --local
-        - context=$(params.shp-source-context)
-        - --local
-        - dockerfile=$(params.shp-source-root)/$(build.dockerfile)
-        - --output
-        - type=image,name=$(params.shp-output-image),push=true,registry.insecure=true
-        - --export-cache
-        - type=inline
-        - --import-cache
-        - type=registry,ref=$(params.shp-output-image)
+        - --local=context=$(params.shp-source-context)
+        - --local=dockerfile=$(params.shp-source-root)/$(build.dockerfile)
+        - --output=type=image,name=$(params.shp-output-image),push=true,registry.insecure=true
+        - --export-cache=type=inline
+        - --import-cache=type=registry,ref=$(params.shp-output-image)


### PR DESCRIPTION
# Changes

Add `securityContext` to BuildKit cluster build strategy samples, which includes `allowPrivilegeEscalation` for `/usr/bin/new{u,g}idmap` binaries used by `rootlesskit` as well as explicit `runAs...` settings.

Simplify `prepare` step command.

Unify flag usage to have the same style for all arguments.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
