### PR TITLE
Skip Git LFS tests in case there is no Git LFS

### DIFF
--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -5,9 +5,11 @@
 package main_test
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -19,7 +21,7 @@ import (
 var _ = Describe("Git Resource", func() {
 	var run = func(args ...string) error {
 		os.Args = append([]string{"tool", "--zap-log-level", "fatal"}, args...)
-		return Execute()
+		return Execute(context.TODO())
 	}
 
 	var withTempDir = func(f func(target string)) {
@@ -288,6 +290,12 @@ var _ = Describe("Git Resource", func() {
 
 	Context("cloning repositories with Git Large File Storage", func() {
 		const exampleRepo = "https://github.com/shipwright-io/sample-lfs"
+
+		BeforeEach(func() {
+			if _, err := exec.LookPath("git-lfs"); err != nil {
+				Skip("Skipping Git Large File Storage test as `git-lfs` binary is not in the PATH")
+			}
+		})
 
 		It("should Git clone a repository to the specified target directory", func() {
 			withTempDir(func(target string) {


### PR DESCRIPTION
# Changes

In the first version of `cmd/git`, it was assumed that Git LFS is installed and
used in the unit tests. As not all environments might have Git LFS, it would
lead to unnecessary unit test failures.

Refactor entry code to only run environment check when executed as the tool.

Add skip code to unit tests to omit tests in case Git LFS is not installed.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
