### PR TITLE
Surface Step Results in BuildRun Status

### DIFF
--- a/cmd/bundle/main.go
+++ b/cmd/bundle/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -21,10 +22,11 @@ import (
 )
 
 type settings struct {
-	help       bool
-	image      string
-	target     string
-	secretPath string
+	help        bool
+	image       string
+	target      string
+	secretPath  string
+	imageDigest string
 }
 
 var flagValues settings
@@ -36,6 +38,7 @@ func init() {
 	// Main flags of the bundle step
 	pflag.StringVar(&flagValues.image, "image", "", "Location of the bundle image (mandatory)")
 	pflag.StringVar(&flagValues.target, "target", "/workspace/source", "The target directory to place the code")
+	pflag.StringVar(&flagValues.imageDigest, "result-file-image-digest", "", "A file to write the image digest")
 	pflag.StringVar(&flagValues.secretPath, "secret-path", "", "A directory that contains access credentials (optional)")
 }
 
@@ -70,15 +73,31 @@ func Do(ctx context.Context) error {
 	}
 
 	log.Printf("Pulling image %q", ref)
-	if err := bundle.PullAndUnpack(
+
+	img, err := bundle.PullAndUnpack(
 		ref,
 		flagValues.target,
 		remote.WithContext(ctx),
-		remote.WithAuth(auth)); err != nil {
+		remote.WithAuth(auth))
+	if err != nil {
 		return err
 	}
 
 	log.Printf("Image content was extracted to %s\n", flagValues.target)
+
+	digest, err := (*img).Digest()
+	if err != nil {
+		return fmt.Errorf("digesting new image: %v", err)
+	}
+
+	if flagValues.imageDigest != "" {
+		if err = ioutil.WriteFile(
+			flagValues.imageDigest, []byte(digest.String()), 0644,
+		); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/bundle/main.go
+++ b/cmd/bundle/main.go
@@ -23,11 +23,11 @@ import (
 )
 
 type settings struct {
-	help        bool
-	image       string
-	target      string
-	secretPath  string
-	imageDigest string
+	help                  bool
+	image                 string
+	target                string
+	secretPath            string
+	resultFileImageDigest string
 }
 
 var flagValues settings
@@ -39,7 +39,8 @@ func init() {
 	// Main flags of the bundle step
 	pflag.StringVar(&flagValues.image, "image", "", "Location of the bundle image (mandatory)")
 	pflag.StringVar(&flagValues.target, "target", "/workspace/source", "The target directory to place the code")
-	pflag.StringVar(&flagValues.imageDigest, "result-file-image-digest", "", "A file to write the image digest")
+	pflag.StringVar(&flagValues.resultFileImageDigest, "result-file-image-digest", "", "A file to write the image digest")
+
 	pflag.StringVar(&flagValues.secretPath, "secret-path", "", "A directory that contains access credentials (optional)")
 }
 
@@ -86,13 +87,13 @@ func Do(ctx context.Context) error {
 
 	log.Printf("Image content was extracted to %s\n", flagValues.target)
 
-	digest, err := (*img).Digest()
-	if err != nil {
-		return fmt.Errorf("digesting new image: %v", err)
-	}
+	if flagValues.resultFileImageDigest != "" {
+		digest, err := (*img).Digest()
+		if err != nil {
+			return fmt.Errorf("retrieving digest of bundle image: %v", err)
+		}
 
-	if flagValues.imageDigest != "" {
-		if err = ioutil.WriteFile(flagValues.imageDigest, []byte(digest.String()), 0644); err != nil {
+		if err = ioutil.WriteFile(flagValues.resultFileImageDigest, []byte(digest.String()), 0644); err != nil {
 			return err
 		}
 	}

--- a/cmd/bundle/main.go
+++ b/cmd/bundle/main.go
@@ -17,8 +17,9 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/shipwright-io/build/pkg/bundle"
 	"github.com/spf13/pflag"
+
+	"github.com/shipwright-io/build/pkg/bundle"
 )
 
 type settings struct {
@@ -91,9 +92,7 @@ func Do(ctx context.Context) error {
 	}
 
 	if flagValues.imageDigest != "" {
-		if err = ioutil.WriteFile(
-			flagValues.imageDigest, []byte(digest.String()), 0644,
-		); err != nil {
+		if err = ioutil.WriteFile(flagValues.imageDigest, []byte(digest.String()), 0644); err != nil {
 			return err
 		}
 	}

--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -11,13 +11,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	. "github.com/shipwright-io/build/cmd/bundle"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 var _ = Describe("Bundle Loader", func() {
@@ -35,7 +36,7 @@ var _ = Describe("Bundle Loader", func() {
 		f(path)
 	}
 
-	withTempFile := func(pattern string, f func(filename string)) {
+	var withTempFile = func(pattern string, f func(filename string)) {
 		file, err := ioutil.TempFile(os.TempDir(), pattern)
 		Expect(err).ToNot(HaveOccurred())
 		defer os.Remove(file.Name())
@@ -43,13 +44,13 @@ var _ = Describe("Bundle Loader", func() {
 		f(file.Name())
 	}
 
-	filecontent := func(path string) string {
+	var filecontent = func(path string) string {
 		data, err := ioutil.ReadFile(path)
 		Expect(err).ToNot(HaveOccurred())
 		return string(data)
 	}
 
-	getImage := func(tag name.Tag) v1.Image {
+	var getImage = func(tag name.Tag) v1.Image {
 		ref, err := name.ParseReference(tag.String())
 		Expect(err).To(BeNil())
 
@@ -62,7 +63,7 @@ var _ = Describe("Bundle Loader", func() {
 		return img
 	}
 
-	getImageDigest := func(tag name.Tag) v1.Hash {
+	var getImageDigest = func(tag name.Tag) v1.Hash {
 		digest, err := getImage(tag).Digest()
 		Expect(err).To(BeNil())
 

--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/shipwright-io/build/cmd/bundle"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerreg "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -50,7 +50,7 @@ var _ = Describe("Bundle Loader", func() {
 		return string(data)
 	}
 
-	var getImage = func(tag name.Tag) v1.Image {
+	var getImage = func(tag name.Tag) containerreg.Image {
 		ref, err := name.ParseReference(tag.String())
 		Expect(err).To(BeNil())
 
@@ -63,7 +63,7 @@ var _ = Describe("Bundle Loader", func() {
 		return img
 	}
 
-	var getImageDigest = func(tag name.Tag) v1.Hash {
+	var getImageDigest = func(tag name.Tag) containerreg.Hash {
 		digest, err := getImage(tag).Digest()
 		Expect(err).To(BeNil())
 

--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -11,6 +11,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -30,6 +33,40 @@ var _ = Describe("Bundle Loader", func() {
 		defer os.RemoveAll(path)
 
 		f(path)
+	}
+
+	withTempFile := func(pattern string, f func(filename string)) {
+		file, err := ioutil.TempFile(os.TempDir(), pattern)
+		Expect(err).ToNot(HaveOccurred())
+		defer os.Remove(file.Name())
+
+		f(file.Name())
+	}
+
+	filecontent := func(path string) string {
+		data, err := ioutil.ReadFile(path)
+		Expect(err).ToNot(HaveOccurred())
+		return string(data)
+	}
+
+	getImage := func(tag name.Tag) v1.Image {
+		ref, err := name.ParseReference(tag.String())
+		Expect(err).To(BeNil())
+
+		desc, err := remote.Get(ref)
+		Expect(err).To(BeNil())
+
+		img, err := desc.Image()
+		Expect(err).To(BeNil())
+
+		return img
+	}
+
+	getImageDigest := func(tag name.Tag) v1.Hash {
+		digest, err := getImage(tag).Digest()
+		Expect(err).To(BeNil())
+
+		return digest
 	}
 
 	Context("validations and error cases", func() {
@@ -55,6 +92,24 @@ var _ = Describe("Bundle Loader", func() {
 				)).ToNot(HaveOccurred())
 
 				Expect(filepath.Join(target, "LICENSE")).To(BeAnExistingFile())
+			})
+		})
+
+		It("should store image digest into file specified in --result-file-image-digest flags", func() {
+			withTempDir(func(target string) {
+				withTempFile("image-digest", func(filename string) {
+					Expect(run(
+						"--image", exampleImage,
+						"--target", target,
+						"--result-file-image-digest",
+						filename,
+					)).ToNot(HaveOccurred())
+
+					tag, err := name.NewTag(exampleImage)
+					Expect(err).To(BeNil())
+
+					Expect(filecontent(filename)).To(Equal(getImageDigest(tag).String()))
+				})
 			})
 		})
 	})

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -40,14 +40,15 @@ func (e ExitError) Error() string {
 }
 
 type settings struct {
-	help                bool
-	url                 string
-	revision            string
-	depth               uint
-	target              string
-	resultFileCommitSha string
-	secretPath          string
-	skipValidation      bool
+	help                   bool
+	url                    string
+	revision               string
+	depth                  uint
+	target                 string
+	resultFileCommitSha    string
+	resultFileCommitAuthor string
+	secretPath             string
+	skipValidation         bool
 }
 
 var flagValues settings
@@ -68,6 +69,7 @@ func init() {
 	pflag.StringVar(&flagValues.revision, "revision", "", "The revision of the Git repository to be cloned. Optional, defaults to the default branch.")
 	pflag.StringVar(&flagValues.target, "target", "", "The target directory of the clone operation")
 	pflag.StringVar(&flagValues.resultFileCommitSha, "result-file-commit-sha", "", "A file to write the commit sha to.")
+	pflag.StringVar(&flagValues.resultFileCommitAuthor, "result-file-commit-author", "", "A file to write the commit author to.")
 	pflag.StringVar(&flagValues.secretPath, "secret-path", "", "A directory that contains a secret. Either username and password for basic authentication. Or a SSH private key and optionally a known hosts file. Optional.")
 
 	// Optional flag to be able to override the default shallow clone depth,
@@ -134,6 +136,19 @@ func runGitClone(ctx context.Context) error {
 		}
 
 		if err := ioutil.WriteFile(flagValues.resultFileCommitSha, []byte(output), 0644); err != nil {
+			return err
+		}
+	}
+
+	if flagValues.resultFileCommitAuthor != "" {
+		output, err := git(ctx, "-C", flagValues.target, "log", "-1", "--pretty=format:%an")
+		if err != nil {
+			return err
+		}
+
+		if err = ioutil.WriteFile(
+			flagValues.resultFileCommitAuthor, []byte(output), 0644,
+		); err != nil {
 			return err
 		}
 	}

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -146,9 +146,7 @@ func runGitClone(ctx context.Context) error {
 			return err
 		}
 
-		if err = ioutil.WriteFile(
-			flagValues.resultFileCommitAuthor, []byte(output), 0644,
-		); err != nil {
+		if err = ioutil.WriteFile(flagValues.resultFileCommitAuthor, []byte(output), 0644); err != nil {
 			return err
 		}
 	}

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -336,7 +336,7 @@ var _ = Describe("Git Resource", func() {
 		})
 	})
 
-	Context("store result", func() {
+	Context("store details in result files", func() {
 		const exampleRepo = "https://github.com/shipwright-io/sample-go"
 
 		It("should store commit-sha into file specified in --result-file-commit-sha flag", func() {

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -335,4 +335,39 @@ var _ = Describe("Git Resource", func() {
 			})
 		})
 	})
+
+	Context("store result", func() {
+		const exampleRepo = "https://github.com/shipwright-io/sample-go"
+
+		It("should store commit-sha into file specified in --result-file-commit-sha flag", func() {
+			withTempFile("commit-sha", func(filename string) {
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--target", target,
+						"--revision", "v0.1.0",
+						"--result-file-commit-sha", filename,
+					)).ToNot(HaveOccurred())
+
+					Expect(filecontent(filename)).To(Equal("8016b0437a7a09079f961e5003e81e5ad54e6c26"))
+				})
+			})
+		})
+
+		It("should store commit-author into file specified in --result-file-commit-author flag", func() {
+			withTempFile("commit-author", func(filename string) {
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--target", target,
+						"--revision", "v0.1.0",
+						"--result-file-commit-author", filename,
+					)).ToNot(HaveOccurred())
+
+					Expect(filecontent(filename)).To(Equal("Enrique Encalada"))
+				})
+			})
+		})
+	})
 })

--- a/cmd/mutate-image/main.go
+++ b/cmd/mutate-image/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerreg "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/spf13/pflag"
 )
@@ -187,7 +187,7 @@ func runMutateImage(ctx context.Context) error {
 		return fmt.Errorf("mutating config: %v", err)
 	}
 
-	img = mutate.Annotations(img, annotations).(v1.Image)
+	img = mutate.Annotations(img, annotations).(containerreg.Image)
 
 	digest, err := img.Digest()
 	if err != nil {
@@ -241,7 +241,7 @@ func runMutateImage(ctx context.Context) error {
 // GetCompressedImageSize calculate the compressed size of the image.
 // By adding up the config and layer sizes we will get the
 // total compressed size of the image
-func GetCompressedImageSize(img v1.Image) (int64, error) {
+func GetCompressedImageSize(img containerreg.Image) (int64, error) {
 	manifest, err := img.Manifest()
 	if err != nil {
 		return 0, err

--- a/cmd/mutate-image/main_test.go
+++ b/cmd/mutate-image/main_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerreg "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo"
@@ -130,7 +130,7 @@ var _ = Describe("Image Mutate Resource", func() {
 		return string(data)
 	}
 
-	getImage := func(tag name.Tag) v1.Image {
+	getImage := func(tag name.Tag) containerreg.Image {
 		auth := authn.FromConfig(authn.AuthConfig{
 			Username: os.Getenv(regUser),
 			Password: os.Getenv(regPass),
@@ -148,7 +148,7 @@ var _ = Describe("Image Mutate Resource", func() {
 		return img
 	}
 
-	getImageDigest := func(tag name.Tag) v1.Hash {
+	getImageDigest := func(tag name.Tag) containerreg.Hash {
 		digest, err := getImage(tag).Digest()
 		Expect(err).To(BeNil())
 

--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -309,6 +309,45 @@ spec:
               latestTaskRunRef:
                 description: "LatestTaskRunRef is the name of the TaskRun responsible for executing this BuildRun. \n TODO: This should be called something like \"TaskRunName\""
                 type: string
+              output:
+                description: Output holds the results emitted from step definition of an output
+                properties:
+                  digest:
+                    description: Digest holds the digest of output image
+                    type: string
+                  size:
+                    description: Size holds the compressed size of output image
+                    type: string
+                type: object
+              sources:
+                description: Sources holds the results emitted from the step definition of different sources
+                items:
+                  description: SourceResult holds the results emitted from the different sources
+                  properties:
+                    bundle:
+                      description: Bundle holds the results emitted from from the step definition of bundle source
+                      properties:
+                        digest:
+                          description: Digest hold the image digest result
+                          type: string
+                      type: object
+                    git:
+                      description: Git holds the results emitted from from the step definition of a git source
+                      properties:
+                        commitAuthor:
+                          description: CommitAuthor holds the commit author of a git source
+                          type: string
+                        commitSha:
+                          description: CommitSha holds the commit sha of git source
+                          type: string
+                      type: object
+                    name:
+                      description: Name is the name of source
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               startTime:
                 description: StartTime is the time the build is actually started.
                 format: date-time

--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -317,7 +317,8 @@ spec:
                     type: string
                   size:
                     description: Size holds the compressed size of output image
-                    type: string
+                    format: int64
+                    type: integer
                 type: object
               sources:
                 description: Sources holds the results emitted from the step definition of different sources

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -10,12 +10,14 @@ SPDX-License-Identifier: Apache-2.0
 - [BuildRun Controller](#buildrun-controller)
 - [Configuring a BuildRun](#configuring-a-buildrun)
   - [Defining the BuildRef](#defining-the-buildref)
-  - [Defining paramValues](#defining-paramvalues)
+  - [Defining ParamValues](#defining-paramvalues)
   - [Defining the ServiceAccount](#defining-the-serviceaccount)
-- [Canceling a `BuildRun`](#canceling-a-buildrun)  
+- [Canceling a `BuildRun`](#canceling-a-buildrun)
 - [BuildRun Status](#buildrun-status)
-  - [Understanding the state of a BuildRun](#understanding-the-state-of-a-BuildRun)
+  - [Understanding the state of a BuildRun](#understanding-the-state-of-a-buildrun)
   - [Understanding failed BuildRuns](#understanding-failed-buildruns)
+  - [Step Results in BuildRun Status](#step-results-in-buildrun-status)
+  - [Build Snapshot](#build-snapshot)
 - [Relationship with Tekton Tasks](#relationship-with-tekton-tasks)
 
 ## Overview
@@ -212,6 +214,46 @@ _Note_: We heavily rely on the Tekton TaskRun [Conditions](https://github.com/te
 To make it easier for users to understand why did a BuildRun failed, users can infer from the `Status.FailedAt` field, the pod and container where the failure took place.
 
 In addition, the `Status.Conditions` will host under the `Message` field a compacted message containing the `kubectl` command to trigger, in order to retrieve the logs.
+
+### Step Results in BuildRun Status
+
+After the successful completion of a `BuildRun`, the `.status` field contains the results (`.status.taskResults`) emitted from the `TaskRun` steps. These results contain valuable metadata for users, like the _image digest_ or the _commit sha_ of the source code used for building.
+The results from the source step will be surfaced to the `.status.sources` and the results from 
+the [output step](https://github.com/shipwright-io/build/blob/main/docs/buildstrategies.md#system-results) 
+will be surfaced to the `.status.output` field of a `BuildRun`.
+
+Example of a `BuildRun` with surfaced results for `git` source:
+
+```yaml
+# [...]
+status:
+  buildSpec:
+    # [...]
+  output:
+    digest: sha256:07626e3c7fdd28d5328a8d6df8d29cd3da760c7f5e2070b534f9b880ed093a53
+    size: "1989004"
+  sources:
+  - git:
+      commitAuthor: xxx xxxxxx
+      commitSha: f25822b85021d02059c9ac8a211ef3804ea8fdde
+    name: default
+```
+
+Another example of a `BuildRun` with surfaced results for local source code(`bundle`) source:
+
+```yaml
+# [...]
+status:
+  buildSpec:
+    # [...]
+  output:
+    digest: sha256:07626e3c7fdd28d5328a8d6df8d29cd3da760c7f5e2070b534f9b880ed093a53
+    size: "1989004"
+  sources:
+  - bundle:
+      digest: sha256:0f5e2070b534f9b880ed093a537626e3c7fdd28d5328a8d6df8d29cd3da760c7
+    name: default
+```
 
 ### Build Snapshot
 

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -217,7 +217,7 @@ In addition, the `Status.Conditions` will host under the `Message` field a compa
 
 ### Step Results in BuildRun Status
 
-After the successful completion of a `BuildRun`, the `.status` field contains the results (`.status.taskResults`) emitted from the `TaskRun` steps. These results contain valuable metadata for users, like the _image digest_ or the _commit sha_ of the source code used for building.
+After the successful completion of a `BuildRun`, the `.status` field contains the results (`.status.taskResults`) emitted from the `TaskRun` steps generate by the `BuildRun` controller as part of processing the `BuildRun`. These results contain valuable metadata for users, like the _image digest_ or the _commit sha_ of the source code used for building.
 The results from the source step will be surfaced to the `.status.sources` and the results from 
 the [output step](https://github.com/shipwright-io/build/blob/main/docs/buildstrategies.md#system-results) 
 will be surfaced to the `.status.output` field of a `BuildRun`.

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -233,10 +233,10 @@ status:
     digest: sha256:07626e3c7fdd28d5328a8d6df8d29cd3da760c7f5e2070b534f9b880ed093a53
     size: "1989004"
   sources:
-  - git:
+  - name: default
+    git:
       commitAuthor: xxx xxxxxx
       commitSha: f25822b85021d02059c9ac8a211ef3804ea8fdde
-    name: default
 ```
 
 Another example of a `BuildRun` with surfaced results for local source code(`bundle`) source:
@@ -250,9 +250,9 @@ status:
     digest: sha256:07626e3c7fdd28d5328a8d6df8d29cd3da760c7f5e2070b534f9b880ed093a53
     size: "1989004"
   sources:
-  - bundle:
+  - name: default
+    bundle:
       digest: sha256:0f5e2070b534f9b880ed093a537626e3c7fdd28d5328a8d6df8d29cd3da760c7
-    name: default
 ```
 
 ### Build Snapshot

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -255,6 +255,8 @@ status:
       digest: sha256:0f5e2070b534f9b880ed093a537626e3c7fdd28d5328a8d6df8d29cd3da760c7
 ```
 
+**Note**: The digest and size of the output image are only included if the build strategy provides them. See [System results](buildstrategies.md#system-results).
+
 ### Build Snapshot
 
 For every BuildRun controller reconciliation, the `buildSpec` in the Status of the `BuildRun` is updated if an existing owned `TaskRun` is present. During this update, a `Build` resource snapshot is generated and embedded into the `status.buildSpec` path of the `BuildRun`. A `buildSpec` is just a copy of the original `Build` spec, from where the `BuildRun` executed a particular image build. The snapshot approach allows developers to see the original `Build` configuration.

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -277,7 +277,7 @@ Contrary to the strategy `spec.parameters`, you can use system parameters and th
 
 ## System results
 
-You can optionally store the size and digest of the image your build strategy created to some files. This information will eventually be made available in the status of the BuildRun.
+You can optionally store the size and digest of the image your build strategy created to some files.
 
 | Result file                        | Description                                     |
 | ---------------------------------- | ----------------------------------------------- |
@@ -285,6 +285,20 @@ You can optionally store the size and digest of the image your build strategy cr
 | `$(results.shp-image-size.path)`   | File to store the compressed size of the image. |
 
 You can look at sample build strategies, such as [Kaniko](../samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml), or [Buildpacks](../samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml), to see how they fill some or all of the results files.
+
+This information will be available in the `.status.output` field of the BuildRun.
+
+```yaml
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+# [...]
+status:
+ # [...]
+  output:
+    digest: sha256:07626e3c7fdd28d5328a8d6df8d29cd3da760c7f5e2070b534f9b880ed093a53
+    size: "1989004"
+  # [...]
+```
 
 ## Steps Resource Definition
 

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -277,7 +277,7 @@ Contrary to the strategy `spec.parameters`, you can use system parameters and th
 
 ## System results
 
-You can optionally store the size and digest of the image your build strategy created to some files.
+You can optionally store the size and digest of the image your build strategy created to a set of files.
 
 | Result file                        | Description                                     |
 | ---------------------------------- | ----------------------------------------------- |

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -64,8 +64,61 @@ const (
 	BuildRunStatePodEvicted = "PodEvicted"
 )
 
+// SourceResult holds the results emitted from the different sources
+type SourceResult struct {
+	// Name is the name of source
+	Name string `json:"name"`
+
+	// Git holds the results emitted from from the
+	// step definition of a git source
+	//
+	// +optional
+	Git *GitSourceResult `json:"git,omitempty"`
+
+	// Bundle holds the results emitted from from the
+	// step definition of bundle source
+	//
+	// +optional
+	Bundle *BundleSourceResult `json:"bundle,omitempty"`
+}
+
+// BundleSourceResult holds the results emitted from the bundle source
+type BundleSourceResult struct {
+	// Digest hold the image digest result
+	Digest string `json:"digest,omitempty"`
+}
+
+// GitSourceResult holds the results emitted from the git source
+type GitSourceResult struct {
+	// CommitSha holds the commit sha of git source
+	CommitSha string `json:"commitSha,omitempty"`
+
+	// CommitAuthor holds the commit author of a git source
+	CommitAuthor string `json:"commitAuthor,omitempty"`
+}
+
+// Output holds the results emitted from the output step (build-and-push)
+type Output struct {
+	// Digest holds the digest of output image
+	Digest string `json:"digest,omitempty"`
+
+	// Size holds the compressed size of output image
+	Size string `json:"size,omitempty"`
+}
+
 // BuildRunStatus defines the observed state of BuildRun
 type BuildRunStatus struct {
+	// Sources holds the results emitted from the step definition
+	// of different sources
+	//
+	// +optional
+	Sources []SourceResult `json:"sources"`
+
+	// Output holds the results emitted from step definition of an output
+	//
+	// +optional
+	Output *Output `json:"output"`
+
 	// Conditions holds the latest available observations of a resource's current state.
 	Conditions Conditions `json:"conditions,omitempty"`
 

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -103,7 +103,7 @@ type Output struct {
 	Digest string `json:"digest,omitempty"`
 
 	// Size holds the compressed size of output image
-	Size string `json:"size,omitempty"`
+	Size int64 `json:"size,omitempty"`
 }
 
 // BuildRunStatus defines the observed state of BuildRun

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -69,11 +69,7 @@ func PackAndPush(ref name.Reference, directory string, options ...remote.Option)
 // PullAndUnpack a container image layer content into a local directory. Analog
 // to the bundle.PackAndPush function, optional remote.Option can be used to
 // configure settings for the image pull, i.e. access credentials.
-func PullAndUnpack(
-	ref name.Reference,
-	targetPath string,
-	options ...remote.Option,
-) (*v1.Image, error) {
+func PullAndUnpack(ref name.Reference, targetPath string, options ...remote.Option) (*v1.Image, error) {
 	desc, err := remote.Get(ref, options...)
 	if err != nil {
 		return nil, err

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerreg "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -69,7 +69,7 @@ func PackAndPush(ref name.Reference, directory string, options ...remote.Option)
 // PullAndUnpack a container image layer content into a local directory. Analog
 // to the bundle.PackAndPush function, optional remote.Option can be used to
 // configure settings for the image pull, i.e. access credentials.
-func PullAndUnpack(ref name.Reference, targetPath string, options ...remote.Option) (*v1.Image, error) {
+func PullAndUnpack(ref name.Reference, targetPath string, options ...remote.Option) (*containerreg.Image, error) {
 	desc, err := remote.Get(ref, options...)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -297,6 +297,8 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, nil
 		}
 
+		resources.UpdateBuildRunUsingTaskResults(buildRun, lastTaskRun)
+
 		trCondition := lastTaskRun.Status.GetCondition(apis.ConditionSucceeded)
 		if trCondition != nil {
 			if err := resources.UpdateBuildRunUsingTaskRunCondition(ctx, r.client, buildRun, lastTaskRun, trCondition); err != nil {

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -297,7 +297,9 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, nil
 		}
 
-		resources.UpdateBuildRunUsingTaskResults(buildRun, lastTaskRun)
+		if len(lastTaskRun.Status.TaskRunResults) > 0 {
+			resources.UpdateBuildRunUsingTaskResults(buildRun, lastTaskRun.Status.TaskRunResults)
+		}
 
 		trCondition := lastTaskRun.Status.GetCondition(apis.ConditionSucceeded)
 		if trCondition != nil {

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -298,7 +298,8 @@ func (r *ReconcileBuildRun) Reconcile(request reconcile.Request) (reconcile.Resu
 		}
 
 		if len(lastTaskRun.Status.TaskRunResults) > 0 {
-			resources.UpdateBuildRunUsingTaskResults(buildRun, lastTaskRun.Status.TaskRunResults)
+			ctxlog.Info(ctx, "surfacing taskRun results to BuildRun status", namespace, request.Namespace, name, request.Name)
+			resources.UpdateBuildRunUsingTaskResults(ctx, buildRun, lastTaskRun.Status.TaskRunResults, request)
 		}
 
 		trCondition := lastTaskRun.Status.GetCondition(apis.ConditionSucceeded)

--- a/pkg/reconciler/buildrun/resources/mutate.go
+++ b/pkg/reconciler/buildrun/resources/mutate.go
@@ -37,9 +37,9 @@ func mutateArgs(annotations, labels map[string]string) []string {
 		"--image",
 		fmt.Sprintf("$(params.%s-%s)", prefixParamsResultsVolumes, paramOutputImage),
 		"--result-file-image-digest",
-		fmt.Sprintf("$(results.%s-%s.path)", prefixParamsResultsVolumes, resultImageDigest),
+		fmt.Sprintf("$(results.%s-%s.path)", prefixParamsResultsVolumes, imageDigestResult),
 		"result-file-image-size",
-		fmt.Sprintf("$(results.%s-%s.path)", prefixParamsResultsVolumes, resultImageSize),
+		fmt.Sprintf("$(results.%s-%s.path)", prefixParamsResultsVolumes, imageSizeResult),
 	}
 
 	if len(annotations) > 0 {

--- a/pkg/reconciler/buildrun/resources/results.go
+++ b/pkg/reconciler/buildrun/resources/results.go
@@ -1,0 +1,89 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"fmt"
+
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+type sourceResult struct {
+	defaultSource,
+	bundleSource buildv1alpha1.SourceResult
+}
+
+const (
+	defaultSourceName       = "default"
+	commitSHAResult         = "commit-sha"
+	commitAuthorResult      = "commit-author"
+	bundleImageDigestResult = "bundle-image-digest"
+	imageDigestResult       = "image-digest"
+	imageSizeResult         = "image-size"
+)
+
+// UpdateBuildRunUsingTaskResults surface the task results
+// to the buildrun
+func UpdateBuildRunUsingTaskResults(
+	buildRun *buildv1alpha1.BuildRun,
+	lastTaskRun *v1beta1.TaskRun,
+) {
+	var sources sourceResult
+
+	// Initializing source result
+	sources.defaultSource.Git = &buildv1alpha1.GitSourceResult{}
+	sources.bundleSource.Bundle = &buildv1alpha1.BundleSourceResult{}
+
+	// Initializing output result
+	buildRun.Status.Output = &buildv1alpha1.Output{}
+
+	for _, result := range lastTaskRun.Status.TaskRunResults {
+		updateBuildRunStatus(buildRun, result, &sources)
+	}
+
+	// Appending the source result only if the defined source
+	// from build spec emitting the results
+	if sources.defaultSource.Name != "" {
+		buildRun.Status.Sources = append(buildRun.Status.Sources, sources.defaultSource)
+	}
+
+	if sources.bundleSource.Name != "" {
+		buildRun.Status.Sources = append(buildRun.Status.Sources, sources.bundleSource)
+	}
+}
+
+func updateBuildRunStatus(
+	buildRun *buildv1alpha1.BuildRun,
+	result v1beta1.TaskRunResult,
+	sources *sourceResult,
+) {
+	switch result.Name {
+	case generateSourceResultName(defaultSourceName, commitSHAResult):
+		// Source name is default as `spec.source` has no name field
+		sources.defaultSource.Name = defaultSourceName
+		sources.defaultSource.Git.CommitSha = result.Value
+	case generateSourceResultName(defaultSourceName, commitAuthorResult):
+		// Source name is default as `spec.source` has no name field
+		sources.defaultSource.Name = defaultSourceName
+		sources.defaultSource.Git.CommitAuthor = result.Value
+	case generateSourceResultName(defaultSourceName, bundleImageDigestResult):
+		// Source name is default as `spec.source` has no name field
+		sources.bundleSource.Name = defaultSourceName
+		sources.bundleSource.Bundle.Digest = result.Value
+	case generateOutputResultName(imageDigestResult):
+		buildRun.Status.Output.Digest = result.Value
+	case generateOutputResultName(imageSizeResult):
+		buildRun.Status.Output.Size = result.Value
+	}
+}
+
+func generateSourceResultName(source string, resultName string) string {
+	return fmt.Sprintf("%s-source-%s-%s", prefixParamsResultsVolumes, defaultSourceName, resultName)
+}
+
+func generateOutputResultName(resultName string) string {
+	return fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, resultName)
+}

--- a/pkg/reconciler/buildrun/resources/results.go
+++ b/pkg/reconciler/buildrun/resources/results.go
@@ -46,12 +46,11 @@ func updateBuildRunStatusWithOutputResult(ctx context.Context, buildRun *build.B
 			buildRun.Status.Output.Digest = result.Value
 
 		case generateOutputResultName(imageSizeResult):
-			size, err := strconv.ParseInt(result.Value, 10, 64)
-			if err != nil {
+			if size, err := strconv.ParseInt(result.Value, 10, 64); err != nil {
 				ctxlog.Info(ctx, "invalid value for output image size from taskRun result", namespace, request.Namespace, name, request.Name, "error", err)
+			} else {
+				buildRun.Status.Output.Size = size
 			}
-
-			buildRun.Status.Output.Size = size
 		}
 	}
 }

--- a/pkg/reconciler/buildrun/resources/results.go
+++ b/pkg/reconciler/buildrun/resources/results.go
@@ -12,87 +12,52 @@ import (
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
-type sourceResult struct {
-	defaultSource,
-	bundleSource build.SourceResult
-}
-
 const (
-	defaultSourceName       = "default"
-	commitSHAResult         = "commit-sha"
-	commitAuthorResult      = "commit-author"
-	bundleImageDigestResult = "bundle-image-digest"
-	imageDigestResult       = "image-digest"
-	imageSizeResult         = "image-size"
+	imageDigestResult = "image-digest"
+	imageSizeResult   = "image-size"
 )
 
 // UpdateBuildRunUsingTaskResults surface the task results
 // to the buildrun
 func UpdateBuildRunUsingTaskResults(
 	buildRun *build.BuildRun,
-	lastTaskRun *pipeline.TaskRun,
+	taskRunResult []pipeline.TaskRunResult,
 ) {
-	var sources sourceResult
+	// Set source results
+	updateBuildRunStatusWithSourceResult(buildRun, taskRunResult)
 
 	// Initializing output result
 	buildRun.Status.Output = &build.Output{}
 
-	for _, result := range lastTaskRun.Status.TaskRunResults {
-		updateBuildRunStatus(buildRun, result, &sources)
-	}
-
-	// Appending the source result only if the defined source
-	// from build spec emitting the results
-	if sources.defaultSource.Name != "" {
-		buildRun.Status.Sources = append(buildRun.Status.Sources, sources.defaultSource)
-	}
-
-	if sources.bundleSource.Name != "" {
-		buildRun.Status.Sources = append(buildRun.Status.Sources, sources.bundleSource)
-	}
+	// Set output results
+	updateBuildRunStatusWithOutputResult(buildRun, taskRunResult)
 }
 
-func updateBuildRunStatus(
-	buildRun *build.BuildRun,
-	result pipeline.TaskRunResult,
-	sources *sourceResult,
-) {
-	switch result.Name {
-	case generateSourceResultName(defaultSourceName, commitSHAResult):
-		if sources.defaultSource.Git == nil {
-			sources.defaultSource.Git = &build.GitSourceResult{}
-		}
+func updateBuildRunStatusWithOutputResult(buildRun *build.BuildRun, taskRunResult []pipeline.TaskRunResult) {
+	for _, result := range taskRunResult {
+		switch result.Name {
+		case generateOutputResultName(imageDigestResult):
+			buildRun.Status.Output.Digest = result.Value
 
-		// Source name is default as `spec.source` has no name field
-		sources.defaultSource.Name = defaultSourceName
-		sources.defaultSource.Git.CommitSha = result.Value
-	case generateSourceResultName(defaultSourceName, commitAuthorResult):
-		if sources.defaultSource.Git == nil {
-			sources.defaultSource.Git = &build.GitSourceResult{}
+		case generateOutputResultName(imageSizeResult):
+			buildRun.Status.Output.Size = result.Value
 		}
-
-		// Source name is default as `spec.source` has no name field
-		sources.defaultSource.Name = defaultSourceName
-		sources.defaultSource.Git.CommitAuthor = result.Value
-	case generateSourceResultName(defaultSourceName, bundleImageDigestResult):
-		if sources.defaultSource.Bundle == nil {
-			sources.bundleSource.Bundle = &build.BundleSourceResult{}
-		}
-
-		// Source name is default as `spec.source` has no name field
-		sources.bundleSource.Name = defaultSourceName
-		sources.bundleSource.Bundle.Digest = result.Value
-	case generateOutputResultName(imageDigestResult):
-		buildRun.Status.Output.Digest = result.Value
-	case generateOutputResultName(imageSizeResult):
-		buildRun.Status.Output.Size = result.Value
 	}
-}
-
-func generateSourceResultName(source string, resultName string) string {
-	return fmt.Sprintf("%s-source-%s-%s", prefixParamsResultsVolumes, defaultSourceName, resultName)
 }
 
 func generateOutputResultName(resultName string) string {
 	return fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, resultName)
+}
+
+func getTaskSpecResults() []pipeline.TaskResult {
+	return []pipeline.TaskResult{
+		{
+			Name:        fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, imageDigestResult),
+			Description: "The digest of the image",
+		},
+		{
+			Name:        fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, imageSizeResult),
+			Description: "The compressed size of the image",
+		},
+	}
 }

--- a/pkg/reconciler/buildrun/resources/results_test.go
+++ b/pkg/reconciler/buildrun/resources/results_test.go
@@ -1,0 +1,107 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
+	"github.com/shipwright-io/build/test"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+var _ = Describe("TaskRun results to BuildRun", func() {
+	var ctl test.Catalog
+
+	Context("when a BuildRun complete successfully", func() {
+		var (
+			br *v1alpha1.BuildRun
+			tr *pipelinev1beta1.TaskRun
+		)
+
+		BeforeEach(func() {
+			tr = ctl.DefaultTaskRun("foo", "bar")
+			br = ctl.DefaultBuildRun("foo", "bar")
+		})
+
+		It("should surface the TaskRun results emitting from default(git) source step", func() {
+			commitSha := "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
+
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-source-default-commit-sha",
+				Value: commitSha,
+			}, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-source-default-commit-author",
+				Value: "foo bar",
+			})
+
+			resources.UpdateBuildRunUsingTaskResults(br, tr)
+
+			Expect(len(br.Status.Sources)).To(Equal(1))
+			Expect(br.Status.Sources[0].Git.CommitSha).To(Equal(commitSha))
+			Expect(br.Status.Sources[0].Git.CommitAuthor).To(Equal("foo bar"))
+		})
+
+		It("should surface the TaskRun results emitting from default(bundle) source step", func() {
+			bundleImageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
+
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-source-default-bundle-image-digest",
+				Value: bundleImageDigest,
+			})
+
+			resources.UpdateBuildRunUsingTaskResults(br, tr)
+
+			Expect(len(br.Status.Sources)).To(Equal(1))
+			Expect(br.Status.Sources[0].Bundle.Digest).To(Equal(bundleImageDigest))
+		})
+
+		It("should surface the TaskRun results emitting from output step", func() {
+			imageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
+
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-image-digest",
+				Value: imageDigest,
+			}, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-image-size",
+				Value: "230",
+			})
+
+			resources.UpdateBuildRunUsingTaskResults(br, tr)
+
+			Expect(br.Status.Output.Digest).To(Equal(imageDigest))
+			Expect(br.Status.Output.Size).To(Equal("230"))
+		})
+
+		It("should surface the TaskRun results emitting from source and output step", func() {
+			commitSha := "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
+			imageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
+
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-source-default-commit-sha",
+				Value: commitSha,
+			}, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-source-default-commit-author",
+				Value: "foo bar",
+			}, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-image-digest",
+				Value: imageDigest,
+			}, pipelinev1beta1.TaskRunResult{
+				Name:  "shp-image-size",
+				Value: "230",
+			})
+
+			resources.UpdateBuildRunUsingTaskResults(br, tr)
+
+			Expect(len(br.Status.Sources)).To(Equal(1))
+			Expect(br.Status.Sources[0].Git.CommitSha).To(Equal(commitSha))
+			Expect(br.Status.Sources[0].Git.CommitAuthor).To(Equal("foo bar"))
+			Expect(br.Status.Output.Digest).To(Equal(imageDigest))
+			Expect(br.Status.Output.Size).To(Equal("230"))
+		})
+	})
+})

--- a/pkg/reconciler/buildrun/resources/results_test.go
+++ b/pkg/reconciler/buildrun/resources/results_test.go
@@ -31,6 +31,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 
 		It("should surface the TaskRun results emitting from default(git) source step", func() {
 			commitSha := "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
+			br.Status.BuildSpec.Source.URL = "https://github.com/shipwright-io/sample-go"
 
 			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
 				pipelinev1beta1.TaskRunResult{
@@ -42,7 +43,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 					Value: "foo bar",
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(br, tr)
+			resources.UpdateBuildRunUsingTaskResults(br, tr.Status.TaskRunResults)
 
 			Expect(len(br.Status.Sources)).To(Equal(1))
 			Expect(br.Status.Sources[0].Git.CommitSha).To(Equal(commitSha))
@@ -51,14 +52,17 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 
 		It("should surface the TaskRun results emitting from default(bundle) source step", func() {
 			bundleImageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
+			br.Status.BuildSpec.Source.BundleContainer = &build.BundleContainer{
+				Image: "quay.io/shipwright/source-bundle:latest",
+			}
 
 			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
 				pipelinev1beta1.TaskRunResult{
-					Name:  "shp-source-default-bundle-image-digest",
+					Name:  "shp-source-default-image-digest",
 					Value: bundleImageDigest,
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(br, tr)
+			resources.UpdateBuildRunUsingTaskResults(br, tr.Status.TaskRunResults)
 
 			Expect(len(br.Status.Sources)).To(Equal(1))
 			Expect(br.Status.Sources[0].Bundle.Digest).To(Equal(bundleImageDigest))
@@ -77,7 +81,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 					Value: "230",
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(br, tr)
+			resources.UpdateBuildRunUsingTaskResults(br, tr.Status.TaskRunResults)
 
 			Expect(br.Status.Output.Digest).To(Equal(imageDigest))
 			Expect(br.Status.Output.Size).To(Equal("230"))
@@ -86,6 +90,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 		It("should surface the TaskRun results emitting from source and output step", func() {
 			commitSha := "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
 			imageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
+			br.Status.BuildSpec.Source.URL = "https://github.com/shipwright-io/sample-go"
 
 			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
 				pipelinev1beta1.TaskRunResult{
@@ -105,7 +110,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 					Value: "230",
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(br, tr)
+			resources.UpdateBuildRunUsingTaskResults(br, tr.Status.TaskRunResults)
 
 			Expect(len(br.Status.Sources)).To(Equal(1))
 			Expect(br.Status.Sources[0].Git.CommitSha).To(Equal(commitSha))

--- a/pkg/reconciler/buildrun/resources/results_test.go
+++ b/pkg/reconciler/buildrun/resources/results_test.go
@@ -8,9 +8,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
 	"github.com/shipwright-io/build/test"
+
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
@@ -19,7 +20,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 
 	Context("when a BuildRun complete successfully", func() {
 		var (
-			br *v1alpha1.BuildRun
+			br *build.BuildRun
 			tr *pipelinev1beta1.TaskRun
 		)
 
@@ -31,13 +32,15 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 		It("should surface the TaskRun results emitting from default(git) source step", func() {
 			commitSha := "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-source-default-commit-sha",
-				Value: commitSha,
-			}, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-source-default-commit-author",
-				Value: "foo bar",
-			})
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-source-default-commit-sha",
+					Value: commitSha,
+				},
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-source-default-commit-author",
+					Value: "foo bar",
+				})
 
 			resources.UpdateBuildRunUsingTaskResults(br, tr)
 
@@ -49,10 +52,11 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 		It("should surface the TaskRun results emitting from default(bundle) source step", func() {
 			bundleImageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-source-default-bundle-image-digest",
-				Value: bundleImageDigest,
-			})
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-source-default-bundle-image-digest",
+					Value: bundleImageDigest,
+				})
 
 			resources.UpdateBuildRunUsingTaskResults(br, tr)
 
@@ -63,13 +67,15 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 		It("should surface the TaskRun results emitting from output step", func() {
 			imageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-image-digest",
-				Value: imageDigest,
-			}, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-image-size",
-				Value: "230",
-			})
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-image-digest",
+					Value: imageDigest,
+				},
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-image-size",
+					Value: "230",
+				})
 
 			resources.UpdateBuildRunUsingTaskResults(br, tr)
 
@@ -81,19 +87,23 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 			commitSha := "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
 			imageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-source-default-commit-sha",
-				Value: commitSha,
-			}, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-source-default-commit-author",
-				Value: "foo bar",
-			}, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-image-digest",
-				Value: imageDigest,
-			}, pipelinev1beta1.TaskRunResult{
-				Name:  "shp-image-size",
-				Value: "230",
-			})
+			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-source-default-commit-sha",
+					Value: commitSha,
+				},
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-source-default-commit-author",
+					Value: "foo bar",
+				},
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-image-digest",
+					Value: imageDigest,
+				},
+				pipelinev1beta1.TaskRunResult{
+					Name:  "shp-image-size",
+					Value: "230",
+				})
 
 			resources.UpdateBuildRunUsingTaskResults(br, tr)
 

--- a/pkg/reconciler/buildrun/resources/results_test.go
+++ b/pkg/reconciler/buildrun/resources/results_test.go
@@ -6,7 +6,6 @@ package resources_test
 
 import (
 	"context"
-	"strconv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -102,11 +101,8 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 
 			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.TaskRunResults, taskRunRequest)
 
-			size, err := strconv.ParseInt("230", 10, 64)
-			Expect(err).To(BeNil())
-
 			Expect(br.Status.Output.Digest).To(Equal(imageDigest))
-			Expect(br.Status.Output.Size).To(Equal(size))
+			Expect(br.Status.Output.Size).To(Equal(int64(230)))
 		})
 
 		It("should surface the TaskRun results emitting from source and output step", func() {
@@ -134,14 +130,11 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 
 			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.TaskRunResults, taskRunRequest)
 
-			size, err := strconv.ParseInt("230", 10, 64)
-			Expect(err).To(BeNil())
-
 			Expect(len(br.Status.Sources)).To(Equal(1))
 			Expect(br.Status.Sources[0].Git.CommitSha).To(Equal(commitSha))
 			Expect(br.Status.Sources[0].Git.CommitAuthor).To(Equal("foo bar"))
 			Expect(br.Status.Output.Digest).To(Equal(imageDigest))
-			Expect(br.Status.Output.Size).To(Equal(size))
+			Expect(br.Status.Output.Size).To(Equal(int64(230)))
 		})
 	})
 })

--- a/pkg/reconciler/buildrun/resources/sources.go
+++ b/pkg/reconciler/buildrun/resources/sources.go
@@ -20,10 +20,10 @@ func AmendTaskSpecWithSources(
 	// create the step for spec.source, either Git or Bundle
 	switch {
 	case build.Spec.Source.BundleContainer != nil:
-		sources.AppendBundleStep(cfg, taskSpec, build.Spec.Source, "default")
+		sources.AppendBundleStep(cfg, taskSpec, build.Spec.Source, defaultSourceName)
 
 	case build.Spec.Source.URL != "":
-		sources.AppendGitStep(cfg, taskSpec, build.Spec.Source, "default")
+		sources.AppendGitStep(cfg, taskSpec, build.Spec.Source, defaultSourceName)
 	}
 
 	// create the step for spec.sources, this will eventually change into different steps depending on the type of the source

--- a/pkg/reconciler/buildrun/resources/sources/bundle.go
+++ b/pkg/reconciler/buildrun/resources/sources/bundle.go
@@ -21,6 +21,12 @@ func AppendBundleStep(
 	source build.Source,
 	name string,
 ) {
+	// append the result
+	taskSpec.Results = append(taskSpec.Results, pipeline.TaskResult{
+		Name:        fmt.Sprintf("%s-source-%s-bundle-image-digest", prefixParamsResultsVolumes, name),
+		Description: "The digest of the bundle image.",
+	})
+
 	// initialize the step from the template
 	bundleStep := pipeline.Step{
 		Container: *cfg.BundleContainerTemplate.DeepCopy(),
@@ -31,6 +37,11 @@ func AppendBundleStep(
 	bundleStep.Container.Args = []string{
 		"--image", source.BundleContainer.Image,
 		"--target", fmt.Sprintf("$(params.%s-%s)", prefixParamsResultsVolumes, paramSourceRoot),
+		"--result-file-image-digest",
+		fmt.Sprintf(
+			"$(results.%s-source-%s-bundle-image-digest.path)",
+			prefixParamsResultsVolumes, name,
+		),
 	}
 
 	// add credentials mount, if provided

--- a/pkg/reconciler/buildrun/resources/sources/bundle.go
+++ b/pkg/reconciler/buildrun/resources/sources/bundle.go
@@ -6,6 +6,7 @@ package sources
 
 import (
 	"fmt"
+	"strings"
 
 	core "k8s.io/api/core/v1"
 
@@ -67,10 +68,12 @@ func AppendBundleStep(
 func AppendBundleResult(buildRun *build.BuildRun, name string, results []pipeline.TaskRunResult) {
 	imageDigest := findResultValue(results, fmt.Sprintf("%s-source-%s-image-digest", prefixParamsResultsVolumes, name))
 
-	buildRun.Status.Sources = append(buildRun.Status.Sources, build.SourceResult{
-		Name: name,
-		Bundle: &build.BundleSourceResult{
-			Digest: imageDigest,
-		},
-	})
+	if strings.TrimSpace(imageDigest) != "" {
+		buildRun.Status.Sources = append(buildRun.Status.Sources, build.SourceResult{
+			Name: name,
+			Bundle: &build.BundleSourceResult{
+				Digest: imageDigest,
+			},
+		})
+	}
 }

--- a/pkg/reconciler/buildrun/resources/sources/bundle.go
+++ b/pkg/reconciler/buildrun/resources/sources/bundle.go
@@ -11,6 +11,7 @@ import (
 
 	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/config"
+
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
@@ -37,11 +38,7 @@ func AppendBundleStep(
 	bundleStep.Container.Args = []string{
 		"--image", source.BundleContainer.Image,
 		"--target", fmt.Sprintf("$(params.%s-%s)", prefixParamsResultsVolumes, paramSourceRoot),
-		"--result-file-image-digest",
-		fmt.Sprintf(
-			"$(results.%s-source-%s-bundle-image-digest.path)",
-			prefixParamsResultsVolumes, name,
-		),
+		"--result-file-image-digest", fmt.Sprintf("$(results.%s-source-%s-bundle-image-digest.path)", prefixParamsResultsVolumes, name),
 	}
 
 	// add credentials mount, if provided

--- a/pkg/reconciler/buildrun/resources/sources/bundle.go
+++ b/pkg/reconciler/buildrun/resources/sources/bundle.go
@@ -24,7 +24,7 @@ func AppendBundleStep(
 ) {
 	// append the result
 	taskSpec.Results = append(taskSpec.Results, pipeline.TaskResult{
-		Name:        fmt.Sprintf("%s-source-%s-bundle-image-digest", prefixParamsResultsVolumes, name),
+		Name:        fmt.Sprintf("%s-source-%s-image-digest", prefixParamsResultsVolumes, name),
 		Description: "The digest of the bundle image.",
 	})
 
@@ -38,7 +38,7 @@ func AppendBundleStep(
 	bundleStep.Container.Args = []string{
 		"--image", source.BundleContainer.Image,
 		"--target", fmt.Sprintf("$(params.%s-%s)", prefixParamsResultsVolumes, paramSourceRoot),
-		"--result-file-image-digest", fmt.Sprintf("$(results.%s-source-%s-bundle-image-digest.path)", prefixParamsResultsVolumes, name),
+		"--result-file-image-digest", fmt.Sprintf("$(results.%s-source-%s-image-digest.path)", prefixParamsResultsVolumes, name),
 	}
 
 	// add credentials mount, if provided
@@ -61,4 +61,16 @@ func AppendBundleStep(
 	}
 
 	taskSpec.Steps = append(taskSpec.Steps, bundleStep)
+}
+
+// AppendBundleResult append bundle source result to build run
+func AppendBundleResult(buildRun *build.BuildRun, name string, results []pipeline.TaskRunResult) {
+	imageDigest := findResultValue(results, fmt.Sprintf("%s-source-%s-image-digest", prefixParamsResultsVolumes, name))
+
+	buildRun.Status.Sources = append(buildRun.Status.Sources, build.SourceResult{
+		Name: name,
+		Bundle: &build.BundleSourceResult{
+			Digest: imageDigest,
+		},
+	})
 }

--- a/pkg/reconciler/buildrun/resources/sources/git.go
+++ b/pkg/reconciler/buildrun/resources/sources/git.go
@@ -24,6 +24,9 @@ func AppendGitStep(
 	taskSpec.Results = append(taskSpec.Results, tektonv1beta1.TaskResult{
 		Name:        fmt.Sprintf("%s-source-%s-commit-sha", prefixParamsResultsVolumes, name),
 		Description: "The commit SHA of the cloned source.",
+	}, tektonv1beta1.TaskResult{
+		Name:        fmt.Sprintf("%s-source-%s-commit-author", prefixParamsResultsVolumes, name),
+		Description: "The commit author of the cloned source.",
 	})
 
 	// initialize the step from the template
@@ -40,6 +43,8 @@ func AppendGitStep(
 		fmt.Sprintf("$(params.%s-%s)", prefixParamsResultsVolumes, paramSourceRoot),
 		"--result-file-commit-sha",
 		fmt.Sprintf("$(results.%s-source-%s-commit-sha.path)", prefixParamsResultsVolumes, name),
+		"--result-file-commit-author",
+		fmt.Sprintf("$(results.%s-source-%s-commit-author.path)", prefixParamsResultsVolumes, name),
 	}
 
 	// Check if a revision is defined

--- a/pkg/reconciler/buildrun/resources/sources/git.go
+++ b/pkg/reconciler/buildrun/resources/sources/git.go
@@ -6,6 +6,7 @@ package sources
 
 import (
 	"fmt"
+	"strings"
 
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/config"
@@ -92,11 +93,13 @@ func AppendGitResult(buildRun *buildv1alpha1.BuildRun, name string, results []te
 	commitAuthor := findResultValue(results, fmt.Sprintf("%s-source-%s-%s", prefixParamsResultsVolumes, name, commitAuthorResult))
 	commitSha := findResultValue(results, fmt.Sprintf("%s-source-%s-%s", prefixParamsResultsVolumes, name, commitSHAResult))
 
-	buildRun.Status.Sources = append(buildRun.Status.Sources, buildv1alpha1.SourceResult{
-		Name: name,
-		Git: &buildv1alpha1.GitSourceResult{
-			CommitAuthor: commitAuthor,
-			CommitSha:    commitSha,
-		},
-	})
+	if strings.TrimSpace(commitAuthor) != "" || strings.TrimSpace(commitSha) != "" {
+		buildRun.Status.Sources = append(buildRun.Status.Sources, buildv1alpha1.SourceResult{
+			Name: name,
+			Git: &buildv1alpha1.GitSourceResult{
+				CommitAuthor: commitAuthor,
+				CommitSha:    commitSha,
+			},
+		})
+	}
 }

--- a/pkg/reconciler/buildrun/resources/sources/git_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/git_test.go
@@ -34,9 +34,10 @@ var _ = Describe("Git", func() {
 			}, "default")
 		})
 
-		It("adds a result for the commit sha", func() {
-			Expect(len(taskSpec.Results)).To(Equal(1))
+		It("adds results for the commit sha and commit author", func() {
+			Expect(len(taskSpec.Results)).To(Equal(2))
 			Expect(taskSpec.Results[0].Name).To(Equal("shp-source-default-commit-sha"))
+			Expect(taskSpec.Results[1].Name).To(Equal("shp-source-default-commit-author"))
 		})
 
 		It("adds a step", func() {
@@ -50,6 +51,8 @@ var _ = Describe("Git", func() {
 				"$(params.shp-source-root)",
 				"--result-file-commit-sha",
 				"$(results.shp-source-default-commit-sha.path)",
+				"--result-file-commit-author",
+				"$(results.shp-source-default-commit-author.path)",
 			}))
 		})
 	})
@@ -71,9 +74,10 @@ var _ = Describe("Git", func() {
 			}, "default")
 		})
 
-		It("adds a result for the commit sha", func() {
-			Expect(len(taskSpec.Results)).To(Equal(1))
+		It("adds results for the commit sha and commit author", func() {
+			Expect(len(taskSpec.Results)).To(Equal(2))
 			Expect(taskSpec.Results[0].Name).To(Equal("shp-source-default-commit-sha"))
+			Expect(taskSpec.Results[1].Name).To(Equal("shp-source-default-commit-author"))
 		})
 
 		It("adds a volume for the secret", func() {
@@ -94,6 +98,8 @@ var _ = Describe("Git", func() {
 				"$(params.shp-source-root)",
 				"--result-file-commit-sha",
 				"$(results.shp-source-default-commit-sha.path)",
+				"--result-file-commit-author",
+				"$(results.shp-source-default-commit-author.path)",
 				"--secret-path",
 				"/workspace/shp-source-secret",
 			}))

--- a/pkg/reconciler/buildrun/resources/sources/utils.go
+++ b/pkg/reconciler/buildrun/resources/sources/utils.go
@@ -64,3 +64,13 @@ func SanitizeVolumeNameForSecretName(secretName string) string {
 
 	return sanitizedName
 }
+
+func findResultValue(results []tektonv1beta1.TaskRunResult, name string) string {
+	for _, result := range results {
+		if result.Name == name {
+			return result.Value
+		}
+	}
+
+	return ""
+}

--- a/pkg/reconciler/buildrun/resources/taskrun.go
+++ b/pkg/reconciler/buildrun/resources/taskrun.go
@@ -27,9 +27,6 @@ const (
 	paramSourceRoot    = "source-root"
 	paramSourceContext = "source-context"
 
-	resultImageDigest = "image-digest"
-	resultImageSize   = "image-size"
-
 	workspaceSource = "source"
 
 	inputParamBuilder    = "BUILDER_IMAGE"
@@ -107,16 +104,6 @@ func GenerateTaskSpec(
 				Type:        taskv1.ParamTypeString,
 			},
 		},
-		Results: []v1beta1.TaskResult{
-			{
-				Name:        fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, resultImageDigest),
-				Description: "The digest of the image",
-			},
-			{
-				Name:        fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, resultImageSize),
-				Description: "The compressed size of the image",
-			},
-		},
 		Workspaces: []v1beta1.WorkspaceDeclaration{
 			// workspace for the source files
 			{
@@ -124,6 +111,8 @@ func GenerateTaskSpec(
 			},
 		},
 	}
+
+	generatedTaskSpec.Results = getTaskSpecResults()
 
 	if build.Spec.Builder != nil {
 		InputBuilder := v1beta1.ParamSpec{

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -84,6 +84,8 @@ var _ = Describe("GenerateTaskrun", func() {
 					"$(params.shp-source-root)",
 					"--result-file-commit-sha",
 					"$(results.shp-source-default-commit-sha.path)",
+					"--result-file-commit-author",
+					"$(results.shp-source-default-commit-author.path)",
 				}))
 			})
 

--- a/test/e2e/e2e_bundle_test.go
+++ b/test/e2e/e2e_bundle_test.go
@@ -77,6 +77,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(testBuild, buildRun)
+			validateBuildRunResultsFromBundleSource(buildRun)
 		})
 
 		It("should work with Buildpacks build strategy", func() {
@@ -99,6 +100,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(testBuild, buildRun)
+			validateBuildRunResultsFromBundleSource(buildRun)
 		})
 
 		It("should work with Buildah build strategy", func() {
@@ -122,6 +124,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 
 			validateBuildRunToSucceed(testBuild, buildRun)
+			validateBuildRunResultsFromBundleSource(buildRun)
 		})
 	})
 })

--- a/test/e2e/e2e_image_mutate_test.go
+++ b/test/e2e/e2e_image_mutate_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerreg "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -114,7 +114,7 @@ func getRegistryAuthentication(
 	return authn.FromConfig(authConfig.Auths[registryName])
 }
 
-func getImage(build *buildv1alpha1.Build) v1.Image {
+func getImage(build *buildv1alpha1.Build) containerreg.Image {
 	// In the GitHub action, we are using a registry inside the cluster to
 	// push the image created by `buildRun`. The registry inside the cluster
 	// is not directly accessible from the local, so that we have mapped
@@ -135,14 +135,14 @@ func getImage(build *buildv1alpha1.Build) v1.Image {
 	return img
 }
 
-func getImageAnnotation(img v1.Image, annotation string) string {
+func getImageAnnotation(img containerreg.Image, annotation string) string {
 	manifest, err := img.Manifest()
 	Expect(err).To(BeNil())
 
 	return manifest.Annotations[annotation]
 }
 
-func getImageLabel(img v1.Image, label string) string {
+func getImageLabel(img containerreg.Image, label string) string {
 	config, err := img.ConfigFile()
 	Expect(err).To(BeNil())
 

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -147,6 +147,50 @@ func validateBuildRunToSucceed(testBuild *utils.TestBuild, testBuildRun *buildv1
 	Logf("Test build '%s' is completed after %v !", testBuildRun.GetName(), testBuildRun.Status.CompletionTime.Time.Sub(testBuildRun.Status.StartTime.Time))
 }
 
+func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) {
+	testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
+	Expect(err).ToNot(HaveOccurred())
+
+	tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
+
+	for _, result := range tr.Status.TaskRunResults {
+		switch result.Name {
+		case "shp-source-default-commit-sha":
+			Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitSha))
+		case "shp-source-default-commit-author":
+			Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitAuthor))
+		case "shp-image-digest":
+			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
+		case "shp-image-size":
+			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Size))
+		}
+	}
+}
+
+func validateBuildRunResultsFromBundleSource(testBuildRun *buildv1alpha1.BuildRun) {
+	testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
+	Expect(err).ToNot(HaveOccurred())
+
+	tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
+
+	for _, result := range tr.Status.TaskRunResults {
+		switch result.Name {
+		case "shp-source-default-bundle-image-digest":
+			Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Bundle.Digest))
+		case "shp-image-digest":
+			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
+		case "shp-image-size":
+			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Size))
+		}
+	}
+}
+
 // validateBuildRunToFail creates the build run and watches its flow until it fails.
 func validateBuildRunToFail(testBuild *utils.TestBuild, testBuildRun *buildv1alpha1.BuildRun) {
 	trueCondition := corev1.ConditionTrue

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -165,7 +165,9 @@ func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) 
 		case "shp-image-digest":
 			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
 		case "shp-image-size":
-			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Size))
+			size, err := strconv.ParseInt(result.Value, 10, 64)
+			Expect(err).To(BeNil())
+			Expect(size).To(Equal(testBuildRun.Status.Output.Size))
 		}
 	}
 }
@@ -186,7 +188,9 @@ func validateBuildRunResultsFromBundleSource(testBuildRun *buildv1alpha1.BuildRu
 		case "shp-image-digest":
 			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
 		case "shp-image-size":
-			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Size))
+			size, err := strconv.ParseInt(result.Value, 10, 64)
+			Expect(err).To(BeNil())
+			Expect(size).To(Equal(testBuildRun.Status.Output.Size))
 		}
 	}
 }

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -181,7 +181,7 @@ func validateBuildRunResultsFromBundleSource(testBuildRun *buildv1alpha1.BuildRu
 
 	for _, result := range tr.Status.TaskRunResults {
 		switch result.Name {
-		case "shp-source-default-bundle-image-digest":
+		case "shp-source-default-image-digest":
 			Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Bundle.Digest))
 		case "shp-image-digest":
 			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))


### PR DESCRIPTION
# Changes

Reference  https://github.com/shipwright-io/community/pull/13

Add git commit author result for git source step

Add bundle image digest result for local source code step

Add a function to surface TaksRun results to BuildRun

This PR only includes a subset of the [enhancements](https://github.com/shipwright-io/community/blob/main/ships/0023-surface-results-in-buildruns.md#strategy-results-api-proposal) called for, those are:
- [Build Results Sources API Proposal](https://github.com/shipwright-io/community/blob/main/ships/0023-surface-results-in-buildruns.md#build-results-sources-api-proposal) (excluded surfacing the http source type results since it is an MVP implementation)
- [Build Results Output API Proposal](https://github.com/shipwright-io/community/blob/main/ships/0023-surface-results-in-buildruns.md#build-results-output-api-proposal)

and not including the [Strategy Results API Proposal](https://github.com/shipwright-io/community/blob/main/ships/0023-surface-results-in-buildruns.md#strategy-results-api-proposal) that allows strategy authors to surface their desire result.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
You can now see the TaskRun results in BuildRun status
```
