### PR TITLE
Tweak Git image size

### DIFF
--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -4,8 +4,8 @@
 FROM registry.access.redhat.com/ubi8-minimal:latest
 
 RUN \
-  microdnf update && \
-  microdnf install git git-lfs && \
+  microdnf --nodocs update && \
+  microdnf --nodocs install git git-lfs && \
   microdnf clean all && \
   rm -rf /var/cache/yum && \
   echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \


### PR DESCRIPTION
# Changes

Add `--nodocs` to reduce the image size.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
