### PR TITLE
Add check for controller gen version

### DIFF
--- a/hack/install-controller-gen.sh
+++ b/hack/install-controller-gen.sh
@@ -20,8 +20,8 @@ if [ ! -f "${GOPATH}/bin/controller-gen" ]; then
   popd >/dev/null 2>&1
 fi
 
-if ! grep -q " $CONTROLLER_GEN_VERSION$" <<<"$(${GOPATH}/bin/controller-gen --version)"; then
-  echo "Current controller-gen version $(${GOPATH}/bin/controller-gen --version | cut -d' ' -f2) does not match desired version $CONTROLLER_GEN_VERSION."
+if ! grep -q " $CONTROLLER_GEN_VERSION$" <<<"$("${GOPATH}"/bin/controller-gen --version)"; then
+  echo "Current controller-gen version $("${GOPATH}"/bin/controller-gen --version | cut -d' ' -f2) does not match desired version $CONTROLLER_GEN_VERSION."
   echo "In order to update, run:"
   echo "  GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}"
   echo
@@ -29,4 +29,4 @@ if ! grep -q " $CONTROLLER_GEN_VERSION$" <<<"$(${GOPATH}/bin/controller-gen --ve
 fi
 
 # print controller-gen version
-${GOPATH}/bin/controller-gen --version
+"${GOPATH}"/bin/controller-gen --version

--- a/hack/install-controller-gen.sh
+++ b/hack/install-controller-gen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright The Shipwright Contributors
-# 
+#
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -13,12 +13,20 @@ set -eu
 # controller-gen version
 CONTROLLER_GEN_VERSION="${CONTROLLER_GEN_VERSION:-v0.5.0}"
 
-if [ ! -f "${GOPATH}/bin/controller-gen" ] ; then
-    echo "# Installing controller-gen..."
-    pushd "$(mktemp -d)" >/dev/null 2>&1
-    GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@"${CONTROLLER_GEN_VERSION}"
-    popd >/dev/null 2>&1
+if [ ! -f "${GOPATH}/bin/controller-gen" ]; then
+  echo "# Installing controller-gen..."
+  pushd "$(mktemp -d)" >/dev/null 2>&1
+  GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@"${CONTROLLER_GEN_VERSION}"
+  popd >/dev/null 2>&1
+fi
+
+if ! grep -q " $CONTROLLER_GEN_VERSION$" <<<"$(${GOPATH}/bin/controller-gen --version)"; then
+  echo "Current controller-gen version $(${GOPATH}/bin/controller-gen --version | cut -d' ' -f2) does not match desired version $CONTROLLER_GEN_VERSION."
+  echo "In order to update, run:"
+  echo "  GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}"
+  echo
+  exit 1
 fi
 
 # print controller-gen version
-controller-gen --version
+${GOPATH}/bin/controller-gen --version


### PR DESCRIPTION
# Changes

In order to avoid using a different version than defined, the `controller-gen`
version should be checked. Add simple check whether the versions match.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
