### PR TITLE
Add step name to message

### DIFF
--- a/pkg/reconciler/buildrun/resources/conditions.go
+++ b/pkg/reconciler/buildrun/resources/conditions.go
@@ -83,7 +83,8 @@ func UpdateBuildRunUsingTaskRunCondition(ctx context.Context, client client.Clie
 
 			if failedContainer != nil {
 				buildRun.Status.FailedAt.Container = failedContainer.Name
-				message = fmt.Sprintf("buildrun step failed in pod %s, for detailed information: kubectl --namespace %s logs %s --container=%s",
+				message = fmt.Sprintf("buildrun step %s failed in pod %s, for detailed information: kubectl --namespace %s logs %s --container=%s",
+					failedContainer.Name,
 					pod.Name,
 					pod.Namespace,
 					pod.Name,

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 					Expect(seq[lastIdx].Type).To(Equal(v1alpha1.Succeeded))
 					Expect(seq[lastIdx].Status).To(Equal(corev1.ConditionFalse))
 					Expect(seq[lastIdx].Reason).To(Equal("Failed"))
-					Expect(seq[lastIdx].Message).To(ContainSubstring("buildrun step failed in pod %s", taskRun.Status.PodName))
+					Expect(seq[lastIdx].Message).To(ContainSubstring("buildrun step %s failed in pod %s", "step-step-build-and-push", taskRun.Status.PodName))
 				})
 			})
 		})


### PR DESCRIPTION
# Changes

For our downstream service, we provide troubleshooting documentation for the user to determine the root cause of a failure. We there separate failures by step name. Since we rewrote the BuildRun message to not anymore contain the TaskRun reason, the step name is only shown at the end of the message in the `kubectl logs` command while we include the pod name earlier as well. I am slightly making a message change to also include the name of the step at the beginning of the message and not just in the `kubectl logs` example which makes it easier to understand and extract the relevant data.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The message field of the Succeeded condition of a failed BuildRun now includes the name of the step that has failed
```