### PR TITLE
Emit events for BuildRun objects

### DIFF
--- a/deploy/200-role.yaml
+++ b/deploy/200-role.yaml
@@ -74,3 +74,8 @@ rules:
 - apiGroups: ['']
   resources: ['serviceaccounts']
   verbs:     ['get', 'list', 'watch', 'create', 'update', 'delete']
+
+# Allow events to be created in any namespace related to BuildRun objects
+- apiGroups: ['']
+  resources: ['events']
+  verbs:     ['create']

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -15,6 +15,8 @@ SPDX-License-Identifier: Apache-2.0
 - [BuildRun Status](#buildrun-status)
   - [Understanding the state of a BuildRun](#understanding-the-state-of-a-BuildRun)
   - [Understanding failed BuildRuns](#understanding-failed-buildruns)
+  - [Build Snapshot](#build-snapshot)
+  - [Events](#events)
 - [Relationship with Tekton Tasks](#relationship-with-tekton-tasks)
 
 ## Overview
@@ -192,6 +194,11 @@ In addition, the `Status.Conditions` will host under the `Message` field a compa
 ### Build Snapshot
 
 For every BuildRun controller reconciliation, the `buildSpec` in the Status of the `BuildRun` is updated if an existing owned `TaskRun` is present. During this update, a `Build` resource snapshot is generated and embedded into the `status.buildSpec` path of the `BuildRun`. A `buildSpec` is just a copy of the original `Build` spec, from where the `BuildRun` executed a particular image build. The snapshot approach allows developers to see the original `Build` configuration.
+
+### Events
+
+The BuildRun controller will emit Kubernetes events when a BuildRun starts and completes.
+If the BuildRun ends in a failure, a `Warning` event is emitted; otherwise a `Normal` event is emitted.
 
 ## Relationship with Tekton Tasks
 

--- a/pkg/reconciler/buildrun/resources/errors.go
+++ b/pkg/reconciler/buildrun/resources/errors.go
@@ -21,10 +21,13 @@ func (e ClientStatusUpdateError) Error() string {
 // IsClientStatusUpdateError checks whether the given error is of type ClientStatusUpdateError or
 // in case this is a list of errors, that it contains at least one error of type ClientStatusUpdateError
 func IsClientStatusUpdateError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	switch terr := err.(type) {
 	case *ClientStatusUpdateError, ClientStatusUpdateError:
 		return true
-
 	case Errors:
 		for _, e := range terr.errors {
 			if IsClientStatusUpdateError(e) {
@@ -32,7 +35,6 @@ func IsClientStatusUpdateError(err error) bool {
 			}
 		}
 	}
-
 	return false
 }
 

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -515,7 +515,8 @@ func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
 
 // DefaultTaskRunWithStatus returns a minimal tekton TaskRun with an Status
 func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, ns string, status corev1.ConditionStatus, reason string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+	now := metav1.Now()
+	taskRun := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
@@ -534,11 +535,15 @@ func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, n
 			},
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				StartTime: &metav1.Time{
-					Time: time.Now(),
+					Time: now.Add(-5 * time.Minute),
 				},
 			},
 		},
 	}
+	if status == corev1.ConditionTrue || status == corev1.ConditionFalse {
+		taskRun.Status.CompletionTime = &now
+	}
+	return taskRun
 }
 
 // TaskRunWithCompletionAndStartTime provides a TaskRun object with a
@@ -577,6 +582,7 @@ func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName 
 
 // DefaultTaskRunWithFalseStatus returns a minimal tektont TaskRun with a FALSE status
 func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName string, ns string) *v1beta1.TaskRun {
+	now := metav1.Now()
 	return &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
@@ -597,8 +603,9 @@ func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName stri
 			},
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				StartTime: &metav1.Time{
-					Time: time.Now(),
+					Time: now.Add(-5 * time.Minute),
 				},
+				CompletionTime: &now,
 			},
 		},
 	}

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -129,6 +129,15 @@ func validateBuildRunToSucceed(testBuild *utils.TestBuild, testBuildRun *buildv1
 	// Verify that the BuildSpec is still available in the status
 	Expect(testBuildRun.Status.BuildSpec).ToNot(BeNil(), "BuildSpec is not available in the status")
 
+	// Verify that a succeeded event was fired
+	events, err := testBuild.GetEventsForObject(testBuildRun.Namespace, testBuildRun)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(events)).To(Equal(2))
+	for _, event := range events {
+		Expect(event.Type).To(Equal("Normal"))
+		Expect(event.Reason).To(Or(Equal("Started"), Equal("Succeeded")))
+	}
+
 	Logf("Test build '%s' is completed after %v !", testBuildRun.GetName(), testBuildRun.Status.CompletionTime.Time.Sub(testBuildRun.Status.StartTime.Time))
 }
 

--- a/test/utils/events.go
+++ b/test/utils/events.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (t *TestBuild) GetEventsForObject(namespace string, obj runtime.Object) ([]corev1.Event, error) {
+	events, err := t.Clientset.CoreV1().Events(namespace).Search(t.Scheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	return events.Items, nil
+}


### PR DESCRIPTION
# Changes

Enhance the BuildRun controller to emit k8s events when build runs start
and complete. If a BuildRun fails, a Warning event is issued.

This is an initial implementation for #823 

/kind feature

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The build controller will emit Kubernetes events when a BuildRun starts and completes. If the BuildRun fails, a Warning event will be issued.
```
