### PR TITLE
Fix output image credentials for bundle E2E

### DIFF
--- a/test/e2e/common_suite_test.go
+++ b/test/e2e/common_suite_test.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
@@ -70,12 +72,20 @@ func (b *buildPrototype) OutputImage(image string) *buildPrototype {
 	return b
 }
 
+func (b *buildPrototype) OutputImageCredentials(name string) *buildPrototype {
+	if name != "" {
+		b.build.Spec.Output.Credentials = &core.LocalObjectReference{Name: name}
+	}
+
+	return b
+}
+
 func (b buildPrototype) Create() (*buildv1alpha1.Build, error) {
 	return testBuild.
 		BuildClientSet.
 		ShipwrightV1alpha1().
 		Builds(b.build.Namespace).
-		Create(context.Background(), &b.build, v1.CreateOptions{})
+		Create(context.Background(), &b.build, meta.CreateOptions{})
 }
 
 func NewBuildRunPrototype() *buildRunPrototype {
@@ -106,7 +116,7 @@ func (b *buildRunPrototype) Create() (*buildv1alpha1.BuildRun, error) {
 		BuildClientSet.
 		ShipwrightV1alpha1().
 		BuildRuns(b.buildRun.Namespace).
-		Create(context.Background(), &b.buildRun, v1.CreateOptions{})
+		Create(context.Background(), &b.buildRun, meta.CreateOptions{})
 }
 
 // Logf logs data

--- a/test/e2e/e2e_bundle_test.go
+++ b/test/e2e/e2e_bundle_test.go
@@ -65,6 +65,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				SourceContextDir("docker-build").
 				Dockerfile("Dockerfile").
 				OutputImage(outputImage).
+				OutputImageCredentials(os.Getenv(EnvVarImageRepoSecret)).
 				Create()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -86,6 +87,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				SourceBundle(inputImage).
 				SourceContextDir("source-build").
 				OutputImage(outputImage).
+				OutputImageCredentials(os.Getenv(EnvVarImageRepoSecret)).
 				Create()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -108,6 +110,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 				SourceContextDir("docker-build").
 				Dockerfile("Dockerfile").
 				OutputImage(outputImage).
+				OutputImageCredentials(os.Getenv(EnvVarImageRepoSecret)).
 				Create()
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
# Changes

The bundle end to end test fails for setups where the output image target
requires credentials to allow the push operation.

Add code to use `TEST_IMAGE_REPO_SECRET` to specify an output secret.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```


