### PR TITLE
[ci] Remove unnecessary matrix values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,12 @@ on:
 name: Unit, Integration, and E2E Tests
 jobs:
     unit:
-        strategy:
-          matrix:
-            go-version: [1.16.x]
-            os: [ubuntu-latest]
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         steps:
         - name: Install Go
           uses: actions/setup-go@v2
           with:
-            go-version: ${{ matrix.go-version }}
+            go-version: 1.16.x
         - name: Check out code
           uses: actions/checkout@v2
         - name: Build
@@ -30,8 +26,6 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            go-version: [1.16.x]
-            os: [ubuntu-latest]
             kubernetes:
               # Only v1.20 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
               #- v1.17.17
@@ -39,12 +33,12 @@ jobs:
               #- v1.19.11
               - v1.20.7
           max-parallel: 1
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         steps:
         - name: Install Go
           uses: actions/setup-go@v2
           with:
-            go-version: ${{ matrix.go-version }}
+            go-version: 1.16.x
         - name: Install Ko
           uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
         - name: Check out code
@@ -92,8 +86,6 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            go-version: [1.16.x]
-            os: [ubuntu-latest]
             kubernetes:
               # Only v1.20 is currently enabled because of the flakiness in the tests, specifically API calls failing with "etcdserver: request timed out"
               #- v1.17.17
@@ -101,12 +93,12 @@ jobs:
               #- v1.19.11
               - v1.20.7
           max-parallel: 2
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         steps:
         - name: Install Go
           uses: actions/setup-go@v2
           with:
-            go-version: ${{ matrix.go-version }}
+            go-version: 1.16.x
         - name: Check out code
           uses: actions/checkout@v2
         - name: Install kubectl


### PR DESCRIPTION
All CI tests run on `ubuntu-latest` using (currently) Go 1.16.x -- there's no need to specify these in matrix variables.

/kind cleanup

# Submitter Checklist

- [n/a] Includes tests if functionality changed/was added
- [n/a] Includes docs if changes are user-facing
- [y] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [y] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```