### PR TITLE
Reduce requested RBAC permissions

### DIFF
--- a/deploy/200-role.yaml
+++ b/deploy/200-role.yaml
@@ -1,96 +1,60 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: shipwright-build-controller
+  namespace: shipwright-build
+rules:
+- apiGroups: ['']
+  resources: ['configmaps']
+  verbs:     ['create', 'get', 'update']
+
+- apiGroups: ['']
+  resources: ['events']
+  verbs:     ['create']
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: shipwright-build-controller
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - shipwright-build
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
-- apiGroups:
-  - shipwright.io
-  resources:
-  - '*'
-  - buildstrategies
-  - clusterbuildstrategies
-  - buildruns
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - tekton.dev
-  resources:
-  - tasks
-  - taskruns
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+- apiGroups: ['shipwright.io']
+  resources: ['buildruns']
+  verbs:     ['get', 'list', 'update', 'watch']
+
+- apiGroups: ['shipwright.io']
+  resources: ['buildruns/status']
+  verbs:     ['update']
+
+- apiGroups: ['shipwright.io']
+  resources: ['builds']
+  verbs:     ['get', 'list', 'watch']
+
+- apiGroups: ['shipwright.io']
+  resources: ['builds/status']
+  verbs:     ['update']
+
+- apiGroups: ['shipwright.io']
+  resources: ['buildstrategies']
+  verbs:     ['get', 'list', 'watch']
+
+- apiGroups: ['shipwright.io']
+  resources: ['clusterbuildstrategies']
+  verbs:     ['get', 'list', 'watch']
+
+- apiGroups: ['tekton.dev']
+  resources: ['taskruns']
+  verbs:     ['get', 'create', 'list', 'watch']
+
+- apiGroups: ['']
+  resources: ['pods']
+  verbs:     ['get', 'list', 'watch']
+
+- apiGroups: ['']
+  resources: ['secrets']
+  verbs:     ['get', 'list', 'watch']
+
+- apiGroups: ['']
+  resources: ['serviceaccounts']
+  verbs:     ['create', 'delete', 'get', 'list', 'update', 'watch']

--- a/deploy/300-rolebinding.yaml
+++ b/deploy/300-rolebinding.yaml
@@ -10,3 +10,19 @@ roleRef:
   kind: ClusterRole
   name: shipwright-build-controller
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: shipwright-build-controller
+  namespace: shipwright-build
+subjects:
+- kind: ServiceAccount
+  name: shipwright-build-controller
+  namespace: shipwright-build
+roleRef:
+  kind: Role
+  name: shipwright-build-controller
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes https://github.com/shipwright-io/build/issues/724

This removes ClusterRole permissions granted to the controller SA, and removes anything it doesn't need (I think). It turns out what we were requesting before was _vastly_ more permissions than we actually needed!

What's left is:

- full read/write/create/delete on all Secrets and SAs (I believe we won't need these after we excise creds-init 🤞)
- list/get Pods
- full read/write/create/delete on shipwright.io/*
- create/get/list/watch on tekton.dev TaskRun only -- no delete or update
- create/get/update on ConfigMaps in the `shipwright-build` namespace only -- this is necessary for leader election

/kind cleanup

# Submitter Checklist

- [n] Includes tests if functionality changed/was added
- [n] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Permissions granted to the controller SA are reduced to what it actually needs to run
```