### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
           with:
             version: ${{ matrix.kubernetes }}
         - name: Create kind cluster
-          uses: helm/kind-action@v1.1.0
+          uses: helm/kind-action@v1.2.0
           with:
-            version: v0.10.0
+            version: v0.11.1
             node_image: kindest/node:${{ matrix.kubernetes }}
             cluster_name: kind
             wait: 120s
@@ -66,9 +66,24 @@ jobs:
             kubectl config use-context "kind-kind"
             echo "# KinD nodes:"
             kubectl get nodes
+
+            NODE_STATUS=$(kubectl get node kind-control-plane -o json | jq -r .'status.conditions[] | select(.type == "Ready") | .status')
+            if [ "${NODE_STATUS}" != "True" ]; then
+              echo "# Node is not ready:"
+              kubectl describe node kind-control-plane
+
+              echo "# Pods:"
+              kubectl get pod -A
+              echo "# Events:"
+              kubectl get events -A
+
+              exit 1
+            fi
         - name: Install Tekton
           run: |
             make kind-tekton
+            kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-controller --timeout=1m
+            kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-webhook --timeout=1m
         - name: Test
           run: |
             export GIT_CONTAINER_IMAGE="$(KO_DOCKER_REPO=kind.local ko publish ./cmd/git)"
@@ -99,9 +114,9 @@ jobs:
           with:
             version: ${{ matrix.kubernetes }}
         - name: Create kind cluster
-          uses: helm/kind-action@v1.1.0
+          uses: helm/kind-action@v1.2.0
           with:
-            version: v0.10.0
+            version: v0.11.1
             node_image: kindest/node:${{ matrix.kubernetes }}
             cluster_name: kind
             config: test/kind/config.yaml
@@ -112,6 +127,19 @@ jobs:
             kubectl config use-context "kind-kind"
             echo "# KinD nodes:"
             kubectl get nodes
+
+            NODE_STATUS=$(kubectl get node kind-control-plane -o json | jq -r .'status.conditions[] | select(.type == "Ready") | .status')
+            if [ "${NODE_STATUS}" != "True" ]; then
+              echo "# Node is not ready:"
+              kubectl describe node kind-control-plane
+
+              echo "# Pods:"
+              kubectl get pod -A
+              echo "# Events:"
+              kubectl get events -A
+
+              exit 1
+            fi
         - name: Install Tekton
           run: |
             make kind-tekton

--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -11,7 +11,7 @@
 set -eu
 
 # kind version
-KIND_VERSION="${KIND_VERSION:-v0.10.0}"
+KIND_VERSION="${KIND_VERSION:-v0.11.1}"
 
 if [ ! -f "${GOPATH}/bin/kind" ] ; then
     echo "# Installing KinD..."


### PR DESCRIPTION
# Changes

Our PR builds were not functional anymore. In the **Verify kind cluster** step, it was visible that the Kubernetes node was not ready but the script did not stop the test. I therefore extended that step to check the node status, print debug information in case it is not ready and also to fail the test from there.

In our case, kube-proxy was not starting with a permission denied error in its logs. I did not look further why this was happening, because my try in updating KinD resolved it.

Also making sure that there is always a `kubectl rollout status deployment` after Tekton has been installed.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```