### PR TITLE
Add `verify-generate.sh` script

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,8 +22,10 @@ jobs:
       with:
         go-version: 1.16.x
 
-    - name: Check out code into the Go module directory
+    - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        path: go/src/github.com/shipwright-io/build
 
     - name: Install Tools
       run: |
@@ -33,17 +35,14 @@ jobs:
         go install honnef.co/go/tools/cmd/staticcheck@latest
         go install github.com/maxbrunsfeld/counterfeiter/v6@latest
 
-    - run: make govet
-    - run: make ineffassign
-    - run: make golint
-    - run: make misspell
-    - run: make staticcheck
-
-    - name: Check make generate-crds
+    - name: Checks
+      env:
+        GOPATH: "/home/runner/work/build/build/go"
       run: |
-        export GOPATH=$(go env GOPATH)
-        make generate-crds
-        if [[ $(git diff --stat) != '' ]]; then
-          echo "CRD YAML is out of date, run make generate-crds"
-          exit 1
-        fi
+        make -C $GOPATH/src/github.com/shipwright-io/build \
+          govet \
+          ineffassign \
+          golint \
+          misspell \
+          staticcheck \
+          verify-codegen

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -27,12 +27,11 @@ jobs:
 
     - name: Install Tools
       run: |
-        pushd $(mktemp -d)
-        go get github.com/gordonklaus/ineffassign
-        go get golang.org/x/lint/golint
-        go get github.com/client9/misspell/cmd/misspell
-        go get honnef.co/go/tools/cmd/staticcheck
-        popd
+        go install github.com/gordonklaus/ineffassign@latest
+        go install golang.org/x/lint/golint@latest
+        go install github.com/client9/misspell/cmd/misspell@latest
+        go install honnef.co/go/tools/cmd/staticcheck@latest
+        go install github.com/maxbrunsfeld/counterfeiter/v6@latest
 
     - run: make govet
     - run: make ineffassign

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,7 @@ generate:
 
 .PHONY: verify-codegen
 verify-codegen: generate
-	# TODO: Verify vendor tree is accurate
-	git diff --quiet -- ':(exclude)go.mod' ':(exclude)go.sum' ':(exclude)vendor/*'
+	@hack/verify-generate.sh
 
 ginkgo:
 ifeq (, $(shell which ginkgo))

--- a/hack/generate-fakes.sh
+++ b/hack/generate-fakes.sh
@@ -10,8 +10,7 @@ set -euo pipefail
 [ ! -d "vendor" ] && echo "$0 requires vendor/ folder, run 'go mod vendor'"
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-BIN=$(go env GOPATH)/bin
 
-GO111MODULE=off "${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/manager.go vendor/sigs.k8s.io/controller-runtime/pkg/manager Manager
-GO111MODULE=off "${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/client.go vendor/sigs.k8s.io/controller-runtime/pkg/client Client
-GO111MODULE=off "${BIN}/counterfeiter" -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/status_writer.go vendor/sigs.k8s.io/controller-runtime/pkg/client StatusWriter
+GO111MODULE=off counterfeiter -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/manager.go vendor/sigs.k8s.io/controller-runtime/pkg/manager Manager
+GO111MODULE=off counterfeiter -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/client.go vendor/sigs.k8s.io/controller-runtime/pkg/client Client
+GO111MODULE=off counterfeiter -header "${SCRIPT_ROOT}/hack/boilerplate.go.txt" -o pkg/controller/fakes/status_writer.go vendor/sigs.k8s.io/controller-runtime/pkg/client StatusWriter

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verifies if a developer has forgot to run the
+# `make generate` so that all the changes in the
+# clientset should also be pushed
+
+if [[ -n "$(git status --porcelain -- pkg/client)" ]]; then
+  echo "The pkg/client package contains changes:"
+  git --no-pager diff --name-only -- pkg/client
+  echo
+  echo "Run make generate to those commit changes!"
+  exit 1
+fi


### PR DESCRIPTION
# Changes

Introduce `verify-generate.sh` script to check for uncommitted changes.

Now, with Go `1.16`, switch to `go install` for tools in preparation of the `go get` install deprecation.

Change `counterfeiter` location from needing to be under `GOPATH` to be anywhere as long as it is in the `PATH`.

Fixes #453

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
