### PR TITLE
Rename basic static checks to "Verify"

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,5 +1,5 @@
 ---
-name: Sanity Checks
+name: Verify
 
 on:
   push:
@@ -14,8 +14,8 @@ on:
       - master
 
 jobs:
-  build:
-    name: Sanity Checks
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
@@ -35,17 +35,8 @@ jobs:
         go get honnef.co/go/tools/cmd/staticcheck
         popd
 
-    - name: Sanity Check (go vet)
-      run: make govet
-
-    - name: Sanity Check (ineffassign)
-      run: make ineffassign
-
-    - name: Sanity Check (golint)
-      run: make golint
-
-    - name: Sanity Check (misspell)
-      run: make misspell
-
-    - name: Sanity Check (staticcheck)
-      run: make staticcheck
+    - run: make govet
+    - run: make ineffassign
+    - run: make golint
+    - run: make misspell
+    - run: make staticcheck

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,4 +1,3 @@
----
 name: Verify
 
 on:
@@ -40,3 +39,12 @@ jobs:
     - run: make golint
     - run: make misspell
     - run: make staticcheck
+
+    - name: Check make generate-crds
+      run: |
+        export GOPATH=$(go env GOPATH)
+        make generate-crds
+        if [[ $(git diff --stat) != '' ]]; then
+          echo "CRD YAML is out of date, run make generate-crds"
+          exit 1
+        fi


### PR DESCRIPTION
Inclusive naming guidelines [recommend against the term "sanity checks"](https://inclusivenaming.org/language/evaluation-framework/#is-the-term-overtly-ableist-or-pejorative-to-neurodiverse-or-disabled-people)

Runs that don't have a name will be shown as, for example, `run make govet` in failure emails, which is just about as descriptive as you can get, and shorter to write.

edit: Also add a new check that `make generate-crds` is up-to-date.
Fixes #798 

/kind cleanup

# Submitter Checklist

- [n/a] Includes tests if functionality changed/was added
- [n/a] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```