### PR TITLE
Add help flag to supporting binaries

### DIFF
--- a/cmd/bundle/main.go
+++ b/cmd/bundle/main.go
@@ -20,13 +20,20 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var flagValues struct {
+type settings struct {
+	help       bool
 	image      string
 	target     string
 	secretPath string
 }
 
+var flagValues settings
+
 func init() {
+	// Explicitly define the help flag so that --help can be invoked and returns status code 0
+	pflag.BoolVar(&flagValues.help, "help", false, "Print the help")
+
+	// Main flags of the bundle step
 	pflag.StringVar(&flagValues.image, "image", "", "Location of the bundle image (mandatory)")
 	pflag.StringVar(&flagValues.target, "target", "/workspace/source", "The target directory to place the code")
 	pflag.StringVar(&flagValues.secretPath, "secret-path", "", "A directory that contains access credentials (optional)")
@@ -40,7 +47,13 @@ func main() {
 
 // Do is the main entry point of the bundle command
 func Do(ctx context.Context) error {
+	flagValues = settings{}
 	pflag.Parse()
+
+	if flagValues.help {
+		pflag.Usage()
+		return nil
+	}
 
 	if flagValues.image == "" {
 		return fmt.Errorf("mandatory flag --image is not set")

--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -32,7 +32,11 @@ var _ = Describe("Bundle Loader", func() {
 		f(path)
 	}
 
-	Context("Error cases", func() {
+	Context("validations and error cases", func() {
+		It("should succeed in case the help is requested", func() {
+			Expect(run("--help")).ToNot(HaveOccurred())
+		})
+
 		It("should fail in case the image is not specified", func() {
 			Expect(run(
 				"--image", "",

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -40,6 +40,7 @@ func (e ExitError) Error() string {
 }
 
 type settings struct {
+	help                bool
 	url                 string
 	revision            string
 	depth               uint
@@ -57,6 +58,9 @@ var (
 )
 
 func init() {
+	// Explicitly define the help flag so that --help can be invoked and returns status code 0
+	pflag.BoolVar(&flagValues.help, "help", false, "Print the help")
+
 	// Main flags for the Git step to define the configuration, for example
 	// the flags for `url`, and `target` will always be used, but `revision`
 	// depends on the respective use case.
@@ -92,6 +96,11 @@ func main() {
 func Execute(ctx context.Context) error {
 	flagValues = settings{depth: 1}
 	pflag.Parse()
+
+	if flagValues.help {
+		pflag.Usage()
+		return nil
+	}
 
 	// pre-req checks
 	if err := checkEnvironment(ctx); err != nil {

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -53,6 +53,10 @@ var _ = Describe("Git Resource", func() {
 	}
 
 	Context("validations and error cases", func() {
+		It("should succeed in case the help is requested", func() {
+			Expect(run("--help")).ToNot(HaveOccurred())
+		})
+
 		It("should fail in case mandatory arguments are missing", func() {
 			Expect(run()).To(HaveOccurred())
 		})

--- a/cmd/mutate-image/main.go
+++ b/cmd/mutate-image/main.go
@@ -59,6 +59,7 @@ func (ht *headerTransport) RoundTrip(in *http.Request) (*http.Response, error) {
 }
 
 type settings struct {
+	help bool
 	annotation,
 	label *[]string
 	image,
@@ -89,6 +90,9 @@ func getLabel() []string {
 var flagValues settings
 
 func initializeFlag() {
+	// Explicitly define the help flag so that --help can be invoked and returns status code 0
+	pflag.BoolVar(&flagValues.help, "help", false, "Print the help")
+
 	// Main flags for the image mutate step to define the configuration, for example
 	// the flag `image` will always be used.
 	pflag.StringVar(&flagValues.image, "image", "", "The name of image in container registry")
@@ -116,6 +120,11 @@ func main() {
 func Execute(ctx context.Context) error {
 	initializeFlag()
 	pflag.Parse()
+
+	if flagValues.help {
+		pflag.Usage()
+		return nil
+	}
 
 	return runMutateImage(ctx)
 }

--- a/cmd/mutate-image/main_test.go
+++ b/cmd/mutate-image/main_test.go
@@ -156,6 +156,10 @@ var _ = Describe("Image Mutate Resource", func() {
 	}
 
 	Context("validations and error cases", func() {
+		It("should succeed in case the help is requested", func() {
+			Expect(run("--help")).ToNot(HaveOccurred())
+		})
+
 		It("should fail in case mandatory arguments are missing", func() {
 			Expect(run()).To(HaveOccurred())
 		})


### PR DESCRIPTION
# Changes

To allow to pre-pull the BuildRun supporting images in a DaemonSet and run the command they use there to verify that the binary works, we need a way to run them without performing real work but to still return exitCode 0. Adding a `--help` flag for this purpose.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```