### PR TITLE
add serviceAccountName to buildrun status

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -332,6 +332,9 @@ spec:
               latestTaskRunRef:
                 description: "LatestTaskRunRef is the name of the TaskRun responsible for executing this BuildRun. \n TODO: This should be called something like \"TaskRunName\""
                 type: string
+              serviceAccountName:
+                description: ServiceAccountName refers to the kubernetes serviceaccount name which is used for resource control.
+                type: string
               startTime:
                 description: StartTime is the time the build is actually started.
                 format: date-time

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -131,7 +131,7 @@ spec:
 
 You can also use set the `spec.serviceAccount.generate` path to `true`. This will generate the service account during runtime for you.
 
-_**Note**_: When the SA is not defined, the `BuildRun` will default to the `default` SA in the namespace.
+_**Note**_: When the SA is not defined, the `BuildRun` will default to the `default` SA in the namespace. The `serviceAccount` used to run a `BuildRun` is set in the `Status.ServiceAccountName` field.
 
 ## Canceling a `BuildRun`
 

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -72,6 +72,11 @@ type BuildRunStatus struct {
 	// +optional
 	LatestTaskRunRef *string `json:"latestTaskRunRef,omitempty"`
 
+	// ServiceAccountName refers to the kubernetes serviceaccount name
+	// which is used for resource control.
+	// +optional
+	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
+
 	// StartTime is the time the build is actually started.
 	// +optional
 	StartTime *metav1.Time `json:"startTime,omitempty"`

--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -179,6 +179,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionTrue,
 					buildSample.Spec,
+					nil,
 					false,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -212,7 +213,6 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(client.DeleteCallCount()).To(Equal(0))
 				Expect(client.StatusCallCount()).To(Equal(0))
 			})
-
 			It("deletes a generated service account when the task run ends", func() {
 
 				// setup a buildrun to use a generated service account
@@ -232,7 +232,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 
 				// Call the reconciler
 				_, err := reconciler.Reconcile(taskRunRequest)
-
+				
 				// Expect no error
 				Expect(err).ToNot(HaveOccurred())
 
@@ -243,6 +243,32 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(castSuccessful).To(BeTrue())
 				Expect(serviceAccount.Name).To(Equal(buildRunSample.Name + "-sa"))
 				Expect(serviceAccount.Namespace).To(Equal(buildRunSample.Namespace))
+			})
+
+			It("register the serviceaccount name in the buildrun status", func() {
+				buildSample = ctl.DefaultBuild(buildName, "foobar-strategy", build.ClusterBuildStrategyKind)
+				buildRunSample = ctl.BuildRunWithSAGenerate(buildRunSample.Name, buildName)
+				saName := buildRunSample.Name+"-sa"
+	
+				statusCall := ctl.StubBuildRunStatus(
+					"Succeeded",
+					&taskRunName,
+					build.Condition{
+						Type:   build.Succeeded,
+						Reason: "Succeeded",
+						Status: corev1.ConditionTrue,
+					},
+					corev1.ConditionTrue,
+					buildSample.Spec,
+					&saName,
+					false,
+				)
+				statusWriter.UpdateCalls(statusCall)
+
+				result, err := reconciler.Reconcile(taskRunRequest)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reconcile.Result{}).To(Equal(result))
+				Expect(client.StatusCallCount()).To(Equal(1))
 			})
 
 			It("should not panic in case the build spec strategy is nil", func() {
@@ -288,6 +314,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionUnknown,
 					buildSample.Spec,
+					nil,
 					false,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -318,6 +345,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionUnknown,
 					buildSample.Spec,
+					nil,
 					false,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -345,6 +373,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionTrue,
 					buildSample.Spec,
+					nil,
 					false,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -440,6 +469,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					nil,
 					false,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -667,6 +697,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					nil,
 					true,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -731,6 +762,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					&saName,
 					true,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -799,6 +831,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					&saName,
 					true,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -864,6 +897,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					&saName,
 					true,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -922,6 +956,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					&saName,
 					true,
 				))
 
@@ -959,6 +994,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					&saName,
 					true,
 				)
 				statusWriter.UpdateCalls(statusCall)
@@ -1059,6 +1095,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 					},
 					corev1.ConditionFalse,
 					buildSample.Spec,
+					nil,
 					true,
 				)
 				statusWriter.UpdateCalls(statusCall)

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -300,7 +300,7 @@ func (c *Catalog) StubBuildStatusReason(reason build.BuildReason, message string
 }
 
 // StubBuildRunStatus asserts Status fields on a BuildRun resource
-func (c *Catalog) StubBuildRunStatus(reason string, name *string, condition build.Condition, status corev1.ConditionStatus, buildSpec build.BuildSpec, tolerateEmptyStatus bool) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
+func (c *Catalog) StubBuildRunStatus(reason string, name *string, condition build.Condition, status corev1.ConditionStatus, buildSpec build.BuildSpec, sa *string, tolerateEmptyStatus bool) func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 	return func(context context.Context, object runtime.Object, _ ...crc.UpdateOption) error {
 		switch object := object.(type) {
 		case *build.BuildRun:
@@ -311,6 +311,9 @@ func (c *Catalog) StubBuildRunStatus(reason string, name *string, condition buil
 			}
 			if object.Status.BuildSpec != nil {
 				Expect(*object.Status.BuildSpec).To(Equal(buildSpec))
+			}
+			if object.Status.ServiceAccountName != nil {
+				Expect(object.Status.ServiceAccountName).To(Equal(sa))
 			}
 		}
 		return nil

--- a/test/integration/buildruns_to_sa_test.go
+++ b/test/integration/buildruns_to_sa_test.go
@@ -102,12 +102,14 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 			// Verify that the sa have our Build specified secret
 			Expect(contains(sa.Secrets, buildObject.Spec.Output.Credentials.Name)).To(BeTrue())
 
-			_, err = tb.GetBRTillCompletion(buildRunObject.Name)
+			br, err := tb.GetBRTillCompletion(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
 			_, err = tb.GetSA(fmt.Sprintf("%s-sa", buildRunObject.Name))
 			Expect(err).ToNot(BeNil())
 
+			// Verify that the sa name is set in the buildrun status
+			Expect(*br.Status.ServiceAccountName).To(Equal(fmt.Sprintf("%s-sa", buildRunObject.Name)))
 		})
 	})
 
@@ -200,12 +202,15 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
-			_, err = tb.GetBRTillStartTime(buildRunObject.Name)
+			br, err := tb.GetBRTillStartTime(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
 			tr, err := tb.GetTaskRunFromBuildRun(buildRunObject.Name)
 			Expect(err).To(BeNil())
 			Expect(tr.Spec.ServiceAccountName).To(Equal("pipeline"))
+
+			// Verify that the sa name is set in the buildrun status
+			Expect(*br.Status.ServiceAccountName).To(Equal("pipeline"))
 		})
 
 		It("defaults to default serviceaccount if pipeline serviceaccount is not specified", func() {
@@ -220,12 +225,15 @@ var _ = Describe("Integration tests BuildRuns and Service-accounts", func() {
 
 			Expect(tb.CreateBR(buildRunObject)).To(BeNil())
 
-			_, err = tb.GetBRTillStartTime(buildRunObject.Name)
+			br, err := tb.GetBRTillStartTime(buildRunObject.Name)
 			Expect(err).To(BeNil())
 
 			tr, err := tb.GetTaskRunFromBuildRun(buildRunObject.Name)
 			Expect(err).To(BeNil())
 			Expect(tr.Spec.ServiceAccountName).To(Equal(expectedServiceAccount))
+
+			// Verify that the sa name is set in the buildrun status
+			Expect(*br.Status.ServiceAccountName).To(Equal(expectedServiceAccount))
 		})
 	})
 


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This PR aims to add the service account name to the buildrun status.

<!-- If this PR fixes a GitHub issue, please mention it like so:
https://github.com/shipwright-io/build/issues/522
Fixes #<insert issue number here>

-->

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The name of the used service account is now reflected in the status of the BuildRun
```