### PR TITLE
Add settings to disable user prompts

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -214,7 +214,10 @@ func clone(ctx context.Context) error {
 				return err
 			}
 
-			var sshCmd = []string{"ssh", "-i", sshPrivateKeyFile.Name()}
+			var sshCmd = []string{"ssh",
+				"-o", "BatchMode=yes",
+				"-i", sshPrivateKeyFile.Name(),
+			}
 
 			var knownHostsFile = filepath.Join(flagValues.secretPath, "known_hosts")
 			if hasFile(knownHostsFile) {
@@ -286,6 +289,10 @@ func clone(ctx context.Context) error {
 func git(ctx context.Context, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	ctxlog.Debug(ctx, cmd.String())
+
+	// Make sure that the spawned process does not try to prompt for infos
+	os.Setenv("GIT_TERMINAL_PROMPT", "0")
+	cmd.Stdin = nil
 
 	out, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
# Changes

There seem to be cases where depending on the system and configuration
the Git CLI prompts for username and password. We do not want the
wrapper tool to ever prompt the user as this is breaking the process.

Add `BatchMode` to SSH options to disable prompts.

Set `GIT_TERMINAL_PROMPT` environment variable to disable prompts.

Connect `/dev/null` to Git command (via `nil`) to disable prompts.

Since we control the base image, these issues _should_ only surface in
the context of unit tests.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

