### PR TITLE
Fix RBAC so Shipwright Build works with the OwnerReferencesPermissionEnforcement admission controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
             version: v0.10.0
             node_image: kindest/node:${{ matrix.kubernetes }}
             cluster_name: kind
+            config: test/kind/config.yaml
             wait: 120s
         - name: Verify kind cluster
           run: |

--- a/deploy/200-role.yaml
+++ b/deploy/200-role.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
 - apiGroups: ['']
   resources: ['configmaps']
-  verbs:     ['create', 'get', 'update']
+  verbs:     ['get', 'create', 'update']
 
 - apiGroups: ['']
   resources: ['events']
@@ -21,7 +21,15 @@ metadata:
 rules:
 - apiGroups: ['shipwright.io']
   resources: ['buildruns']
-  verbs:     ['get', 'list', 'update', 'watch']
+  # The build-run-deletion annotation sets an owner ref on BuildRun objects.
+  # With the OwnerReferencesPermissionEnforcement admission controller enabled, controllers need the "delete" permission on objects that they set owner references on.
+  verbs:     ['get', 'list', 'watch', 'update', 'delete']
+
+- apiGroups: ['shipwright.io']
+  # BuildRuns are set as the owners of Tekton TaskRuns.
+  # With the OwnerReferencesPermissionEnforcement admission controller enabled, controllers need the "update" permission on the finalizer of the parent object in the owner reference.
+  resources: ['buildruns/finalizers']
+  verbs:     ['update']
 
 - apiGroups: ['shipwright.io']
   resources: ['buildruns/status']
@@ -30,6 +38,12 @@ rules:
 - apiGroups: ['shipwright.io']
   resources: ['builds']
   verbs:     ['get', 'list', 'watch']
+
+- apiGroups: ['shipwright.io']
+  # The build-run-deletion annotation makes Builds an owner of BuildRun objects.
+  # With the OwnerReferencesPermissionEnforcement admission controller enabled, controllers need the "update" permission on the finalizer of the parent object in the owner reference.
+  resources: ['builds/finalizers']
+  verbs:     ['update']
 
 - apiGroups: ['shipwright.io']
   resources: ['builds/status']
@@ -45,7 +59,9 @@ rules:
 
 - apiGroups: ['tekton.dev']
   resources: ['taskruns']
-  verbs:     ['get', 'create', 'list', 'watch']
+  # BuildRuns are set as the owners of Tekton TaskRuns.
+  # With the OwnerReferencesPermissionEnforcement admission controller enabled, controllers need the "delete" permission on objects that they set owner references on.
+  verbs:     ['get', 'list', 'watch', 'create', 'delete']
 
 - apiGroups: ['']
   resources: ['pods']
@@ -57,4 +73,4 @@ rules:
 
 - apiGroups: ['']
   resources: ['serviceaccounts']
-  verbs:     ['create', 'delete', 'get', 'list', 'update', 'watch']
+  verbs:     ['get', 'list', 'watch', 'create', 'update', 'delete']

--- a/test/data/build_buildpacks-v3_golang_delete_cr.yaml
+++ b/test/data/build_buildpacks-v3_golang_delete_cr.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: buildpack-golang-build
+  annotations:
+    build.shipwright.io/build-run-deletion: "true"
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-go
+    contextDir: source-build
+  strategy:
+    name: buildpacks-v3
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/kind/config.yaml
+++ b/test/kind/config.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        enable-admission-plugins: CertificateApproval,CertificateSigning,CertificateSubjectRestriction,DefaultIngressClass,DefaultStorageClass,DefaultTolerationSeconds,LimitRanger,MutatingAdmissionWebhook,NamespaceLifecycle,NodeRestriction,OwnerReferencesPermissionEnforcement,PersistentVolumeClaimResize,PersistentVolumeLabel,PodNodeSelector,PodTolerationRestriction,Priority,ResourceQuota,RuntimeClass,ServiceAccount,StorageObjectInUseProtection,TaintNodesByCondition,ValidatingAdmissionWebhook


### PR DESCRIPTION
# Changes

- Update the admission controllers enabled for KinD so that it more
closely aligns with enterprise Kubernetes distributions.
- Add RBAC needed for the `OwnerReferencesPermissionEnforcement` admission controller.

With this admission controller enabled, service accounts need to have
explicit permission to delete objects that they set owner references on.
When `blockOwnerDeletion` is set on an owner ref, the controller must
also have explicit permission to update the finalizer subresource of the
parent object.

/kind bug

Fixes #806 

See also https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add RBAC permissions to let the build controller set owner references if a cluster has the OwnerReferencesPermissionEnforcement admission controller enabled.
```
