### PR TITLE
Add commit SHA label to SHP image

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -11,7 +11,9 @@ echo "$REGISTRY_PASSWORD" | ko login -u "$REGISTRY_USERNAME" --password-stdin "$
 
 echo "Building container image"
 
+echo "Adding io.shipwright.vcs-ref label with value: ${GITHUB_SHA}"
+
 # Using defaults, this pushes to:
 # quay.io/shipwright/shipwright-build-controller:latest
-KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS}" ko resolve -t "$TAG" --bare --platform=all -R -f deploy/ > release.yaml
-KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve -t "$TAG-debug" --bare --platform=all -R -f deploy/ > release-debug.yaml
+KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS}" ko resolve -t "$TAG" --image-label "io.shipwright.vcs-ref=${GITHUB_SHA}" --bare --platform=all -R -f deploy/ > release.yaml
+KO_DOCKER_REPO="$IMAGE_HOST/$IMAGE" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve -t "$TAG-debug" --image-label "io.shipwright.vcs-ref=${GITHUB_SHA}" --bare --platform=all -R -f deploy/ > release-debug.yaml


### PR DESCRIPTION
# Changes

Adding the SHA that trigger the build of https://quay.io/repository/shipwright/shipwright-operator as a label. This is mainly to have a clear mapping to the commit on this same repository.

_Note_: Wondering if we should use `quay.expires-after` label, for the nightly images, we can set a max lifetime for those ones, so that we keep pruning them. 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/master/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add SHA label to SHP controller img
```

