### PR TITLE
Tag release images with release version

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,8 +35,9 @@ jobs:
         REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
         IMAGE_HOST: quay.io
         IMAGE: shipwright/shipwright-operator
+        TAG: "nightly-${{ steps.date.outputs.date }}"
       run: |
-        TAG="nightly-${{ steps.date.outputs.date }}" make release
+        make release
         mv release.yaml nightly-${{ steps.date.outputs.date }}.yaml
         mv release-debug.yaml nightly-${{ steps.date.outputs.date }}-debug.yaml
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,9 @@ jobs:
         REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
         IMAGE_HOST: quay.io
         IMAGE: shipwright/shipwright-operator
-      run: make release
+        TAG: ${{ github.events.input.release }}
+      run: |
+        make release
     - name: Upload Release Asset
       id: upload_release_asset 
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
# Changes

Fixes https://github.com/shipwright-io/build/issues/718

Instruct the release process to tag images with the release name (e.g., `v0.5.0`)

/kind bug

@adambkaplan @qu1queee 

# Submitter Checklist

- [n] Includes tests if functionality changed/was added
- [n] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Released container images are automatically tagged with the release version.
```