### PR TITLE
Enhance integration flaky test case

### DIFF
--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 				// BuildRun reason can be ExceededNodeResources
 				// if the Tekton TaskRun Pod is queued due to
 				// insufficient cluster resources.
-				Or(Equal("Pending"), Equal("ExceededNodeResources")))
+				Or(Equal("Pending"), Equal("ExceededNodeResources"), Equal("Running")))
 		})
 	})
 


### PR DESCRIPTION
# Changes

On a BuildRun with an `Unknown` status, ensure different Reasons are contemplated. The current test case
only includes _Pending_ and _ExceededNodeResources_, but _Running_ is another Reason that could pop.

See flaky test example in [here](https://github.com/shipwright-io/build/runs/2501877220#step:8:104)

_Note_: We could also remove this test case. It is in place to ensure the state of an existing BuildRun that is **running** is not affected when the referenced Build is deleted.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
