### PR TITLE
Make status.output.size a number in samples

### DIFF
--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -287,7 +287,7 @@ status:
     # [...]
   output:
     digest: sha256:07626e3c7fdd28d5328a8d6df8d29cd3da760c7f5e2070b534f9b880ed093a53
-    size: "1989004"
+    size: 1989004
   sources:
   - name: default
     git:
@@ -304,7 +304,7 @@ status:
     # [...]
   output:
     digest: sha256:07626e3c7fdd28d5328a8d6df8d29cd3da760c7f5e2070b534f9b880ed093a53
-    size: "1989004"
+    size: 1989004
   sources:
   - name: default
     bundle:


### PR DESCRIPTION
# Changes

One of the last changes of the PR to add the results to the BuildRun was that we made the size a number rather than a string. The corresponding adjustment in the documentation was forgotten.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
