### PR TITLE
Only add secret to build for private repos

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -110,10 +110,11 @@ func amendSourceURL(b *buildv1alpha1.Build, sourceURL string) {
 
 // amendBuild make changes on build object.
 func amendBuild(identifier string, b *buildv1alpha1.Build) {
-	amendSourceSecretName(b, os.Getenv(EnvVarSourceURLSecret))
 	if strings.Contains(identifier, "github") {
+		amendSourceSecretName(b, os.Getenv(EnvVarSourceURLSecret))
 		amendSourceURL(b, os.Getenv(EnvVarSourceURLGithub))
 	} else if strings.Contains(identifier, "gitlab") {
+		amendSourceSecretName(b, os.Getenv(EnvVarSourceURLSecret))
 		amendSourceURL(b, os.Getenv(EnvVarSourceURLGitlab))
 	}
 


### PR DESCRIPTION
# Changes

With the new git command, we changed the behavior from warning to error if a http source URL is referencing an SSH secret. I am adopting the e2e test code accordingly to only assign the source secret when necessary. This was uncovered before because the private repo tests are not yet enabled for the CI-driven e2e test run.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
