### PR TITLE
Fix another typo in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
         IMAGE_HOST: quay.io
         IMAGE: shipwright/shipwright-operator
-        TAG: ${{ github.events.inputs.release }}
+        TAG: ${{ github.event.inputs.release }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         make release


### PR DESCRIPTION
🤦 

/kind cleanup

# Submitter Checklist

- [n/a] Includes tests if functionality changed/was added
- [n/a] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```