### PR TITLE
Update mirror action config

### DIFF
--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Install crane
-        run: curl --fail --silent --location https://github.com/google/go-containerregistry/releases/download/v0.5.1/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin crane
+        run: curl --fail --silent --location https://github.com/google/go-containerregistry/releases/download/v0.6.0/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin crane
 
       - name: Login to container registry
         run: crane auth login --username "${{ secrets.REGISTRY_USERNAME }}" --password-stdin quay.io <<<"${{ secrets.REGISTRY_PASSWORD }}"

--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -15,7 +15,7 @@ jobs:
         run: curl --fail --silent --location https://github.com/google/go-containerregistry/releases/download/v0.6.0/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin crane
 
       - name: Login to container registry
-        run: crane auth login --username "${{ secrets.REGISTRY_USERNAME }}" --password-stdin quay.io <<<"${{ secrets.REGISTRY_PASSWORD }}"
+        run: echo "${{ secrets.REGISTRY_PASSWORD }}" | crane auth login -u "${{ secrets.REGISTRY_USERNAME }}" --password-stdin quay.io
 
       - name: Mirror images
         run: |


### PR DESCRIPTION
# Changes

The newly introduced mirror GitHub Action does not work. It looks like the authentication is not working even though the output looks as expected. In order to rule out unexpected side effects, change the login style to the one in the other GitHub Actions that log into `quay.io`.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

