### PR TITLE
Don't rely on actions/upload-release-asset

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,47 +17,24 @@ jobs:
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d-%s')"
 
-    - name: Get latest nightly release upload_url
-      id: get_release
-      run: |
-        UPLOAD_URL=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases | jq -r '.[] | select(.name | startswith("Nightly Releases")).upload_url' | tail -n 1 | cut -d"{" -f1)
-        echo "Latest nightly release upload URL is ${UPLOAD_URL}"
-        echo "::set-output name=upload_url::${UPLOAD_URL}"
-
     - name: Install Go
       uses: actions/setup-go@v2
     - name: Install Ko
       uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
 
-    - name: Ko resolve nightly.yaml
+    - name: Generate and upload release YAMLs
       env:
         REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
         IMAGE_HOST: quay.io
         IMAGE: shipwright/shipwright-operator
         TAG: "nightly-${{ steps.date.outputs.date }}"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         make release
-        mv release.yaml nightly-${{ steps.date.outputs.date }}.yaml
-        mv release-debug.yaml nightly-${{ steps.date.outputs.date }}-debug.yaml
 
-    - name: Upload Release Asset
-      id: upload_release_asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}?name=nightly-${{ steps.date.outputs.date }}.yaml
-        asset_path: ./nightly-${{ steps.date.outputs.date }}.yaml
-        asset_name: nightly-${{ steps.date.outputs.date}}.yaml
-        asset_content_type: application/x-yaml
-    - name: Upload Release Asset
-      id: upload_release_asset-debug
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}?name=nightly-${{ steps.date.outputs.date }}-debug.yaml
-        asset_path: ./nightly-${{ steps.date.outputs.date }}-debug.yaml
-        asset_name: nightly-${{ steps.date.outputs.date}}-debug.yaml
-        asset_content_type: application/x-yaml
+        mv release.yaml nightly-${{ steps.date.outputs.date }}.yaml
+        gh release upload nightly nightly-${{ steps.date.outputs.date }}.yaml
+
+        mv release-debug.yaml nightly-${{ steps.date.outputs.date }}-debug.yaml
+        gh release upload nightly nightly-${{ steps.date.outputs.date }}-debug.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,22 +46,14 @@ jobs:
     - name: Install Ko
       uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
 
-    - name: Ko resolve release.yaml
+    - name: Generate and upload release.yaml
       env:
         REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
         IMAGE_HOST: quay.io
         IMAGE: shipwright/shipwright-operator
         TAG: ${{ github.events.input.release }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         make release
-    - name: Upload Release Asset
-      id: upload_release_asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.draft_release.outputs.upload_url }} 
-        asset_path: ./release.yaml
-        asset_name: release.yaml
-        asset_content_type: application/x-yaml
+        gh release upload ${TAG} release.yaml


### PR DESCRIPTION
That repo is unmaintained and archived.

Instead, use the GitHub CLI that's pre-installed in the GitHub Actions
execution environment and has simple CLI for uploading release assets to
existing releases.

/kind cleanup

Builds on https://github.com/shipwright-io/build/pull/766

cc @SaschaSchwarze0 

# Submitter Checklist

- [n] Includes tests if functionality changed/was added
- [n] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```