### PR TITLE
Map ImagePullPolicy from build strategy step to TaskRun step

### DIFF
--- a/pkg/reconciler/buildrun/resources/taskrun.go
+++ b/pkg/reconciler/buildrun/resources/taskrun.go
@@ -155,6 +155,7 @@ func GenerateTaskSpec(
 		step := v1beta1.Step{
 			Container: corev1.Container{
 				Image:           taskImage,
+				ImagePullPolicy: containerValue.ImagePullPolicy,
 				Name:            containerValue.Name,
 				VolumeMounts:    containerValue.VolumeMounts,
 				Command:         taskCommand,

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -62,6 +62,7 @@ var _ = Describe("GenerateTaskrun", func() {
 
 				buildStrategy, err = ctl.LoadBuildStrategyFromBytes([]byte(test.MinimalBuildahBuildStrategy))
 				Expect(err).To(BeNil())
+				buildStrategy.Spec.BuildSteps[0].ImagePullPolicy = "Always"
 
 				expectedCommandOrArg = []string{
 					"bud", "--tag=$(params.shp-output-image)", fmt.Sprintf("--file=$(inputs.params.%s)", "DOCKERFILE"), "$(params.shp-source-context)",
@@ -97,6 +98,10 @@ var _ = Describe("GenerateTaskrun", func() {
 
 			It("should ensure IMAGE is replaced by builder image when needed.", func() {
 				Expect(got.Steps[1].Container.Image).To(Equal("quay.io/containers/buildah:v1.20.1"))
+			})
+
+			It("should ensure ImagePullPolicy can be set by the build strategy author.", func() {
+				Expect(got.Steps[1].Container.ImagePullPolicy).To(Equal(corev1.PullPolicy("Always")))
 			})
 
 			It("should ensure command replacements happen when needed", func() {

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -26,6 +26,7 @@ spec:
         - /tekton/home
     - name: build-and-push
       image: moby/buildkit:master-rootless
+      imagePullPolicy: Always
       securityContext:
         allowPrivilegeEscalation: true
         runAsUser: 1000

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_insecure_cr.yaml
@@ -26,6 +26,7 @@ spec:
         - /tekton/home
     - name: build-and-push
       image: moby/buildkit:master-rootless
+      imagePullPolicy: Always
       securityContext:
         allowPrivilegeEscalation: true
         runAsUser: 1000

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -7,6 +7,7 @@ spec:
   buildSteps:
     - name: prepare
       image: docker.io/paketobuildpacks/builder:full
+      imagePullPolicy: Always
       securityContext:
         runAsUser: 0
         capabilities:
@@ -27,6 +28,7 @@ spec:
           memory: 65Mi
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder:full
+      imagePullPolicy: Always
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -7,6 +7,7 @@ spec:
   buildSteps:
     - name: prepare
       image: docker.io/paketobuildpacks/builder:full
+      imagePullPolicy: Always
       securityContext:
         runAsUser: 0
         capabilities:
@@ -27,6 +28,7 @@ spec:
           memory: 65Mi
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder:full
+      imagePullPolicy: Always
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -7,6 +7,7 @@ spec:
   buildSteps:
     - name: prepare
       image: golang:1.15
+      imagePullPolicy: Always
       securityContext:
         runAsUser: 0
         capabilities:

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -11,7 +11,8 @@ spec:
         - $(build.builder.image)
         - '--as-dockerfile'
         - /gen-source/Dockerfile.gen
-      image: 'quay.io/openshift-pipeline/s2i:nightly'
+      image: quay.io/openshift-pipeline/s2i:nightly
+      imagePullPolicy: Always
       name: s2i-build-as-dockerfile
       volumeMounts:
         - mountPath: /gen-source


### PR DESCRIPTION
# Changes

When defining a build strategy, the author defines which images are to be used. For certain tools, beside immutable image tags for specific versions, there are also nightly or latest-like tags available that are not using `latest` themselves. In such a a case, [Kubernetes sets the image pull policy implicitly to `IfNotPresent` and does never reload these images](https://kubernetes.io/docs/concepts/configuration/overview/#container-images) so that they get outdated. Examples in our context are:

* [moby/buildkit:nightly-rootless](https://hub.docker.com/r/moby/buildkit/tags)
* [paketobuildpacks/builder:full](https://hub.docker.com/r/paketobuildpacks/builder/tags)

In case of `latest`, Kubernetes would always contact the registry to check if there is a newer version. To enforce the very same behavior for other tags, the build strategy author needs to specify the `Always` image pull policy explicitly. But, our code does not pass this flag on to the TaskRun.

Given that this has positive security impact (assuming a newer image is more secure), but some performance cost that the build strategy author explicitly "opts in", I suggest that we pass on this field.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Build strategy authors can now specify an `imagePullPolicy` on each step, for example to enforce the `Always` policy also for images that do not use the `latest` tag
```
