### PR TITLE
Add missing test case for Build name validations

### DIFF
--- a/test/utils/builds.go
+++ b/test/utils/builds.go
@@ -43,6 +43,11 @@ func (t *TestBuild) GetBuild(name string) (*v1alpha1.Build, error) {
 		Builds(t.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
+// ListBuilds returns existing Builds from the desired namespace
+func (t *TestBuild) ListBuilds(namespace string) (*v1alpha1.BuildList, error) {
+	return t.BuildClientSet.ShipwrightV1alpha1().Builds(namespace).List(t.Context, metav1.ListOptions{})
+}
+
 // PatchBuild patches an existing Build using the merge patch type
 func (t *TestBuild) PatchBuild(buildName string, data []byte) (*v1alpha1.Build, error) {
 	return t.PatchBuildWithPatchType(buildName, data, types.MergePatchType)


### PR DESCRIPTION
# Changes

Add test case that validates the Kubernetes automatic sanity check,
which shrinks the provided generateName in order to be compliant with
the 63 max characters.

Signed-off-by: Shahul T <Shahul.T@ibm.com>

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
