### PR TITLE
Ensure Note msg doesn't belong to the conditions Table

### DIFF
--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -204,6 +204,7 @@ The following table illustrates the different states a BuildRun can have under i
 | False    | BuildRunCanceled             | Yes | The BuildRun and underlying TaskRun were canceled successfully. |
 | False    | BuildRunNameInvalid          | Yes | The defined `BuildRun` name (`metadata.name`) is invalid. The `BuildRun` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
 | False    | PodEvicted                   | Yes | The BuildRun Pod was evicted from the node it was running on. See [API-initiated Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/) and [Node-pressure Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/) for more information. |
+
 _Note_: We heavily rely on the Tekton TaskRun [Conditions](https://github.com/tektoncd/pipeline/blob/main/docs/taskruns.md#monitoring-execution-status) for populating the BuildRun ones, with some exceptions.
 
 ### Understanding failed BuildRuns


### PR DESCRIPTION
# Changes

Add newline to avoid this. Introduced in https://github.com/shipwright-io/build/pull/858, I wanted to block that PR but it was merged already.

See current [table](https://github.com/shipwright-io/build/blob/main/docs/buildrun.md#understanding-the-state-of-a-buildrun) with the issue.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```