### PR TITLE
Add results to Kaniko-Trivy sample

### DIFF
--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
@@ -40,10 +40,12 @@ spec:
         - --snapshotMode=redo
         - --no-push
         - --tarPath
-        - /tar/image.tar
+        - /kaniko/tar-image/image.tar
       volumeMounts:
+        - name: layout
+          mountPath: /kaniko/oci-image-layout
         - name: tar
-          mountPath: /tar/
+          mountPath: /kaniko/tar-image
       resources:
         limits:
           cpu: 500m
@@ -63,6 +65,9 @@ spec:
         - --severity=CRITICAL
         - --input
         - /image/image.tar
+      env:
+        - name: HOME
+          value: /tekton/home
       resources:
         limits:
           cpu: 500m
@@ -84,5 +89,29 @@ spec:
         - /image/image.tar
         - $(params.shp-output-image)
       env:
-        - name: DOCKER_CONFIG
-          value: /root/.docker/
+        - name: HOME
+          value: /tekton/home
+    - name: results
+      image: registry.access.redhat.com/ubi8/ubi-minimal
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          set -euo pipefail
+          
+          # Store the image digest
+          grep digest /kaniko/oci-image-layout/index.json | sed -E 's/.*sha256([^"]*).*/sha256\1/' | tr -d '\n' > "$(results.shp-image-digest.path)"
+
+          # Store the image size
+          du -b -c /kaniko/oci-image-layout/blobs/sha256/* | tail -1 | sed 's/\s*total//' | tr -d '\n' > "$(results.shp-image-size.path)"
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      volumeMounts:
+        - name: layout
+          mountPath: /kaniko/oci-image-layout


### PR DESCRIPTION
# Changes

fya @blairdrummond 

I tried the strategy on my local cluster. Works on arm64. :-)

I added the necessary step to write the image digest and size result in the same way as the "normal" Kaniko strategy does it. Beside that I changed this:

* In the Kaniko step, I changed the output path of the tar image to a path inside /kaniko as this path is safe and Kaniko never considers it to be included into the image it builds
* I added the `HOME=/tekton/home` env var to the trivy step. Recent Tekton versions don't set this anymore by default. For me the step failed to create a directory under `/` without the env var.
* I also added the same env var to the crane-push step. And that confused me. Originally, the DOCKER_CONFIG was set to /root/.docker/ but I have no idea why that could work. We still rely on Tekton's creds-init to place the output image secret in the container and that goes into /tekton/home/.docker/config.json. In the e2e tests this did not matter as the registry there does not require authentication. But not sure how @blairdrummond had this set up.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
