### PR TITLE
Fix documentation links

### DIFF
--- a/HACK.md
+++ b/HACK.md
@@ -46,4 +46,4 @@ make clean && make build
 
 # Testing
 
-Please refer to the [testing docs](/docs/development/testing.md) for more information about our test levels.
+Please refer to the [testing docs](docs/development/testing.md) for more information about our test levels.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 
 | Version | Docs                           | Examples                    |
 | ------- | ------------------------------ | --------------------------- |
-| HEAD    | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/samples) |
+| HEAD    | [Docs @ HEAD](docs/README.md) | [Examples @ HEAD](samples) |
 | [v0.5.1](https://github.com/shipwright-io/build/releases/tag/v0.5.1)    | [Docs @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/docs) | [Examples @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/samples) |
 | [v0.5.0](https://github.com/shipwright-io/build/releases/tag/v0.5.0)    | [Docs @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/docs) | [Examples @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/samples) |
 | [v0.4.0](https://github.com/shipwright-io/build/releases/tag/v0.4.0)    | [Docs @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/docs) | [Examples @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/samples) |

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -114,7 +114,7 @@ spec:
     kind: BuildStrategy
 ```
 
-See more about `paramValues` usage in the related [Build](./build.md#defining-params) resource docs.
+See more about `paramValues` usage in the related [Build](./build.md#defining-paramvalues) resource docs.
 
 ### Defining the ServiceAccount
 
@@ -276,8 +276,7 @@ In addition, the `Status.Conditions` will host under the `Message` field a compa
 
 After the successful completion of a `BuildRun`, the `.status` field contains the results (`.status.taskResults`) emitted from the `TaskRun` steps generate by the `BuildRun` controller as part of processing the `BuildRun`. These results contain valuable metadata for users, like the _image digest_ or the _commit sha_ of the source code used for building.
 The results from the source step will be surfaced to the `.status.sources` and the results from 
-the [output step](https://github.com/shipwright-io/build/blob/main/docs/buildstrategies.md#system-results) 
-will be surfaced to the `.status.output` field of a `BuildRun`.
+the [output step](buildstrategies.md#system-results) will be surfaced to the `.status.output` field of a `BuildRun`.
 
 Example of a `BuildRun` with surfaced results for `git` source:
 

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -130,7 +130,7 @@ To install the cluster scope strategy, use:
 kubectl apply -f samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
 ```
 
-*Note: doing image scanning is not a substitute for trusting the Dockerfile you are building. The build process itself is also susceptible if the Dockerfile has a vulnerability. Frameworks/strategies such as build-packs or source-to-image (which avoid directly building a Dockerfile) should be considered if you need guardrails around the code you want to build.* 
+*Note: doing image scanning is not a substitute for trusting the Dockerfile you are building. The build process itself is also susceptible if the Dockerfile has a vulnerability. Frameworks/strategies such as build-packs or source-to-image (which avoid directly building a Dockerfile) should be considered if you need guardrails around the code you want to build.*
 
 ---
 
@@ -256,7 +256,7 @@ spec:
     - $(params.sleep-time)
 ```
 
-See more information on how to use this parameter in a `Build` or `BuildRun` in the related [docs](./build.md#defining-params).
+See more information on how to use this parameter in a `Build` or `BuildRun` in the related [docs](./build.md#defining-paramvalues).
 
 ## System parameters
 
@@ -507,8 +507,8 @@ In this scenario, only one container can have the `spec.resources.requests` defi
 
 If we will apply the following resources:
 
-- [buildahBuild](../samples/build/buildah/build_buildah_cr.yaml)
-- [buildahBuildRun](../samples/buildrun/buildah/buildrun_buildah_cr.yaml)
+- [buildahBuild](../samples/build/build_buildah_cr.yaml)
+- [buildahBuildRun](../samples/buildrun/buildrun_buildah_cr.yaml)
 - We will use a modified buildah strategy, with the following steps resources:
 
   ```yaml

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -131,7 +131,7 @@ The following table contains a list of environment variables that will override 
 | `TEST_IMAGE_REPO_SECRET`           | `spec.output.credentials.name` | Container credentials secret name                             |
 | `TEST_IMAGE_REPO_DOCKERCONFIGJSON` | _none_                         | JSON payload equivalent to `~/.docker/config.json`            |
 
-The contents of `TEST_IMAGE_REPO_DOCKERCONFIGJSON` can be obtained from [quay.io](quay.io) using a [robot account](https://docs.quay.io/glossary/robot-accounts.html). The JSON payload is for example:
+The contents of `TEST_IMAGE_REPO_DOCKERCONFIGJSON` can be obtained from [quay.io](https://quay.io) using a [robot account](https://docs.quay.io/glossary/robot-accounts.html). The JSON payload is for example:
 
 ```json
 { "auths": { "quay.io": { "auth": "<secret-credentials>" } } }
@@ -158,7 +158,7 @@ End-to-end tests can also be executed with the context of private Git repositori
 | `TEST_PRIVATE_GITLAB` | `spec.source.url`              | Private URL, like `git@gitlab.com`    |
 | `TEST_SOURCE_SECRET`  | `spec.source.credentials.name` | Private repository credentials        |
 
-On using `TEST_SOURCE_SECRET`, the environment variable must contain the name of the Kubernetes Secret containing SSH private key, for given private Git repository. See the [docs](/docs/development/authentication.md) for more information about authentication methods in the Build.
+On using `TEST_SOURCE_SECRET`, the environment variable must contain the name of the Kubernetes Secret containing SSH private key, for given private Git repository. See the [docs](authentication.md) for more information about authentication methods in the Build.
 
 The secret definition must define the following annotations:
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ export PROMETHEUS_BR_COMP_DUR_BUCKETS=30,60,90,120,180,240,300,360,420,480
 make local
 ```
 
-When you deploy the build controller in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [controller.yaml](../deploy/controller.yaml). Add an additional entry:
+When you deploy the build controller in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [controller.yaml](../deploy/500-controller.yaml). Add an additional entry:
 
 ```yaml
 [...]

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -37,22 +37,20 @@ Shipwright ships with a set of strategies that are available across the cluster.
 
 The default installation includes these [buildstrategies](/docs/buildstrategies.md):
 
-* [Buildpacks-v3](docs/buildstrategies.md#buildpacks-v3)
-* [Kaniko](docs/buildstrategies.md#kaniko)
-* [BuildKit](docs/buildstrategies.md#buildkit)
-* [Source-to-Image](docs/buildstrategies.md#source-to-image)
-* [Buildah](docs/buildstrategies.md#buildah)
-* [ko](docs/buildstrategies.md#ko)
+* [Buildpacks-v3](../buildstrategies.md#buildpacks-v3)
+* [Kaniko](../buildstrategies.md#kaniko)
+* [BuildKit](../buildstrategies.md#buildkit)
+* [Source-to-Image](../buildstrategies.md#source-to-image)
+* [Buildah](../buildstrategies.md#buildah)
+* [ko](../buildstrategies.md#ko)
 
-For more information about strategies see the related [docs](/docs/buildstrategies.md).
+For more information about strategies see the related [docs](../buildstrategies.md).
 
 ## Examples
 
-* [Example with Kaniko](/docs/tutorials/building_with_kaniko.md)
-
-* [Example with Buildpacks](/docs/tutorials/building_with_buildpacks.md)
-
-* [Example with BuildKit](/docs/tutorials/building_with_buildkit.md)
+* [Example with Kaniko](building_with_kaniko.md)
+* [Example with Buildpacks](building_with_buildpacks.md)
+* [Example with BuildKit](building_with_buildkit.md)
 
 Depending on your source code you might want to try a specific example. The following table serves as a guide to help you understand which
 strategy to choose:

--- a/docs/tutorials/building_with_buildkit.md
+++ b/docs/tutorials/building_with_buildkit.md
@@ -21,7 +21,7 @@ $ REGISTRY_SERVER=https://index.docker.io/v1/ REGISTRY_USER=<your_registry_user>
 $ kubectl create secret docker-registry tutorial-secret --docker-server=$REGISTRY_SERVER --docker-username=$REGISTRY_USER --docker-password=$REGISTRY_PASSWORD  --docker-email=me@here.com
 ```
 
-_Note_: For more information about authentication, please refer to the related [docs](/docs/development/authentication.md).
+_Note_: For more information about authentication, please refer to the related [document](../development/authentication.md).
 
 ## Create the strategy
 
@@ -39,7 +39,7 @@ ko                96s
 source-to-image   96s
 ```
 
-_Note_: For more information about strategies, please refer to the related [docs](/docs/buildstrategies.md).
+_Note_: For more information about strategies, please refer to the related [docs](../buildstrategies.md).
 
 ## Creating a Build
 
@@ -83,7 +83,7 @@ NAME                         REGISTERED   REASON      BUILDSTRATEGYKIND      BUI
 go-tutorial-buildkit         True         Succeeded   ClusterBuildStrategy   buildkit            4s
 ```
 
-_Note_: For more information about Build resources, please refer to the related [docs](/docs/build.md).
+_Note_: For more information about Build resources, please refer to the related [docs](../build.md).
 
 ## Creating a BuildRun
 
@@ -125,7 +125,7 @@ $ kubectl get buildrun a-buildkit-buildrun -o json | jq '.status.conditions[]'
 _Note_: A BuildRun is a resource that runs to completion. The `REASON` column reflects the state of the resource. If the BuildRun ran to completion successfully,
 a `Succeeded` `REASON` is expected.
 
-_Note_: For more information about BuildRun resources, please refer to the related [docs](/docs/buildrun.md).
+_Note_: For more information about BuildRun resources, please refer to the related [docs](../buildrun.md).
 
 ## Closing
 

--- a/docs/tutorials/building_with_buildpacks.md
+++ b/docs/tutorials/building_with_buildpacks.md
@@ -21,7 +21,7 @@ $ REGISTRY_SERVER=https://index.docker.io/v1/ REGISTRY_USER=<your_registry_user>
 $ kubectl create secret docker-registry tutorial-secret --docker-server=$REGISTRY_SERVER --docker-username=$REGISTRY_USER --docker-password=$REGISTRY_PASSWORD  --docker-email=me@here.com
 ```
 
-_Note_: For more information about authentication, please refer to the related [docs](/docs/development/authentication.md).
+_Note_: For more information about authentication, please refer to the related [docs](../development/authentication.md).
 
 ## Create the strategy
 
@@ -45,7 +45,7 @@ NAME            AGE
 buildpacks-v3   23m
 ```
 
-_Note_: For more information about strategies, please refer to the related [docs](/docs/buildstrategies.md).
+_Note_: For more information about strategies, please refer to the related [docs](../buildstrategies.md).
 
 ## Creating a Build
 
@@ -86,7 +86,7 @@ NAME            REGISTERED   REASON      BUILDSTRATEGYKIND      BUILDSTRATEGYNAM
 ruby-tutorial   True         Succeeded   ClusterBuildStrategy   buildpacks-v3       22s
 ```
 
-_Note_: For more information about Build resources, please refer to the related [docs](/docs/build.md).
+_Note_: For more information about Build resources, please refer to the related [docs](../build.md).
 
 ## Creating a BuildRun
 
@@ -128,7 +128,7 @@ $ kubectl get buildrun ruby-tutorial-buildrun -o json | jq '.status.conditions[]
 _Note_: A BuildRun is a resource that runs to completion. The `REASON` column reflects the state of the resource. If the BuildRun ran to completion successfully,
 a `Succeeded` `REASON` is expected.
 
-_Note_: For more information about BuildRun resources, please refer to the related [docs](/docs/buildrun.md).
+_Note_: For more information about BuildRun resources, please refer to the related [docs](../buildrun.md).
 
 ## Closing
 

--- a/docs/tutorials/building_with_kaniko.md
+++ b/docs/tutorials/building_with_kaniko.md
@@ -21,7 +21,7 @@ $ REGISTRY_SERVER=https://index.docker.io/v1/ REGISTRY_USER=<your_registry_user>
 $ kubectl create secret docker-registry tutorial-secret --docker-server=$REGISTRY_SERVER --docker-username=$REGISTRY_USER --docker-password=$REGISTRY_PASSWORD  --docker-email=me@here.com
 ```
 
-_Note_: For more information about authentication, please refer to the related [docs](/docs/development/authentication.md).
+_Note_: For more information about authentication, please refer to the related [docs](../development/authentication.md).
 
 ## Create the strategy
 
@@ -37,7 +37,7 @@ ko                2m
 source-to-image   2m
 ```
 
-_Note_: For more information about strategies, please refer to the related [docs](/docs/buildstrategies.md).
+_Note_: For more information about strategies, please refer to the related [docs](../buildstrategies.md).
 
 ## Creating a Build
 
@@ -78,7 +78,7 @@ NAME          REGISTERED   REASON      BUILDSTRATEGYKIND      BUILDSTRATEGYNAME 
 go-tutorial   True         Succeeded   ClusterBuildStrategy   kaniko              13s
 ```
 
-_Note_: For more information about Build resources, please refer to the related [docs](/docs/build.md).
+_Note_: For more information about Build resources, please refer to the related [docs](../build.md).
 
 ## Creating a BuildRun
 
@@ -120,7 +120,7 @@ kubectl get buildrun go-tutorial-buildrun -o json | jq '.status.conditions[]'
 _Note_: A BuildRun is a resource that runs to completion. The `REASON` column reflects the state of the resource. If the BuildRun ran to completion successfully,
 a `Succeeded` `REASON` is expected.
 
-_Note_: For more information about BuildRun resources, please refer to the related [docs](/docs/buildrun.md).
+_Note_: For more information about BuildRun resources, please refer to the related [docs](../buildrun.md).
 
 ## Closing
 


### PR DESCRIPTION
# Changes

Stumbled over some broken link while writing the 0.6 blog post. Some updates simply change from absolute to relative links because linters prefer this.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
