### PR TITLE
Use Go `1.16` in GitHub Actions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,6 +19,9 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+
     - name: Install Ko
       uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,9 @@ jobs:
 
     - name: Install Go
       uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.x
+
     - name: Install Ko
       uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.16
+        go-version: 1.16.x
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2


### PR DESCRIPTION
# Changes

If not set, the Go version in GitHub Actions seems to default to `1.15` at the moment. With recent changes, Shipwright requires Go version `1.16` to compile.

Set Go version to `1.16` in GitHub Actions.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
