### PR TITLE
Increase log output readability

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -15,7 +16,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/shipwright-io/build/pkg/ctxlog"
 	"github.com/spf13/pflag"
 )
 
@@ -46,6 +46,7 @@ type settings struct {
 	target              string
 	resultFileCommitSha string
 	secretPath          string
+	skipValidation      bool
 }
 
 var flagValues settings
@@ -56,10 +57,6 @@ var (
 )
 
 func init() {
-	// Add the zap logger flag set to the CLI. The flag set must
-	// be added before calling pflag.Parse().
-	pflag.CommandLine.AddGoFlagSet(ctxlog.CustomZapFlagSet())
-
 	// Main flags for the Git step to define the configuration, for example
 	// the flags for `url`, and `target` will always be used, but `revision`
 	// depends on the respective use case.
@@ -73,30 +70,22 @@ func init() {
 	// which should be fine for almost all use cases we use the Git source step
 	// for (in the context of Shipwright build).
 	pflag.UintVar(&flagValues.depth, "depth", 1, "Create a shallow clone based on the given depth")
+
+	// Mostly internal flag
+	pflag.BoolVar(&flagValues.skipValidation, "skip-validation", false, "skip pre-requisite validation")
 }
 
 func main() {
-	if err := checkAndRun(); err != nil {
+	if err := Execute(context.Background()); err != nil {
 		var exitcode = 1
 		switch err := err.(type) {
 		case *ExitError:
 			exitcode = err.Code
 		}
 
+		log.Print(err.Error())
 		os.Exit(exitcode)
 	}
-}
-
-func checkAndRun() error {
-	// create logger and context
-	l := ctxlog.NewLogger("git")
-	ctx := ctxlog.NewParentContext(l)
-
-	if err := checkEnvironment(ctx); err != nil {
-		return err
-	}
-
-	return Execute(ctx)
 }
 
 // Execute performs flag parsing, input validation and the Git clone
@@ -104,12 +93,16 @@ func Execute(ctx context.Context) error {
 	flagValues = settings{depth: 1}
 	pflag.Parse()
 
-	err := runGitClone(ctx)
-	if err != nil {
-		ctxlog.Error(ctx, err, "program failed with an error")
+	// pre-req checks
+	if err := checkEnvironment(ctx); err != nil {
+		return err
 	}
 
-	return err
+	if err := runGitClone(ctx); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func runGitClone(ctx context.Context) error {
@@ -140,6 +133,10 @@ func runGitClone(ctx context.Context) error {
 }
 
 func checkEnvironment(ctx context.Context) error {
+	if flagValues.skipValidation {
+		return nil
+	}
+
 	var checks = []struct{ toolName, versionArg string }{
 		{toolName: "ssh", versionArg: "-V"},
 		{toolName: "git", versionArg: "version"},
@@ -157,9 +154,10 @@ func checkEnvironment(ctx context.Context) error {
 			return err
 		}
 
-		ctxlog.Info(ctx, check.toolName,
-			"path", path,
-			"version", strings.TrimRight(string(out), "\n"),
+		log.Printf("Info: %s (%s): %s\n",
+			check.toolName,
+			path,
+			strings.TrimRight(string(out), "\n"),
 		)
 	}
 
@@ -296,13 +294,28 @@ func clone(ctx context.Context) error {
 	if flagValues.depth > 0 {
 		submoduleArgs = append(submoduleArgs, "--depth", fmt.Sprintf("%d", flagValues.depth))
 	}
-	_, err := git(ctx, submoduleArgs...)
-	return err
+
+	if _, err := git(ctx, submoduleArgs...); err != nil {
+		return err
+	}
+
+	head, err := ioutil.ReadFile(filepath.Join(flagValues.target, ".git", "HEAD"))
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Successfully loaded %s (%s) into %s\n",
+		flagValues.url,
+		strings.TrimRight(string(head), "\n"),
+		flagValues.target,
+	)
+
+	return nil
 }
 
 func git(ctx context.Context, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
-	ctxlog.Debug(ctx, cmd.String())
+	log.Print(cmd.String())
 
 	// Make sure that the spawned process does not try to prompt for infos
 	os.Setenv("GIT_TERMINAL_PROMPT", "0")
@@ -328,11 +341,6 @@ func git(ctx context.Context, args ...string) (string, error) {
 				Cause:   err,
 			}
 		}
-
-		ctxlog.Error(ctx, err, "git command failed",
-			"command", cmd.String(),
-			"output", output,
-		)
 	}
 
 	return output, err

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -299,14 +299,20 @@ func clone(ctx context.Context) error {
 		return err
 	}
 
-	head, err := ioutil.ReadFile(filepath.Join(flagValues.target, ".git", "HEAD"))
-	if err != nil {
-		return err
+	revision := flagValues.revision
+	if revision == "" {
+		// user requested to clone the default branch, determine the branch name
+		refParse, err := git(ctx, "-C", flagValues.target, "rev-parse", "--abbrev-ref", "HEAD")
+		if err != nil {
+			return err
+		}
+
+		revision = strings.TrimRight(refParse, "\n")
 	}
 
 	log.Printf("Successfully loaded %s (%s) into %s\n",
 		flagValues.url,
-		strings.TrimRight(string(head), "\n"),
+		revision,
 		flagValues.target,
 	)
 

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -7,6 +7,7 @@ package main_test
 import (
 	"context"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -20,7 +21,8 @@ import (
 
 var _ = Describe("Git Resource", func() {
 	var run = func(args ...string) error {
-		os.Args = append([]string{"tool", "--zap-log-level", "fatal"}, args...)
+		log.SetOutput(ioutil.Discard)
+		os.Args = append([]string{"tool", "--skip-validation"}, args...)
 		return Execute(context.TODO())
 	}
 


### PR DESCRIPTION
# Changes

The current output of the Git step was using the log style of the controller,
which is configured to be machine consumable. However, the output should be
more aligned with the output that is created by other steps. Tools like Kaniko
or Buildpacks produce more human style output. This is also feedback that we
received from users, especially in the case when the source retrieval failed for
some reason, for example TYPO of the branch name or similar.

Replace `ctxlog` with `log` and simplify log output to be human friendly.

Add new end message that contains all relevant details, including HEAD info.

For reference:
- Before:
  ```json
  {"level":"info","ts":1626871924.300413,"logger":"git","msg":"ssh","path":"/usr/bin/ssh","version":"OpenSSH_8.1p1, LibreSSL 2.7.3"}
  {"level":"info","ts":1626871924.319007,"logger":"git","msg":"git","path":"/usr/local/bin/git","version":"git version 2.32.0"}
  {"level":"info","ts":1626871924.3794508,"logger":"git","msg":"git-lfs","path":"/usr/local/bin/git-lfs","version":"git-lfs/2.13.3 (GitHub; darwin amd64; go 1.16.5)"}
  {"level":"debug","ts":1626871924.379594,"logger":"git","msg":"/usr/local/bin/git clone --quiet --no-tags --single-branch --depth 1 -- https://github.com/shipwright-io/sample-go /tmp/workspace/source"}
  {"level":"debug","ts":1626871925.524959,"logger":"git","msg":"/usr/local/bin/git -C /tmp/workspace/source submodule update --init --recursive --depth 1"}
  ```
- After:
  ```
  2021/07/21 14:39:15 Info: ssh (/usr/bin/ssh): OpenSSH_8.1p1, LibreSSL 2.7.3
  2021/07/21 14:39:15 Info: git (/usr/local/bin/git): git version 2.32.0
  2021/07/21 14:39:16 Info: git-lfs (/usr/local/bin/git-lfs): git-lfs/2.13.3 (GitHub; darwin amd64; go 1.16.5)
  2021/07/21 14:39:16 /usr/local/bin/git clone --quiet --no-tags --single-branch --depth 1 -- https://github.com/shipwright-io/sample-go /tmp/workspace/source
  2021/07/21 14:39:16 /usr/local/bin/git -C /tmp/workspace/source submodule update --init --recursive --depth 1
  2021/07/21 14:39:17 Successfully loaded https://github.com/shipwright-io/sample-go (ref: refs/heads/main) into /tmp/workspace/source
  ```

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Improved output messages created by the Git step to be more human readable.
```
