### PR TITLE
Publish latest tag during nightly release / publish sample strategies

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,12 +10,18 @@ jobs:
   nightly:
     if: ${{ github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
+    env:
+      IMAGE_HOST: quay.io
+      IMAGE_NAMESPACE: shipwright
     steps:
     - uses: actions/checkout@v2
 
     - name: Get current date
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d-%s')"
+
+    - name: Install crane
+      run: curl --fail --silent --location https://github.com/google/go-containerregistry/releases/download/v0.6.0/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - -C /usr/local/bin crane
 
     - name: Install Go
       uses: actions/setup-go@v2
@@ -29,8 +35,6 @@ jobs:
       env:
         REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
-        IMAGE_HOST: quay.io
-        IMAGE: shipwright/shipwright-operator
         TAG: "nightly-${{ steps.date.outputs.date }}"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -41,3 +45,13 @@ jobs:
 
         mv release-debug.yaml nightly-${{ steps.date.outputs.date }}-debug.yaml
         gh release upload nightly nightly-${{ steps.date.outputs.date }}-debug.yaml
+
+        mv sample-strategies.yaml nightly-${{ steps.date.outputs.date }}-sample-strategies.yaml
+        gh release upload nightly nightly-${{ steps.date.outputs.date }}-sample-strategies.yaml
+    - name: Update latest tag of supporting images
+      working-directory: ./cmd
+      run: |
+        for command in *
+        do
+          crane copy "${IMAGE_HOST}/${IMAGE_NAMESPACE}/${command}:nightly-${{ steps.date.outputs.date }}" "${IMAGE_HOST}/${IMAGE_NAMESPACE}/${command}:latest"
+        done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,7 @@ jobs:
       run: |
         make release
         gh release upload ${TAG} release.yaml
+        gh release upload ${TAG} sample-strategies.yaml
 
     - name: Update docs after release creation
       env:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,3 +27,7 @@ KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" GOFLAGS="${GO_FLAGS} -tags=ppr
   --tags "${TAG}-debug" \
   --image-label "io.shipwright.vcs-ref=${GITHUB_SHA}" \
   --platform=all -R -f deploy/ > release-debug.yaml
+
+# Bundle the sample cluster build strategies, remove namespace strategies first
+find samples/buildstrategy -type f -print0 | xargs -0 grep -l "kind: BuildStrategy" | xargs rm -f
+KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" ko resolve -R -f samples/buildstrategy/ > sample-strategies.yaml


### PR DESCRIPTION
# Changes

Fixes #801
Fixes #877

Some pipeline changes:

* Create a sample-strategies.yaml in the release.sh script containing all cluster build strategies
* Publish the sample-strategies.yaml in a release and nightly release
* Using `crane copy` to create the latest tag for our images during the nightly build

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Nightly and normal releases now incluse a sample-strategies.yaml
```
