### PR TITLE
Remove incorrect statement about contextDir limitation

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -91,7 +91,7 @@ A `Build` resource can specify a Git source, together with other parameters like
 
 - `source.credentials.name` - For private repositories, the name is a reference to an existing secret on the same namespace containing the `ssh` data.
 - `source.revision` - An specific revision to select from the source repository, this can be a commit, tag or branch name. If not defined, it will fallback to the git repository default branch.
-- `source.contextDir` - For repositories where the source code is not located at the root folder, you can specify this path here. Currently, only supported by `buildah`, `kaniko` and `buildpacks` build strategies.
+- `source.contextDir` - For repositories where the source code is not located at the root folder, you can specify this path here.
 
 By default, the Build controller won't validate that the Git repository exists. If the validation is desired, users can define the `build.shipwright.io/verify.repository` annotation with `true` explicitly. For example:
 


### PR DESCRIPTION
# Changes

Since a while already, all our strategies support the contextDir. Buildah was the last one. Fixing this in the docs.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Correcting the statement about the contextDir which is supported in all sample build strategies
```