### PR TITLE
Ensure buildRunSample is initialized

### DIFF
--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 
 		// init the Build resource, this never change throughout this test suite
 		buildSample = ctl.DefaultBuild(buildName, strategyName, build.ClusterBuildStrategyKind)
-
+		buildRunSample = ctl.DefaultBuildRun(buildRunName, buildName)
 	})
 
 	// JustBeforeEach will always execute just before the It() specs,
@@ -1236,9 +1236,6 @@ var _ = Describe("Reconcile BuildRun", func() {
 		})
 
 		Context("when environment variables are specified", func() {
-			JustBeforeEach(func() {
-
-			})
 			It("fails when the name is blank", func() {
 				buildRunSample.Spec.Env = []corev1.EnvVar{
 					{


### PR DESCRIPTION
# Changes

I still like to use `make test-unit-ginkgo` because of the better output. Using it, the test case paniked because `buildRunSample` was `nil`. I guess has to do with potentially the random ordering that we are doing there and maybe different ways in general on how Ginkgo runs the tests.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
