### PR TITLE
Update ko and tested Kubernetes version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
             go-version: [1.15.x]
             os: [ubuntu-latest]
             kubernetes:
-              # Only v1.18 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
+              # Only v1.20 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
               #- v1.17.17
-              #- v1.18.15
-              #- v1.19.7
-              - v1.20.2
+              #- v1.18.19
+              #- v1.19.11
+              - v1.20.7
           max-parallel: 1
         runs-on: ${{ matrix.os }}
         steps:
@@ -80,11 +80,11 @@ jobs:
             go-version: [1.15.x]
             os: [ubuntu-latest]
             kubernetes:
-              # Only v1.18 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
+              # Only v1.20 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
               #- v1.17.17
-              #- v1.18.15
-              #- v1.19.7
-              - v1.20.2
+              #- v1.18.19
+              #- v1.19.11
+              - v1.20.7
           max-parallel: 2
         runs-on: ${{ matrix.os }}
         steps:

--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -25,7 +25,7 @@ kind --version
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
 # kind cluster version
-KIND_CLUSTER_VERSION="${KIND_CLUSTER_VERSION:-v1.20.2}"
+KIND_CLUSTER_VERSION="${KIND_CLUSTER_VERSION:-v1.20.7}"
 
 echo "# Creating a new Kubernetes cluster..."
 kind create cluster --quiet --name="${KIND_CLUSTER_NAME}" --image="kindest/node:${KIND_CLUSTER_VERSION}" --wait=120s

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -68,7 +68,7 @@ spec:
 
           # Download ko
           pushd /tmp > /dev/null
-            curl -f -s -L https://github.com/google/ko/releases/download/v0.8.2/ko_0.8.2_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz | tar xzf - ko
+            curl -f -s -L https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz | tar xzf - ko
           popd > /dev/null
 
           # Run ko


### PR DESCRIPTION
# Changes

Two small dependency updates:

1. Using ko v0.8.3 in the build strategy
2. Using the newer 1.20.7 kind kubernetes image in integration and e2e tests

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Update sample build strategy to latest ko version
```
