### PR TITLE
Extend CI with README updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
         git commit -m "Update Readme with new Tag ${{ github.event.inputs.release }}"
         git clean -f
     - name: Create Readme PR
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29
       with:
         commit-message: Update Readme with new Tag
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,3 +57,51 @@ jobs:
       run: |
         make release
         gh release upload ${TAG} release.yaml
+
+    - name: Update docs after release creation
+      env:
+        PREVIOUS_TAG: ${{ github.event.inputs.tags }}
+        NEW_TAG: ${{ github.event.inputs.release }}
+      run: |
+        # Update README.md with new tag
+
+        sed -i 's#https://github.com/shipwright-io/build/releases/download/'"$PREVIOUS_TAG"'/release.yaml#https://github.com/shipwright-io/build/releases/download/'"$NEW_TAG"'/release.yaml#g' README.md
+        sed -i '/Examples @ HEAD/a | ['"$NEW_TAG"'](https://github.com/shipwright-io/build/releases/tag/'"$NEW_TAG"')    | [Docs @ '"$NEW_TAG"'](https://github.com/shipwright-io/build/tree/'"$NEW_TAG"'/docs) | [Examples @ '"$NEW_TAG"'](https://github.com/shipwright-io/build/tree/'"$NEW_TAG"'/samples) |' README.md
+
+    - name: Create Readme commits
+      run: |
+        git config user.name ${{ github.actor }}
+        git config user.email ${{ github.actor }}@users.noreply.github.com
+        git add README.md
+        git commit -m "Update Readme with new Tag ${{ github.event.inputs.release }}"
+        git clean -f
+    - name: Create Readme PR
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: Update Readme with new Tag
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        signoff: false
+        labels: |
+          kind/documentation
+        branch: update-readme-tag-refs
+        delete-branch: true
+        title: 'Update Readme with new tag'
+        body: |
+          Update README.md
+          # Changes
+
+          - Bump tag references to ${{ github.event.inputs.release }}
+
+          # Submitter Checklist
+
+          - [ ] Includes tests if functionality changed/was added
+          - [x] Includes docs if changes are user-facing
+          - [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
+          - [x] Release notes block has been filled in, or marked NONE
+
+          # Release Notes
+
+          ```release-note
+          None
+          ```
+        draft: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ git
 shipwright-build-controller
 build/_output
 build/_test
+hub-linux-*
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-


### PR DESCRIPTION
# Changes

This will open a new PR based on README updates.

The PR will contain updates that point to the latest tag created when shipping a new release. This should avoid people committing manual Readme updates, see examples:
- https://github.com/shipwright-io/build/commit/33175e4a1eeccf23239676ae54a46533ee0e58be
- https://github.com/shipwright-io/build/commit/d34799619ae22294189c138fd064c27279c681ce
- https://github.com/shipwright-io/build/pull/802

Example of PR generated with changes: https://github.com/qu1queee/build/pull/24

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Enhance CI with automated README updates
```


