### PR TITLE
Add image digest result to remaining sample build strategies

### DIFF
--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -5,18 +5,36 @@ metadata:
   name: buildah
 spec:
   buildSteps:
-    - name: buildah-bud
+    - name: build-and-push
       image: quay.io/containers/buildah:v1.20.1
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
       command:
-        - /usr/bin/buildah
+        - /bin/bash
       args:
-        - bud
-        - --tag=$(params.shp-output-image)
-        - --file=$(build.dockerfile)
-        - $(params.shp-source-context)
+        - -c
+        - |
+          set -euo pipefail
+
+          # Building the image
+          echo '[INFO] Building image $(params.shp-output-image)'
+          buildah bud \
+            --tag='$(params.shp-output-image)' \
+            --file='$(build.dockerfile)' \
+            '$(params.shp-source-context)'
+
+          # Push the image
+          echo '[INFO] Pushing image $(params.shp-output-image)'
+          buildah push \
+            --tls-verify=false \
+            '$(params.shp-output-image)' \
+            'docker://$(params.shp-output-image)'
+          
+          # Store the digest result
+          buildah images \
+            --format='{{.Digest}}' \
+            '$(params.shp-output-image)' | tr -d "\n" > '$(results.shp-image-digest.path)'
       resources:
         limits:
           cpu: 500m
@@ -24,27 +42,3 @@ spec:
         requests:
           cpu: 250m
           memory: 65Mi
-      volumeMounts:
-        - name: buildah-images
-          mountPath: /var/lib/containers/storage
-    - name: buildah-push
-      image: quay.io/containers/buildah:v1.20.1
-      securityContext:
-        privileged: true
-      command:
-        - /usr/bin/buildah
-      args:
-        - push
-        - --tls-verify=false
-        - $(params.shp-output-image)
-        - docker://$(params.shp-output-image)
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 250m
-          memory: 65Mi
-      volumeMounts:
-        - name: buildah-images
-          mountPath: /var/lib/containers/storage

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -25,7 +25,7 @@ spec:
         - 1000:1000
         - /tekton/home
     - name: build-and-push
-      image: moby/buildkit:master-rootless
+      image: moby/buildkit:nightly-rootless
       imagePullPolicy: Always
       securityContext:
         allowPrivilegeEscalation: true
@@ -39,13 +39,21 @@ spec:
       - name: BUILDKITD_FLAGS
         value: --oci-worker-no-process-sandbox
       command:
-        - buildctl-daemonless.sh
+        - /bin/ash
       args:
-        - build
-        - --progress=plain
-        - --frontend=dockerfile.v0
-        - --local=context=$(params.shp-source-context)
-        - --local=dockerfile=$(params.shp-source-root)/$(build.dockerfile)
-        - --output=type=image,name=$(params.shp-output-image),push=true,registry.insecure=false
-        - --export-cache=type=inline
-        - --import-cache=type=registry,ref=$(params.shp-output-image)
+        - -c
+        - |
+          set -euo pipefail
+
+          buildctl-daemonless.sh build \
+            --progress=plain \
+            --frontend=dockerfile.v0 \
+            --local=context='$(params.shp-source-context)' \
+            --local=dockerfile='$(params.shp-source-root)/$(build.dockerfile)' \
+            --output=type=image,name='$(params.shp-output-image)',push=true,registry.insecure=false \
+            --export-cache=type=inline \
+            --import-cache=type=registry,ref='$(params.shp-output-image)' \
+            --metadata-file /tmp/image-metadata.json
+          
+          # Store the image digest
+          sed -E 's/.*containerimage.digest":"([^"]*).*/\1/' < /tmp/image-metadata.json > '$(results.shp-image-digest.path)'

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
@@ -25,7 +25,7 @@ spec:
         - 1000:1000
         - /tekton/home
     - name: build-and-push
-      image: moby/buildkit:master-rootless
+      image: moby/buildkit:nightly-rootless
       imagePullPolicy: Always
       securityContext:
         allowPrivilegeEscalation: true
@@ -39,13 +39,21 @@ spec:
       - name: BUILDKITD_FLAGS
         value: --oci-worker-no-process-sandbox
       command:
-        - buildctl-daemonless.sh
+        - /bin/ash
       args:
-        - build
-        - --progress=plain
-        - --frontend=dockerfile.v0
-        - --local=context=$(params.shp-source-context)
-        - --local=dockerfile=$(params.shp-source-root)/$(build.dockerfile)
-        - --output=type=image,name=$(params.shp-output-image),push=true,registry.insecure=true
-        - --export-cache=type=inline
-        - --import-cache=type=registry,ref=$(params.shp-output-image)
+        - -c
+        - |
+          set -euo pipefail
+
+          buildctl-daemonless.sh build \
+            --progress=plain \
+            --frontend=dockerfile.v0 \
+            --local=context='$(params.shp-source-context)' \
+            --local=dockerfile='$(params.shp-source-root)/$(build.dockerfile)' \
+            --output=type=image,name='$(params.shp-output-image)',push=true,registry.insecure=true \
+            --export-cache=type=inline \
+            --import-cache=type=registry,ref='$(params.shp-output-image)' \
+            --metadata-file /tmp/image-metadata.json
+          
+          # Store the image digest
+          sed -E 's/.*containerimage.digest":"([^"]*).*/\1/' < /tmp/image-metadata.json > '$(results.shp-image-digest.path)'

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -17,31 +17,32 @@ spec:
       volumeMounts:
         - name: s2i
           mountPath: /s2i
-    - name: buildah-bud
+    - name: buildah
       image: quay.io/containers/buildah:v1.20.1
       workingDir: /s2i
       securityContext:
         privileged: true
       command:
-        - /usr/bin/buildah
+        - /bin/bash
       args:
-        - bud
-        - --tag=$(params.shp-output-image)
+        - -c
+        - |
+          set -euo pipefail
+
+          # Building the image
+          echo '[INFO] Building image $(params.shp-output-image)'
+          buildah bud --tag='$(params.shp-output-image)'
+
+          # Push the image
+          echo '[INFO] Pushing image $(params.shp-output-image)'
+          buildah push \
+            --tls-verify=false \
+            'docker://$(params.shp-output-image)'
+          
+          # Store the digest result
+          buildah images \
+            --format='{{.Digest}}' \
+            '$(params.shp-output-image)' | tr -d "\n" > '$(results.shp-image-digest.path)'
       volumeMounts:
         - name: s2i
           mountPath: /s2i
-        - name: buildah-images
-          mountPath: /var/lib/containers/storage
-    - name: buildah-push
-      image: quay.io/containers/buildah:v1.20.1
-      securityContext:
-        privileged: true
-      command:
-        - /usr/bin/buildah
-      args:
-        - push
-        - --tls-verify=false
-        - docker://$(params.shp-output-image)
-      volumeMounts:
-        - name: buildah-images
-          mountPath: /var/lib/containers/storage


### PR DESCRIPTION
# Changes

There were some build strategies remaining where the image digest result has not yet been provided. Doing this here:

- For BuildKit, I am using the brand-new `--metadata-file` field. Thanks @qu1queee for pointing me to [Add --metadata-file flag to output build metadata #2095](https://github.com/moby/buildkit/pull/2095). Also switching from master-rootless to nightly-rootless which is the same image without the `master` term.
- For Buildah, I use the `buildah images` command with the [`--format` option to access the `.Digest` property](https://github.com/containers/buildah/blob/v1.20.1/docs/buildah-images.md#options). I spent some time to see if I can also get the image size here. Unfortunately, the `.Size` property of the same command is [always formatted](https://github.com/containers/buildah/blob/v1.20.1/cmd/buildah/images.go#L335) (10.3 MB instead of the bytes count) and the raw value available in the code is not exposed. As I had to run another `buildah` command (after `bud` and `push`), I decided to consolidate all of them to run in a single container.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```