### PR TITLE
Draft: Add private git repo hack script

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -15,6 +15,7 @@ This directory contains several scripts useful in the development process of Shi
 - `install-kubectl.sh` Install the kubectl command line.
 - `install-registry.sh` Install the local container registry in the KinD cluster.
 - `install-tekton.sh` Install the latest verified Tekton Pipeline release.
+- `install-private-repo.sh` Install a "private repo" (sample-nodejs) as a ssh-gitserver inside kind.
 - `release.sh` Creates a new release of Shipwright Build.
 - `update-codegen.sh` Updates auto-generated client libraries.
 - `verify-codegen.sh` Verifies that auto-generated client libraries are up-to-date.

--- a/hack/install-private-repo.sh
+++ b/hack/install-private-repo.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Copyright The Shipwright Contributors
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Installs a private git repo into the cluster (for testing private repo builds)
+#
+
+set -eu
+
+DOCKER_PRIVATE_REPO_IMAGE=private-git-repo-test
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+
+tmp_dir=$(mktemp -d -t ssh-XXXXXXXXXX)
+trap "rm -rf $tmp_dir" EXIT
+
+ssh-keygen -b 2048 -t rsa -f $tmp_dir/sshkey -q -N ""
+
+echo "# Building a private repo docker image..."
+
+# The Dockerhub repo
+# https://hub.docker.com/r/jkarlos/git-server-docker/
+cat <<EOF | docker build -t $DOCKER_PRIVATE_REPO_IMAGE -
+FROM docker.io/jkarlos/git-server-docker
+
+RUN echo "$(cat ${tmp_dir}/sshkey.pub)" > /git-server/keys/sshkey.pub \
+    && chmod 600 /git-server/keys/sshkey.pub
+
+RUN git clone https://github.com/shipwright-io/sample-nodejs \
+      /git-server/repos/sample-nodejs.git
+
+WORKDIR /git-server/
+EOF
+
+echo "# Loading into kind..."
+kind load docker-image $DOCKER_PRIVATE_REPO_IMAGE --name $KIND_CLUSTER_NAME
+
+echo "# Deploying Git Server..."
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitserver
+  labels:
+    app: gitserver
+spec:
+  selector:
+    matchLabels:
+      app: gitserver
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: gitserver
+    spec:
+      containers:
+      - name: gitserver
+        image: $DOCKER_PRIVATE_REPO_IMAGE
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: ssh
+          containerPort: 22
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitserver
+spec:
+  ports:
+  - name: ssh
+    port: 22
+    targetPort: 22
+  selector:
+    app: gitserver
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${DOCKER_PRIVATE_REPO_IMAGE}-secret
+type: kubernetes.io/ssh-auth
+data:
+  ssh-privatekey: "$(cat ${tmp_dir}/sshkey | base64 | sed 's/$/\\n/' | tr -d '\n')"
+EOF
+
+kubectl rollout restart deployment gitserver
+
+# The GIT_SSH_COMMAND magic
+# https://stackoverflow.com/a/29754018
+
+cat <<EOF
+# To clone from this repo, run
+#
+#   > kubectl get secrets private-git-repo-test-secret -o json | jq -r '.data[]' | base64 -d > sshkey
+#   > chmod 600 sshkey
+#   > kubectl port-forward svc/gitserver 2222:22
+#   > GIT_SSH_COMMAND='ssh -i sshkey -o IdentitiesOnly=yes -o StrictHostKeyChecking=no' \
+#         git clone ssh://git@localhost:2222/git-server/repos/sample-private-repo.git
+#
+EOF


### PR DESCRIPTION
**NOTE: PR still in draft, looking for feedback on whether to continue**

# Changes

I noticed this issue https://github.com/shipwright-io/build/issues/689 to create tests for pulling from private repos. I had recently done something similar, so thought I might take a look, and threw together this little `hack/` script. I wondered if it might be useful

Instead of doing all the plumbing with private github/gitlab repos, this just deploys an ssh-key based git server (with a copy of `sample-nodejs`) into `kind` at `svc/gitserver` and it creates a one-off ssh key, loading the pubkey into the git server and the private key into a k8s secret.

This is definitely not as comprehensive as having a dedicated github and gitlab repo all plumbed up... However it means that you can test the functionality without having a private repo on-hand and in a pretty "passwordless" way. Plus collaborators will be able to run the e2e tests themselves with this route.

If you're interested in this as a possible solution for #689 , I can try to do the github-actions plumbing to run the hack script and cherry-pick the e2e tests from here https://github.com/shipwright-io/build/pull/757/files , probably this weekend

# TODO

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```

