### PR TITLE
Fix the gosec finding TLS MinVersion too low

### DIFF
--- a/cmd/mutate-image/main.go
+++ b/cmd/mutate-image/main.go
@@ -278,7 +278,10 @@ func getOptions(ctx context.Context) *[]crane.Option {
 	options = append(options, crane.WithContext(ctx))
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: false}
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: false,
+		MinVersion:         tls.VersionTLS12,
+	}
 
 	var rt http.RoundTripper = transport
 	// Add any http headers if they are set in the config file.


### PR DESCRIPTION
# Changes

We were not specifying the minimum TLS version that is acceptable in mutate image code.

Update TLS client configuration with TLS 1.2.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

