### PR TITLE
Add shipwright sample pre-req image mirroring

### DIFF
--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -1,0 +1,25 @@
+name: Mirror pre-requisite images for Shipwright samples
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  build:
+    if: ${{ github.repository == 'shipwright-io/build' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install crane
+        run: curl --fail --silent --location https://github.com/google/go-containerregistry/releases/download/v0.5.1/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin crane
+
+      - name: Login to container registry
+        run: crane auth login --username "${{ secrets.REGISTRY_USERNAME }}" --password-stdin quay.io <<<"${{ secrets.REGISTRY_PASSWORD }}"
+
+      - name: Mirror images
+        run: |
+          crane cp golang:1.16 quay.io/shipwright-samples/golang:1.16
+          crane cp maven:3-jdk-8-openj9 quay.io/shipwright-samples/maven:3-jdk-8-openj9
+          crane cp openliberty/open-liberty:kernel-java8-openj9-ubi quay.io/shipwright-samples/open-liberty:kernel-java8-openj9-ubi
+          crane cp node:12 quay.io/shipwright-samples/node:12


### PR DESCRIPTION
# Changes

In order to be independent of DockerHub images in the samples, we should aim
for having equivalent images available in `quay.io`.

Add daily mirror job for required images.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
