### PR TITLE
Extend the Buildpack strategy to work with the environment variables

### DIFF
--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -10,7 +10,7 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: 
+          add:
             - CHOWN
       command:
         - chown
@@ -39,6 +39,19 @@ spec:
 
           mkdir /tmp/cache /tmp/layers
 
+          echo "> Processing environment variables..."
+          ENV_DIR="/platform/env"
+
+          envs=($(env))
+
+          for env in "${envs[@]}"; do
+              IFS='=' read -r key value string <<< "$env"
+              if [[ "$key" != "" ]]; then
+                  path="${ENV_DIR}/${key}"
+                  echo -n "$value" > "$path"
+              fi
+          done
+
           /cnb/lifecycle/creator \
             '-app=$(params.shp-source-context)' \
             -cache-dir=/tmp/cache \
@@ -48,6 +61,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      volumeMounts:
+        - mountPath: /platform/env
+          name: platform-env
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -10,7 +10,7 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: 
+          add:
             - CHOWN
       command:
         - chown
@@ -39,6 +39,19 @@ spec:
 
           mkdir /tmp/cache /tmp/layers
 
+          echo "> Processing environment variables..."
+          ENV_DIR="/platform/env"
+
+          envs=($(env))
+
+          for env in "${envs[@]}"; do
+              IFS='=' read -r key value string <<< "$env"
+              if [[ "$key" != "" ]]; then
+                  path="${ENV_DIR}/${key}"
+                  echo -n "$value" > "$path"
+              fi
+          done
+
           /cnb/lifecycle/creator \
             '-app=$(params.shp-source-context)' \
             -cache-dir=/tmp/cache \
@@ -48,6 +61,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      volumeMounts:
+        - mountPath: /platform/env
+          name: platform-env
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -11,7 +11,7 @@ spec:
       securityContext:
         runAsUser: 0
         capabilities:
-          add: 
+          add:
             - CHOWN
       command:
         - chown
@@ -39,6 +39,20 @@ spec:
         - |
           set -euo pipefail
 
+          echo "> Processing environment variables..."
+          ENV_DIR="/platform/env"
+
+          envs=($(env))
+
+          for env in "${envs[@]}"; do
+              IFS='=' read -r key value string <<< "$env"
+              if [[ "$key" != "" && "$value" != "" ]]; then
+                  path="${ENV_DIR}/${key}"
+                  echo "--> Writing ${path}..."
+                  echo -n "$value" > "$path"
+              fi
+          done
+
           mkdir /tmp/cache /tmp/layers
 
           /cnb/lifecycle/creator \
@@ -50,6 +64,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      volumeMounts:
+        - mountPath: /platform/env
+          name: platform-env
       resources:
         limits:
           cpu: 500m

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -46,9 +46,8 @@ spec:
 
           for env in "${envs[@]}"; do
               IFS='=' read -r key value string <<< "$env"
-              if [[ "$key" != "" && "$value" != "" ]]; then
+              if [[ "$key" != "" ]]; then
                   path="${ENV_DIR}/${key}"
-                  echo "--> Writing ${path}..."
                   echo -n "$value" > "$path"
               fi
           done

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -41,6 +41,19 @@ spec:
 
           mkdir /tmp/cache /tmp/layers
 
+          echo "> Processing environment variables..."
+          ENV_DIR="/platform/env"
+
+          envs=($(env))
+
+          for env in "${envs[@]}"; do
+              IFS='=' read -r key value string <<< "$env"
+              if [[ "$key" != "" ]]; then
+                  path="${ENV_DIR}/${key}"
+                  echo -n "$value" > "$path"
+              fi
+          done
+
           /cnb/lifecycle/creator \
             '-app=$(params.shp-source-context)' \
             -cache-dir=/tmp/cache \
@@ -50,6 +63,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      volumeMounts:
+        - mountPath: /platform/env
+          name: platform-env
       resources:
         limits:
           cpu: 500m

--- a/test/data/build_buildpacks-v3_golang_cr+env.yaml
+++ b/test/data/build_buildpacks-v3_golang_cr+env.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: buildpack-golang-build
+spec:
+  source:
+    url: https://github.com/shipwright-io/sample-go
+    contextDir: source-build
+  env:
+    - name: BP_GO_TARGETS
+      value: "target-build"
+  strategy:
+    name: buildpacks-v3
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/build-examples/taxi-app

--- a/test/data/build_buildpacks-v3_golang_cr_env.yaml
+++ b/test/data/build_buildpacks-v3_golang_cr_env.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   source:
     url: https://github.com/shipwright-io/sample-go
-    contextDir: source-build
+    contextDir: source-build-with-package
   env:
     - name: BP_GO_TARGETS
-      value: "target-build"
+      value: "main-package"
   strategy:
     name: buildpacks-v3
     kind: ClusterBuildStrategy

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -258,6 +258,27 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
+	Context("when a Buildpacks v3 build is defined for a golang runtime with `BP_GO_TARGETS` env", func() {
+
+		BeforeEach(func() {
+			testID = generateTestID("buildpacks-v3-golang")
+
+			// create the build definition
+			build = createBuild(
+				testBuild,
+				testID,
+				"test/data/build_buildpacks-v3_golang_cr+env.yaml",
+			)
+		})
+
+		It("successfully runs a build", func() {
+			buildRun, err = buildRunTestData(testBuild.Namespace, testID, "test/data/buildrun_buildpacks-v3_golang_cr.yaml")
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
+
+			validateBuildRunToSucceed(testBuild, buildRun)
+		})
+	})
+
 	Context("when a build uses the build-run-deletion annotation", func() {
 
 		BeforeEach(func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -259,7 +259,6 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 	})
 
 	Context("when a Buildpacks v3 build is defined for a golang runtime with `BP_GO_TARGETS` env", func() {
-
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-golang")
 
@@ -267,7 +266,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			build = createBuild(
 				testBuild,
 				testID,
-				"test/data/build_buildpacks-v3_golang_cr+env.yaml",
+				"test/data/build_buildpacks-v3_golang_cr_env.yaml",
 			)
 		})
 


### PR DESCRIPTION
# Changes

We noticed a shortcoming of the `Buildpacks` build strategy: as we bypass pack, the environment variables are not working.

Extend the `buildstrategy_buildpacks-v3_cr.yaml` with the script to process environment variables.

Add a test case to verify the environment variables working with the `Buildpack` build strategy.

**Note: This PR has a dependency with https://github.com/shipwright-io/sample-go/pull/6. The test cases will only pass after merging the https://github.com/shipwright-io/sample-go/pull/6**.


# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The Buildpacks sample build strategies now pass environment variables to the the Buildpacks allowing users to customize their behavior
```
