### PR TITLE
Only run the TaskRun checks if Tekton objects can be accessed

### DIFF
--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -148,15 +148,15 @@ func validateBuildRunToSucceed(testBuild *utils.TestBuild, testBuildRun *buildv1
 }
 
 func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) {
+	testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
+
 	// Only run the TaskRun checks if Tekton objects can be accessed
 	if os.Getenv(EnvVarVerifyTektonObjects) == "true" {
-		testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
-		Expect(err).ToNot(HaveOccurred())
-
 		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
 		Expect(err).ToNot(HaveOccurred())
-
-		Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
 
 		for _, result := range tr.Status.TaskRunResults {
 			switch result.Name {
@@ -176,15 +176,15 @@ func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) 
 }
 
 func validateBuildRunResultsFromBundleSource(testBuildRun *buildv1alpha1.BuildRun) {
+	testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
+	Expect(err).ToNot(HaveOccurred())
+
+	Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
+
 	// Only run the TaskRun checks if Tekton objects can be accessed
 	if os.Getenv(EnvVarVerifyTektonObjects) == "true" {
-		testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
-		Expect(err).ToNot(HaveOccurred())
-
 		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
 		Expect(err).ToNot(HaveOccurred())
-
-		Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
 
 		for _, result := range tr.Status.TaskRunResults {
 			switch result.Name {

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -148,49 +148,55 @@ func validateBuildRunToSucceed(testBuild *utils.TestBuild, testBuildRun *buildv1
 }
 
 func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) {
-	testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
-	Expect(err).ToNot(HaveOccurred())
+	// Only run the TaskRun checks if Tekton objects can be accessed
+	if os.Getenv(EnvVarVerifyTektonObjects) == "true" {
+		testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
+		Expect(err).ToNot(HaveOccurred())
 
-	tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
-	Expect(err).ToNot(HaveOccurred())
+		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
+		Expect(err).ToNot(HaveOccurred())
 
-	Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
+		Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
 
-	for _, result := range tr.Status.TaskRunResults {
-		switch result.Name {
-		case "shp-source-default-commit-sha":
-			Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitSha))
-		case "shp-source-default-commit-author":
-			Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitAuthor))
-		case "shp-image-digest":
-			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
-		case "shp-image-size":
-			size, err := strconv.ParseInt(result.Value, 10, 64)
-			Expect(err).To(BeNil())
-			Expect(size).To(Equal(testBuildRun.Status.Output.Size))
+		for _, result := range tr.Status.TaskRunResults {
+			switch result.Name {
+			case "shp-source-default-commit-sha":
+				Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitSha))
+			case "shp-source-default-commit-author":
+				Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitAuthor))
+			case "shp-image-digest":
+				Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
+			case "shp-image-size":
+				size, err := strconv.ParseInt(result.Value, 10, 64)
+				Expect(err).To(BeNil())
+				Expect(size).To(Equal(testBuildRun.Status.Output.Size))
+			}
 		}
 	}
 }
 
 func validateBuildRunResultsFromBundleSource(testBuildRun *buildv1alpha1.BuildRun) {
-	testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
-	Expect(err).ToNot(HaveOccurred())
+	// Only run the TaskRun checks if Tekton objects can be accessed
+	if os.Getenv(EnvVarVerifyTektonObjects) == "true" {
+		testBuildRun, err := testBuild.GetBR(testBuildRun.Name)
+		Expect(err).ToNot(HaveOccurred())
 
-	tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
-	Expect(err).ToNot(HaveOccurred())
+		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
+		Expect(err).ToNot(HaveOccurred())
 
-	Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
+		Expect(len(testBuildRun.Status.Sources)).To(Equal(1))
 
-	for _, result := range tr.Status.TaskRunResults {
-		switch result.Name {
-		case "shp-source-default-image-digest":
-			Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Bundle.Digest))
-		case "shp-image-digest":
-			Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
-		case "shp-image-size":
-			size, err := strconv.ParseInt(result.Value, 10, 64)
-			Expect(err).To(BeNil())
-			Expect(size).To(Equal(testBuildRun.Status.Output.Size))
+		for _, result := range tr.Status.TaskRunResults {
+			switch result.Name {
+			case "shp-source-default-image-digest":
+				Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Bundle.Digest))
+			case "shp-image-digest":
+				Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
+			case "shp-image-size":
+				size, err := strconv.ParseInt(result.Value, 10, 64)
+				Expect(err).To(BeNil())
+				Expect(size).To(Equal(testBuildRun.Status.Output.Size))
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Changes

Check Tekton objects can be accessed in the validateBuildRunResultsFromBundleSource function.

Check Tekton objects can be accessed in the validateBuildRunResultsFromGitSource function.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
