### PR TITLE
Update links to point to restrictions for a label value

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -62,7 +62,7 @@ In order to prevent users from triggering `BuildRuns` (_execution of a Build_) t
 | RestrictedParametersInUse | One or many defined `params` are colliding with Shipwright reserved parameters. See [Defining Params](#defining-params) for more information. |
 | UndefinedParameter | One or many defined `params` are not defined in the referenced strategy. Please ensure that the strategy defines them under its `spec.parameters` list. |
 | RemoteRepositoryUnreachable | The defined `spec.source.url` was not found. This validation only take place for http/https protocols. |
-| BuildNameInvalid | The defined `Build` name (`metadata.name`) is invalid. The `Build` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). |
+| BuildNameInvalid | The defined `Build` name (`metadata.name`) is invalid. The `Build` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
 
 ## Configuring a Build
 

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -202,7 +202,7 @@ The following table illustrates the different states a BuildRun can have under i
 | False    | BuildRegistrationFailed      | Yes | The related Build in the BuildRun is on a Failed state. |
 | False    | BuildNotFound                | Yes | The related Build in the BuildRun was not found. |
 | False    | BuildRunCanceled             | Yes | The BuildRun and underlying TaskRun were canceled successfully. |
-| False | BuildRunNameInvalid | Yes | The defined `BuildRun` name (`metadata.name`) is invalid. The `BuildRun` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). |
+| False | BuildRunNameInvalid | Yes | The defined `BuildRun` name (`metadata.name`) is invalid. The `BuildRun` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
 
 _Note_: We heavily rely on the Tekton TaskRun [Conditions](https://github.com/tektoncd/pipeline/blob/main/docs/taskruns.md#monitoring-execution-status) for populating the BuildRun ones, with some exceptions.
 


### PR DESCRIPTION
# Changes

Just stumbled over our docs link there which is going to Kubernetes' limitations for a label key. But, relevant are the limitations of label values. Updating the link.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
