### PR TITLE
Ensure buildrun is not nil

### DIFF
--- a/pkg/reconciler/buildrun/resources/credentials_test.go
+++ b/pkg/reconciler/buildrun/resources/credentials_test.go
@@ -138,6 +138,16 @@ var _ = Describe("Credentials", func() {
 				},
 			}
 
+			// This is just a placeholder BuildRun with no
+			// SecretRef added to the ones from the Build
+			buildRun = &buildv1alpha1.BuildRun{
+				Spec: buildv1alpha1.BuildRunSpec{
+					Output: &buildv1alpha1.Image{
+						Image: "https://image.url/",
+					},
+				},
+			}
+
 			expectedAfterServiceAccount = beforeServiceAccount
 		})
 


### PR DESCRIPTION
# Changes

Recently, our credentials handling was extended to support the BuildRun to specify a credential for the output image. For this the test cases were also extended. Depending on in which order the test cases in credentials_test run, the buildrun might be nil which is causing a npe:

```
  Test Panicked

  runtime error: invalid memory address or nil pointer dereference

  /home/travis/.gimme/versions/go1.15.11.linux.amd64/src/runtime/panic.go:212

  Full Stack Trace

  github.com/shipwright-io/build/pkg/reconciler/buildrun/resources.ApplyCredentials(0x234b000, 0xc000122018, 0xc0001808c0, 0x0, 0xc0002d4580, 0x292)

  	/home/travis/gopath/src/github.ibm.com/coligo/source-to-image/src/build/pkg/reconciler/buildrun/resources/credentials.go:36 +0xa3

  github.com/shipwright-io/build/pkg/reconciler/buildrun/resources_test.glob..func3.4.2()

  	/home/travis/gopath/src/github.ibm.com/coligo/source-to-image/src/build/pkg/reconciler/buildrun/resources/credentials_test.go:146 +0x145
```

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
