### PR TITLE
Fixing oc policy command in HACK.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Temporary Build Files
+.DS_Store
 git
 shipwright-build-controller
 build/_output

--- a/HACK.md
+++ b/HACK.md
@@ -24,13 +24,13 @@ If your `Build`'s `outputImage` is to be pushed to the OpenShift internal regist
 `pipeline` service account has the required role:
 
 ```sh
-oc policy add-role-to-user registry-editor pipeline
+oc policy add-role-to-user registry-editor -z pipeline
 ```
 
 Or
 
 ```sh
-oc policy add-role-to-user  system:image-builder  pipeline
+oc policy add-role-to-user  system:image-builder -z pipeline
 ```
 
 In the near future, the above would be setup by the controller.


### PR DESCRIPTION
# Changes
Add the `-z`  flag for `oc policy add-role-to-user` otherwise, the command complains about user not found. 

```release-note
NONE
```