### PR TITLE
Add deprecation warnings for .spec.runtime

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -153,7 +153,7 @@ spec:
                       type: object
                     type: array
                   runtime:
-                    description: Runtime represents the runtime-image.
+                    description: "Runtime represents the runtime-image. \n Deprecated: This feature is deprecated and will be removed in a future release.  See https://github.com/shipwright-io/community/blob/main/ships/deprecate-runtime.md for more information."
                     properties:
                       base:
                         description: Base runtime base image.

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -103,7 +103,7 @@ spec:
                   type: object
                 type: array
               runtime:
-                description: Runtime represents the runtime-image.
+                description: "Runtime represents the runtime-image. \n Deprecated: This feature is deprecated and will be removed in a future release.  See https://github.com/shipwright-io/community/blob/main/ships/deprecate-runtime.md for more information."
                 properties:
                   base:
                     description: Base runtime base image.

--- a/docs/build.md
+++ b/docs/build.md
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
   - [Defining the Strategy](#defining-the-strategy)
   - [Defining the Builder or Dockerfile](#defining-the-builder-or-dockerfile)
   - [Defining the Output](#defining-the-output)
-  - [Runtime-Image](#Runtime-Image)
+  - [Runtime-Image](#Runtime-Image) (⚠️ Deprecated)
 - [BuildRun deletion](#BuildRun-deletion)
 
 ## Overview
@@ -76,7 +76,7 @@ The `Build` definition supports the following fields:
   - `spec.parameters` - Refers to a list of `name-value` that could be used to loosely type parameters in the `BuildStrategy`.
   - `spec.dockerfile` - Path to a Dockerfile to be used for building an image. (_Use this path for strategies that require a Dockerfile_)
   - `spec.sources` - [Sources](#Sources) describes a slice of artifacts that will be imported into project context, before the actual build process starts.
-  - `spec.runtime` - Runtime-Image settings, to be used for a multi-stage build.
+  - `spec.runtime` - Runtime-Image settings, to be used for a multi-stage build. ⚠️ Deprecated
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example `5m`. The default is ten minutes. The value can be overwritten in the `BuildRun`.
   - `metadata.annotations[build.shipwright.io/build-run-deletion]` - Defines if delete all related BuildRuns when deleting the Build. The default is `false`.
 
@@ -281,6 +281,9 @@ Additionally, we have plan to keep evolving `.spec.sources` by adding more types
 At this initial stage, authentication is not supported therefore you can only download from sources without this mechanism in place.
 
 ### Runtime-Image
+
+**⚠️ Deprecated:** This feature is deprecated and will be removed in a future release.
+See https://github.com/shipwright-io/community/blob/main/ships/deprecate-runtime.md for more information.
 
 Runtime-image is a new image composed with build-strategy outcome. On which you can compose a multi-stage image build, copying parts out the original image into a new one. This feature allows replacing the base-image of any container-image, creating leaner images, and other use-cases.
 

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -98,6 +98,11 @@ type BuildSpec struct {
 
 	// Runtime represents the runtime-image.
 	//
+	// Deprecated: This feature is deprecated and will be removed in a
+	// future release.  See
+	// https://github.com/shipwright-io/community/blob/main/ships/deprecate-runtime.md
+	// for more information.
+	//
 	// +optional
 	Runtime *Runtime `json:"runtime,omitempty"`
 

--- a/pkg/reconciler/buildrun/resources/runtime_image.go
+++ b/pkg/reconciler/buildrun/resources/runtime_image.go
@@ -285,9 +285,11 @@ func isBuilderDefined(b *buildv1alpha1.Build) bool {
 // IsRuntimeDefined inspect if build has `.spec.runtime` defined, checking intermediary attributes
 // and making sure Image is informed.
 func IsRuntimeDefined(b *buildv1alpha1.Build) bool {
+	//lint:ignore SA1019 should be set until removed
 	if b.Spec.Runtime == nil {
 		return false
 	}
+	//lint:ignore SA1019 should be set until removed
 	if b.Spec.Runtime.Base.Image == "" {
 		return false
 	}

--- a/pkg/reconciler/buildrun/resources/runtime_image_test.go
+++ b/pkg/reconciler/buildrun/resources/runtime_image_test.go
@@ -57,6 +57,7 @@ var _ = Describe("runtime-image", func() {
 		})
 
 		It("expect user and group joined by colon", func() {
+			//lint:ignore SA1019 should be set until removed
 			u := renderUserAndGroup(b.Spec.Runtime.User)
 			Expect(u).To(Equal("username:1001"))
 
@@ -77,6 +78,7 @@ var _ = Describe("runtime-image", func() {
 
 	Context("rendering entrypoint", func() {
 		It("expect entrypoint concatenated", func() {
+			//lint:ignore SA1019 should be set until removed
 			entrypoint := renderEntrypoint(b.Spec.Runtime.Entrypoint)
 
 			Expect(entrypoint).To(Equal("\"/bin/bash\", \"-x\", \"-c\""))

--- a/pkg/validate/runtime.go
+++ b/pkg/validate/runtime.go
@@ -24,6 +24,7 @@ type RuntimeRef struct {
 // that the Build spec runtime definition is properly populated
 func (r RuntimeRef) ValidatePath(ctx context.Context) error {
 	if resources.IsRuntimeDefined(r.Build) {
+		//lint:ignore SA1019 should be set until removed
 		if len(r.Build.Spec.Runtime.Paths) == 0 {
 			r.Build.Status.Reason = build.RuntimePathsCanNotBeEmpty
 			r.Build.Status.Message = "the property 'spec.runtime.paths' must not be empty"


### PR DESCRIPTION
# Changes

Marks the `runtime` field as `Deprecated` in docs and Go doc comments

First step of [SHIP-0002](https://github.com/shipwright-io/community/blob/main/ships/0002-deprecate-runtime.md)

/kind cleanup

# Submitter Checklist

- [n/a] Includes tests if functionality changed/was added
- [y] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Mark the runtime feature as deprecated
```