### PR TITLE
Fix kind installation

### DIFF
--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -15,9 +15,9 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # kind version
 KIND_VERSION="${KIND_VERSION:-v0.11.1}"
 
-if [ ! -f "${GOPATH}/bin/kind" ] ; then
+if ! hash kind > /dev/null 2>&1 ; then
     echo "# Installing KinD..."
-    go get sigs.k8s.io/kind@${KIND_VERSION}
+    go install "sigs.k8s.io/kind@${KIND_VERSION}"
 fi
 
 # print kind version


### PR DESCRIPTION
# Changes

Making two changes:

1. Check the existence of kind somewhere on the path and not just in GOPATH.
2. Make sure the installation does not run inside the build directory as this would update the go.mod there.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```