### PR TITLE
Add support for contextDir in S2I strategy

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -199,7 +199,8 @@ metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/sclorg/nodejs-ex
+    url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy
@@ -220,7 +221,8 @@ metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/sclorg/nodejs-ex
+    url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy
@@ -239,7 +241,8 @@ metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/sclorg/nodejs-ex
+    url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy

--- a/samples/build/build_source-to-image_cr.yaml
+++ b/samples/build/build_source-to-image_cr.yaml
@@ -1,14 +1,12 @@
 ---
-# TODO: The source-to-image Strategy does not support contextDir, therefore
-# we are not adding a reference to https://github.com/shipwright-io/sample-nodejs
-# with the /source-build contextDir in this sample.
 apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/sclorg/nodejs-ex
+    url: https://github.com/shipwright-io/sample-nodejs
+    contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -10,7 +10,7 @@ spec:
       workingDir: $(params.shp-source-root)
       args:
         - build
-        - .
+        - $(params.shp-source-context)
         - $(build.builder.image)
         - $(params.shp-output-image)
         - --as-dockerfile=/s2i/Dockerfile

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -7,7 +7,7 @@ spec:
     - command:
         - /usr/local/bin/s2i
         - build
-        - .
+        - $(params.shp-source-context)
         - $(build.builder.image)
         - '--as-dockerfile'
         - /gen-source/Dockerfile.gen


### PR DESCRIPTION
# Changes

Fixes https://github.com/shipwright-io/build/issues/638

S2I strategies should make use of $(params.shp-source-context) to
retrieve the path to source code. This param will also use a default value
when users do not specify the spec.contextDir.

The changes on the strategy are also inlined with how Tekton Catalog
does it upstread, see:

https://github.com/tektoncd/catalog/blob/main/task/s2i/0.2/s2i.yaml#L49


# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Ensure contexDir is supported in S2I strategies
```