### PR TITLE
readd required buildrun permission when OwnerRefererencesPermissionEnforcement is enabled

### DIFF
--- a/deploy/200-role.yaml
+++ b/deploy/200-role.yaml
@@ -27,6 +27,13 @@ rules:
   resources: ['buildruns/status']
   verbs:     ['update']
 
+# This permission is required by the OwnerReferencesPermissionEnforcement admission controller,
+# which requires that controllers wishing to set OwnerReferences with blockOwnerDeletion have permission
+# to update finalizers on the owner resource.
+- apiGroups: ['shipwright.io']
+  resources: ['buildruns/finalizers']
+  verbs:     ['update']
+
 - apiGroups: ['shipwright.io']
   resources: ['builds']
   verbs:     ['get', 'list', 'watch']


### PR DESCRIPTION
# Changes

Fixes #806

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [/ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Use of the OwnerRefererencesPermissionEnforcement admission controller was broken because of permission reductions introduced in v0.5.0.  The required permissions have been reintroduced.
```
