### PR TITLE
Rebuild build object on retry

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -48,6 +48,12 @@ func createBuild(testBuild *utils.TestBuild, identifier string, filePath string)
 		if build.Status.Registered != "" {
 			err = testBuild.DeleteBuild(build.Name)
 			Expect(err).ToNot(HaveOccurred())
+
+			// create a fresh object
+			build, err = buildTestData(testBuild.Namespace, identifier, filePath)
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving build test data")
+
+			amendBuild(identifier, build)
 		}
 
 		err = testBuild.CreateBuild(build)


### PR DESCRIPTION
# Changes

Arg, when I reviewed [Retry build creation if build controller did not find build strategy #764](https://github.com/shipwright-io/build/pull/764) with @HeavyWombat, we actually considered if it would make sense to build a fresh Build object for the retry, but then did not do so. But, we have to ... :-( Otherwise it fails like this:

```
[1]     Unable to create build buildpacks-v3-namespaced-2m2qf
[1]     Unexpected error:
[1]         <*errors.StatusError | 0xc0002f9860>: {
[1]             ErrStatus: {
[1]                 TypeMeta: {Kind: "", APIVersion: ""},
[1]                 ListMeta: {
[1]                     SelfLink: "",
[1]                     ResourceVersion: "",
[1]                     Continue: "",
[1]                     RemainingItemCount: nil,
[1]                 },
[1]                 Status: "Failure",
[1]                 Message: "resourceVersion should not be set on objects to be created",
[1]                 Reason: "",
[1]                 Details: nil,
[1]                 Code: 500,
[1]             },
[1]         }
[1]         resourceVersion should not be set on objects to be created
[1]     occurred
[1] 
[1]     /home/runner/work/build/build/test/e2e/common_test.go:54
```

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
