### PR TITLE
Enforce label name limits in resource names

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -62,6 +62,7 @@ In order to prevent users from triggering `BuildRuns` (_execution of a Build_) t
 | RestrictedParametersInUse | One or many defined `params` are colliding with Shipwright reserved parameters. See [Defining Params](#defining-params) for more information. |
 | UndefinedParameter | One or many defined `params` are not defined in the referenced strategy. Please ensure that the strategy defines them under its `spec.parameters` list. |
 | RemoteRepositoryUnreachable | The defined `spec.source.url` was not found. This validation only take place for http/https protocols. |
+| BuildNameInvalid | The defined `Build` name (`metadata.name`) is invalid. The `Build` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). |
 
 ## Configuring a Build
 

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -202,6 +202,7 @@ The following table illustrates the different states a BuildRun can have under i
 | False    | BuildRegistrationFailed      | Yes | The related Build in the BuildRun is on a Failed state. |
 | False    | BuildNotFound                | Yes | The related Build in the BuildRun was not found. |
 | False    | BuildRunCanceled             | Yes | The BuildRun and underlying TaskRun were canceled successfully. |
+| False | BuildRunNameInvalid | Yes | The defined `BuildRun` name (`metadata.name`) is invalid. The `BuildRun` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). |
 
 _Note_: We heavily rely on the Tekton TaskRun [Conditions](https://github.com/tektoncd/pipeline/blob/main/docs/taskruns.md#monitoring-execution-status) for populating the BuildRun ones, with some exceptions.
 

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -38,6 +38,8 @@ const (
 	UndefinedParameter BuildReason = "UndefinedParameter"
 	// RemoteRepositoryUnreachable indicates the referenced repository is unreachable
 	RemoteRepositoryUnreachable BuildReason = "RemoteRepositoryUnreachable"
+	// BuildNameInvaid indicates the build name is invalid
+	BuildNameInvaid BuildReason = "BuildNameInvalid"
 	// AllValidationsSucceeded indicates a Build was successfully validated
 	AllValidationsSucceeded = "all validations succeeded"
 )

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -38,8 +38,8 @@ const (
 	UndefinedParameter BuildReason = "UndefinedParameter"
 	// RemoteRepositoryUnreachable indicates the referenced repository is unreachable
 	RemoteRepositoryUnreachable BuildReason = "RemoteRepositoryUnreachable"
-	// BuildNameInvaid indicates the build name is invalid
-	BuildNameInvaid BuildReason = "BuildNameInvalid"
+	// BuildNameInvalid indicates the build name is invalid
+	BuildNameInvalid BuildReason = "BuildNameInvalid"
 	// AllValidationsSucceeded indicates a Build was successfully validated
 	AllValidationsSucceeded = "all validations succeeded"
 )

--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -73,6 +73,7 @@ func (r *ReconcileBuild) Reconcile(request reconcile.Request) (reconcile.Result,
 		validate.Strategies,
 		validate.Runtime,
 		validate.Sources,
+		validate.BuildName,
 	}
 
 	// trigger all current validations

--- a/pkg/reconciler/buildrun/resources/conditions.go
+++ b/pkg/reconciler/buildrun/resources/conditions.go
@@ -33,6 +33,7 @@ const (
 	ConditionServiceAccountNotFound  string = "ServiceAccountNotFound"
 	ConditionBuildRegistrationFailed string = "BuildRegistrationFailed"
 	ConditionBuildNotFound           string = "BuildNotFound"
+	BuildRunNameInvalid              string = "BuildRunNameInvalid"
 )
 
 // UpdateBuildRunUsingTaskRunCondition updates the BuildRun Succeeded Condition

--- a/pkg/validate/buildname.go
+++ b/pkg/validate/buildname.go
@@ -1,0 +1,31 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"strings"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// BuildNameRef contains all required fields
+// to validate a build name
+type BuildNameRef struct {
+	Build *build.Build // build instance for analysis
+}
+
+// ValidatePath implements BuildPath interface and validates
+// that build name is a valid label value
+func (b *BuildNameRef) ValidatePath(_ context.Context) error {
+	if errs := validation.IsValidLabelValue(b.Build.Name); len(errs) > 0 {
+		b.Build.Status.Reason = build.BuildNameInvaid
+		b.Build.Status.Message = strings.Join(errs, ", ")
+	}
+
+	return nil
+}

--- a/pkg/validate/buildname.go
+++ b/pkg/validate/buildname.go
@@ -23,7 +23,7 @@ type BuildNameRef struct {
 // that build name is a valid label value
 func (b *BuildNameRef) ValidatePath(_ context.Context) error {
 	if errs := validation.IsValidLabelValue(b.Build.Name); len(errs) > 0 {
-		b.Build.Status.Reason = build.BuildNameInvaid
+		b.Build.Status.Reason = build.BuildNameInvalid
 		b.Build.Status.Message = strings.Join(errs, ", ")
 	}
 

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -24,6 +24,8 @@ const (
 	Runtime = "runtime"
 	// Sources for validating `spec.sources` entries
 	Sources = "sources"
+	// BuildName for validating `metadata.name` entry
+	BuildName = "buildname"
 	// OwnerReferences for validating the ownerreferences between a Build
 	// and BuildRun objects
 	OwnerReferences = "ownerreferences"
@@ -58,6 +60,8 @@ func NewValidation(
 		return &OwnerRef{Build: build, Client: client, Scheme: scheme}, nil
 	case Sources:
 		return &SourcesRef{Build: build}, nil
+	case BuildName:
+		return &BuildNameRef{Build: build}, nil
 	default:
 		return nil, fmt.Errorf("unknown validation type")
 	}

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -500,4 +500,23 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(buildIsDeleted).To(Equal(true))
 		})
 	})
+
+	Context("when a build name is invalid", func() {
+		BeforeEach(func() {
+			buildSample = []byte(test.BuildCBSMinimal)
+		})
+
+		It("fails the build with a proper error in Reason", func() {
+			// Set build name more than 63 characters
+			buildObject.Name = strings.Repeat("s", 64)
+			Expect(tb.CreateBuild(buildObject)).To(BeNil())
+
+			buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
+			Expect(err).To(BeNil())
+
+			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.BuildNameInvaid))
+			Expect(buildObject.Status.Message).To(ContainSubstring("must be no more than 63 characters"))
+		})
+	})
 })

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -515,7 +515,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 
 			Expect(buildObject.Status.Registered).To(Equal(corev1.ConditionFalse))
-			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.BuildNameInvaid))
+			Expect(buildObject.Status.Reason).To(Equal(v1alpha1.BuildNameInvalid))
 			Expect(buildObject.Status.Message).To(ContainSubstring("must be no more than 63 characters"))
 		})
 	})


### PR DESCRIPTION
# Changes

We got user feedback that build and buildrun names can be specified lead to controller error.
This is caused by the fact that the names used in the label they are strict in their length.

Add validation to enforce specific length for build and buildrun names.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Added validation to make sure that Build and BuildRun names follow the required character limits
```