### PR TITLE
Remove Kaniko image configuration of runtime image feature

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,6 @@ The following environment variables are available:
 | Environment Variable | Description |
 | --- | --- |
 | `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. |
-| `KANIKO_CONTAINER_IMAGE` | Specify the Kaniko container image to be used for the runtime image build instead of the default, for example `gcr.io/kaniko-project/executor:v1.6.0`. |
 | `REMOTE_ARTIFACTS_CONTAINER_IMAGE` | Specify the container image used for the `.spec.sources` remote artifacts download, by default it uses `busybox:latest`. |
 | `GIT_CONTAINER_TEMPLATE` | JSON representation of a [Container](https://pkg.go.dev/k8s.io/api/core/v1#Container) template that is used for steps that clone a Git repository. Default is `{"image":"quay.io/shipwright/git:latest", "command":["/ko-app/git"], "securityContext":{"runAsUser":1000,"runAsGroup":1000}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
 | `GIT_CONTAINER_IMAGE` | Custom container image for Git clone steps. If `GIT_CONTAINER_TEMPLATE` is also specifying an image, then the value for `GIT_CONTAINER_IMAGE` has precedence. |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,9 +22,6 @@ const (
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5
 	contextTimeoutEnvVar = "CTX_TIMEOUT"
 
-	kanikoDefaultImage = "gcr.io/kaniko-project/executor:v1.6.0"
-	kanikoImageEnvVar  = "KANIKO_CONTAINER_IMAGE"
-
 	remoteArtifactsDefaultImage = "quay.io/quay/busybox:latest"
 	remoteArtifactsEnvVar       = "REMOTE_ARTIFACTS_CONTAINER_IMAGE"
 
@@ -90,7 +87,6 @@ type Config struct {
 	GitContainerTemplate,
 	MutateImageContainerTemplate corev1.Container
 	BundleContainerTemplate       corev1.Container
-	KanikoContainerImage          string
 	RemoteArtifactsContainerImage string
 	TerminationLogPath            string
 	Prometheus                    PrometheusConfig
@@ -158,7 +154,6 @@ func NewDefaultConfig() *Config {
 				RunAsGroup: nonRoot,
 			},
 		},
-		KanikoContainerImage:          kanikoDefaultImage,
 		RemoteArtifactsContainerImage: remoteArtifactsDefaultImage,
 		MutateImageContainerTemplate: corev1.Container{
 			Image: mutateImageDefaultImage,
@@ -271,10 +266,6 @@ func (c *Config) SetConfigFromEnv() error {
 	// the dedicated environment variable for the image overwrites what is defined in the bundle container template
 	if bundleImage := os.Getenv(bundleImageEnvVar); bundleImage != "" {
 		c.BundleContainerTemplate.Image = bundleImage
-	}
-
-	if kanikoImage := os.Getenv(kanikoImageEnvVar); kanikoImage != "" {
-		c.KanikoContainerImage = kanikoImage
 	}
 
 	if remoteArtifactsImage := os.Getenv(remoteArtifactsEnvVar); remoteArtifactsImage != "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,13 +31,6 @@ var _ = Describe("Config", func() {
 			})
 		})
 
-		It("should allow for an override of the default Kaniko project image using an environment variable", func() {
-			var overrides = map[string]string{"KANIKO_CONTAINER_IMAGE": "gcr.io/kaniko-project/executor:v1.0.1"}
-			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.KanikoContainerImage).To(Equal("gcr.io/kaniko-project/executor:v1.0.1"))
-			})
-		})
-
 		It("should allow for an override of the Prometheus buckets settings using an environment variable", func() {
 			var overrides = map[string]string{
 				"PROMETHEUS_BR_COMP_DUR_BUCKETS":   "1,2,3,4",


### PR DESCRIPTION
# Changes

We recently removed the runtime image feature. It had a configuration option that we forgot to remove, the Kaniko image that was used to build the runtime image. Cleaning this up.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```