### PR TITLE
Declutter Git step log output

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -221,6 +221,7 @@ func clone(ctx context.Context) error {
 			}
 
 			var sshCmd = []string{"ssh",
+				"-o", "LogLevel=ERROR",
 				"-o", "BatchMode=yes",
 				"-i", sshPrivateKeyFile.Name(),
 			}

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -9,6 +9,7 @@ RUN \
   microdnf clean all && \
   rm -rf /var/cache/yum && \
   echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
-  echo 'nonroot:x:1000:' > /etc/group
+  echo 'nonroot:x:1000:' > /etc/group && \
+  mkdir /.docker && chown 1000:1000 /.docker
 
 USER 1000:1000

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -10,6 +10,7 @@ RUN \
   rm -rf /var/cache/yum && \
   echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
   echo 'nonroot:x:1000:' > /etc/group && \
-  mkdir /.docker && chown 1000:1000 /.docker
+  mkdir /.docker && chown 1000:1000 /.docker && \
+  mkdir /.ssh && chown 1000:1000 /.ssh
 
 USER 1000:1000


### PR DESCRIPTION
# Changes

We received end user feedback on some Git step output messages being misleading, which might take the focus away from the actual error message:
- Omit warnings in Git+SSH use cases.
- Add Tekton related `.docker` directory to base image to avoid warning.
- Avoid misleading `.ssh` directory message by putting it into the base image.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Updated Git download step to avoid misleading warnings and messages.
```

