### PR TITLE
Use `--no-tags` only when available

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -27,6 +27,8 @@ const (
 	typeUsernamePassword
 )
 
+var useNoTagsFlag = false
+
 // ExitError is an error which has an exit code to be used in os.Exit() to
 // return both an exit code and an error message
 type ExitError struct {
@@ -109,6 +111,10 @@ func Execute(ctx context.Context) error {
 		return err
 	}
 
+	// Check if Git CLI supports --no-tags for clone
+	out, _ := git(ctx, "clone", "-h")
+	useNoTagsFlag = strings.Contains(out, "--no-tags")
+
 	if err := runGitClone(ctx); err != nil {
 		return err
 	}
@@ -190,7 +196,10 @@ func clone(ctx context.Context) error {
 	cloneArgs := []string{
 		"clone",
 		"--quiet",
-		"--no-tags",
+	}
+
+	if useNoTagsFlag {
+		cloneArgs = append(cloneArgs, "--no-tags")
 	}
 
 	var commitSha string


### PR DESCRIPTION
# Changes

There are some cases where the Git step binary is used in an environment
with a Git CLI that does not support the `--no-tags` flag since this was only
introduced in newer versions of Git. This only occurred in unit tests so far as
we are in control of the base image used for the Git step.

Add check to verify whether the `--no-tags` flag can be used.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
