### PR TITLE
Add Gatekeeper (Source Allowlist) example to docs

### DIFF
--- a/docs/gatekeeper.md
+++ b/docs/gatekeeper.md
@@ -10,7 +10,7 @@ An organization may want to limit builds to trusted sources, such as a github or
 
 ### Configure Gatekeeper to watch for `Build` resources
 
-Either Create or append to your gatekeeper-system config. This configmap specificies all resources that Gatekeeper will monitor.
+Either Create or append to your gatekeeper-system config. This configmap specifies all resources that Gatekeeper will monitor.
 
 ```yaml
 apiVersion: config.gatekeeper.sh/v1alpha1
@@ -141,7 +141,7 @@ spec:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/hello-world
 ```
 
-Attempting to create this will yeild an error.
+Attempting to create this will yield an error.
 
 ```sh
 $ kubectl apply -f hello-world-build.yaml

--- a/docs/gatekeeper.md
+++ b/docs/gatekeeper.md
@@ -1,0 +1,149 @@
+# Configure Shipwright with Gatekeeper
+
+[Gatekeeper](https://github.com/open-policy-agent/gatekeeper) is a customizable admission webhook for Kubernetes, which allows you to configure [policy](https://www.openpolicyagent.org/docs/latest/policy-language/) over what resources can be created in the cluster. Gatekeeper is very generic, but in particular we can use it to add policy to Shipwright `Build`s.
+
+## Only allow builds of allow-listed sources
+
+An organization may want to limit builds to trusted sources, such as a github organization or an internal git repository. This is an example of how something like that could be configured.
+
+(If you are using `kind` to test, you can use [hack/install-gatekeeper.sh](https://github.com/shipwright-io/build/blob/main/hack/install-tekton.sh) to install gatekeeper)
+
+### Configure Gatekeeper to watch for `Build` resources
+
+Either Create or append to your gatekeeper-system config. This configmap specificies all resources that Gatekeeper will monitor.
+
+```yaml
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: "gatekeeper-system"
+spec:
+  sync:
+    syncOnly:
+      - group: "shipwright.io"
+        version: "v1alpha1"
+        kind: "Build"
+```
+
+### Create the ShipwrightAllowlist Constraint Template
+
+This constraint template will let us create our [`ShipwrightAllowlist`](#create-your-shipwrightallowlist-constraint); in the paremeters to the `ShipwrightAllowlist` we will specify the allowed sources, and this constraint template will apply the logic.
+
+```yaml
+# Reference: https://github.com/open-policy-agent/gatekeeper/blob/master/demo/agilebank/templates/k8sallowedrepos_template.yaml
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: shipwrightallowlist
+spec:
+  crd:
+    spec:
+      names:
+        kind: ShipwrightAllowlist
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package shipwrightallowlist
+
+        violation[{"msg": msg}] {
+          input.review.object.kind == "Build"
+          repo_url := input.review.object.spec.source.url
+          repo = strings.replace_n({
+            "https://": "",
+            "http://": "",
+            "git://": "",
+            "ssh://": "",
+          }, repo_url)
+
+          # is the repo in the allowlist?
+          allowlist := [
+            good | source = input.parameters.allowedsources[_];
+            good = startswith(repo, source)
+          ]
+          not any(allowlist)
+
+          msg := sprintf("The Build repo has not been pre-approved: %v. Allowed sources are: %v", [repo, input.parameters.allowedsources])
+        }
+```
+
+### Create your ShipwrightAllowlist constraint
+
+```yaml
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: ShipwrightAllowlist
+metadata:
+  name: shipwrightallowlist
+spec:
+  match:
+    kinds:
+      - apiGroups: ["shipwright.io"]
+        kinds: ["Build"]
+  parameters:
+    # Remember to terminate the sources with a `/` at the end.
+    # Don't include the protocol. I.e.
+    # GOOD: "github.com/shipwright-io/"
+    # BAD:  "https://github.com/shipwright-io/"
+    allowedsources:
+      - "github.com/shipwright-io/"
+```
+
+
+### Test it out
+
+This `Build` will be created, as is under the `github.com/shipwright-io/` organization, so it is allowed.
+
+```yaml
+# sample-go-build.yaml
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: buildah-golang-build
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-go
+    contextDir: docker-build
+  strategy:
+    name: buildah
+    kind: ClusterBuildStrategy
+  dockerfile: Dockerfile
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app
+```
+
+Create it 
+
+```sh
+$ kubectl apply -f sample-go-build.yaml
+build.shipwright.io/buildah-golang-build created
+```
+
+
+However the build below will not be created, as it belongs to `https://github.com/docker-library/`
+
+```yaml
+# hello-world-build.yaml
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: kaniko-hello-world-build
+  annotations:
+    build.shipwright.io/build-run-deletion: "true"
+spec:
+  source:
+    url: https://github.com/docker-library/hello-world
+    contextDir: .
+  strategy:
+    name: kaniko
+    kind: ClusterBuildStrategy
+  dockerfile: Dockerfile.build
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/hello-world
+```
+
+Attempting to create this will yeild an error.
+
+```sh
+$ kubectl apply -f hello-world-build.yaml
+Error from server ([shipwrightallowlist] The Build repo has not been pre-approved: github.com/docker-library/hello-world. Allowed sources are: ["github.com/shipwright-io/"]): error when creating "hello-world-build.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [shipwrightallowlist] The Build repo has not been pre-approved: github.com/docker-library/hello-world. Allowed sources are: ["github.com/shipwright-io/"]
+```

--- a/hack/README.md
+++ b/hack/README.md
@@ -15,6 +15,7 @@ This directory contains several scripts useful in the development process of Shi
 - `install-kubectl.sh` Install the kubectl command line.
 - `install-registry.sh` Install the local container registry in the KinD cluster.
 - `install-tekton.sh` Install the latest verified Tekton Pipeline release.
+- `install-gatekeeper.sh` Install Gatekeeper release.
 - `release.sh` Creates a new release of Shipwright Build.
 - `update-codegen.sh` Updates auto-generated client libraries.
 - `verify-codegen.sh` Verifies that auto-generated client libraries are up-to-date.

--- a/hack/install-gatekeeper.sh
+++ b/hack/install-gatekeeper.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright The Shipwright Contributors
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Installs Gatekeeper.
+# (Used for example gatekeeper policies)
+#
+# At the time of writing, installing 3.4 instead of 3.5
+# because of a regression in the latest release
+# https://github.com/open-policy-agent/gatekeeper/issues/1468
+
+set -eu
+
+GATEKEEPER_VERSION="${GATEKEEPER_VERSION:-3.4}"
+GATEKEEPER_HOST="raw.githubusercontent.com"
+GATEKEEPER_HOST_PATH="open-policy-agent/gatekeeper/release-${GATEKEEPER_VERSION}/deploy"
+
+echo "# Deploying Gatekeeper '${GATEKEEPER_VERSION}'"
+
+kubectl apply -f "https://${GATEKEEPER_HOST}/${GATEKEEPER_HOST_PATH}/gatekeeper.yaml"


### PR DESCRIPTION
# Changes

Adds an example [Gatekeeper](https://github.com/open-policy-agent/gatekeeper) ConstraintTemplate (ShipwrightAllowlist) and Constraint to the docs (and an install script in `hack/`) to show how one could apply an allowlist to `source.url`s in the `Build`s. 

The motivation for this is organizations who might only want to build source code from trusted sources, such as their own git servers or specific trusted organizations.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```