### PR TITLE
Cleanup namespace after test case

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -22,9 +22,8 @@ func TestIntegration(t *testing.T) {
 // TODO: clean resources in cluster, e.g. mainly cluster-scope ones
 // TODO: clean each resource created per spec
 var (
-	deleteNSList []string
-	tb           *utils.TestBuild
-	err          error
+	tb  *utils.TestBuild
+	err error
 )
 
 var _ = BeforeEach(func() {
@@ -37,8 +36,6 @@ var _ = BeforeEach(func() {
 	if err != nil {
 		fmt.Printf("fail to create namespace: %v, with error: %v", tb.Namespace, err)
 	}
-
-	deleteNSList = append(deleteNSList, tb.Namespace)
 
 	// We store a channel for each Build controller instance we start,
 	// so that we can nuke the instance later inside the AfterEach Ginkgo
@@ -56,14 +53,14 @@ var _ = AfterEach(func() {
 		close(tb.StopBuildControllers)
 	}
 
+	// Cleanup the namespace
+	if err := tb.DeleteNamespace(); err != nil {
+		fmt.Printf("failed to delete namespace: %v, with error: %v", tb.Namespace, err)
+	}
+
 	if CurrentGinkgoTestDescription().Failed && tb.BuildControllerLogBuffer != nil {
 		// print operator logs
 		fmt.Println("\nLogs of the operator:")
 		fmt.Printf("%v\n", tb.BuildControllerLogBuffer)
 	}
-})
-
-var _ = AfterSuite(func() {
-	// Ensure a proper cleanup of test environments
-	Expect(tb.DeleteNamespaces(deleteNSList)).To(BeNil())
 })

--- a/test/utils/environment.go
+++ b/test/utils/environment.go
@@ -54,7 +54,7 @@ type TestBuild struct {
 // NewTestBuild returns an initialized instance of TestBuild
 func NewTestBuild() (*TestBuild, error) {
 	namespaceID := gomegaConfig.GinkgoConfig.ParallelNode*200 + int(atomic.AddInt32(&namespaceCounter, 1))
-	testNamespace := "test-build-" + strconv.Itoa(int(namespaceID))
+	testNamespace := "test-build-" + strconv.Itoa(namespaceID)
 
 	logBuffer := &bytes.Buffer{}
 	l := ctxlog.NewLoggerTo(logBuffer, testNamespace)


### PR DESCRIPTION
# Changes

In the integration tests, we sometimes observe pods that cannot be scheduled because of limited node resources. This happens because we collect namespaces and delete them at the end of the suite. Within those namespaces, there are sometimes pods in Terminating state that still claim resources that pods in a different namespace cannot yet use.

I am changing this to delete the namespace after each test.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
