### PR TITLE
Optional Git URL rewrite rule

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -52,7 +52,7 @@ type settings struct {
 	resultFileCommitAuthor string
 	secretPath             string
 	skipValidation         bool
-	gitUrlRewrite 		   bool
+	gitURLRewrite 		   bool
 }
 
 var flagValues settings
@@ -83,7 +83,7 @@ func init() {
 
 	// Mostly internal flag
 	pflag.BoolVar(&flagValues.skipValidation, "skip-validation", false, "skip pre-requisite validation")
-	pflag.BoolVar(&flagValues.gitUrlRewrite, "git-url-rewrite-rule", false, "rewrite the git url")
+	pflag.BoolVar(&flagValues.gitURLRewrite, "git-url-rewrite-rule", false, "rewrite the git url")
 }
 
 func main() {
@@ -203,9 +203,9 @@ func checkGitVersionSpecificSettings(ctx context.Context) {
 	useDepthForSubmodule = strings.Contains(out, "single-branch")
 }
 
-func convertToSSH(repoUrlHost string) string {
+func convertToSSH(repoURLHost string) string {
 	// url.ssh://git@github.ibm.com/.insteadOf https://github.ibm.com/
-	return fmt.Sprintf("url.ssh://git@%s/.insteadOf https://%s/", repoUrlHost, repoUrlHost);
+	return fmt.Sprintf("url.ssh://git@%s/.insteadOf https://%s/", repoURLHost, repoURLHost);
 }
 
 func clone(ctx context.Context) error {
@@ -320,9 +320,9 @@ func clone(ctx context.Context) error {
 			if _, err := git(ctx, "config", "--global", "credential.helper", fmt.Sprintf("store --file %s", credHelperFile.Name())); err != nil {
 				return err
 			}
-			if flagValues.gitUrlRewrite {
-				sshUrl := convertToSSH(repoURL.Host)
-				if _, err := git(ctx, "config", "--global", sshUrl); err != nil {
+			if flagValues.gitURLRewrite {
+				sshURL := convertToSSH(repoURL.Host)
+				if _, err := git(ctx, "config", "--global", sshURL); err != nil {
 					return err
 				}
 			}

--- a/deploy/500-controller.yaml
+++ b/deploy/500-controller.yaml
@@ -34,6 +34,8 @@ spec:
               value: "shipwright-build"
             - name: GIT_CONTAINER_IMAGE
               value: ko://github.com/shipwright-io/build/cmd/git
+            - name: GIT_REWRITE_RULE
+              value: yes
             - name: MUTATE_IMAGE_CONTAINER_IMAGE
               value: ko://github.com/shipwright-io/build/cmd/mutate-image
             - name: BUNDLE_CONTAINER_IMAGE

--- a/deploy/500-controller.yaml
+++ b/deploy/500-controller.yaml
@@ -35,7 +35,7 @@ spec:
             - name: GIT_CONTAINER_IMAGE
               value: ko://github.com/shipwright-io/build/cmd/git
             - name: GIT_REWRITE_RULE
-              value: yes
+              value: 'true'
             - name: MUTATE_IMAGE_CONTAINER_IMAGE
               value: ko://github.com/shipwright-io/build/cmd/mutate-image
             - name: BUNDLE_CONTAINER_IMAGE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,9 @@ const (
 
 	terminationLogPathDefault = "/dev/termination-log"
 	terminationLogPathEnvVar  = "TERMINATION_LOG_PATH"
+
+	// environment variable for the Github rewrite rule
+	githubRewriteRule = "GIT_REWRITE_RULE"
 )
 
 var (
@@ -93,6 +96,7 @@ type Config struct {
 	ManagerOptions                ManagerOptions
 	Controllers                   Controllers
 	KubeAPIOptions                KubeAPIOptions
+	GitRewriteRule				  bool
 }
 
 // PrometheusConfig contains the specific configuration for the
@@ -209,6 +213,7 @@ func NewDefaultConfig() *Config {
 			Burst: 0,
 		},
 		TerminationLogPath: terminationLogPathDefault,
+		GitRewriteRule: false,
 	}
 }
 
@@ -251,6 +256,12 @@ func (c *Config) SetConfigFromEnv() error {
 	// what is defined in the mutate image container template
 	if mutateImage := os.Getenv(mutateImageEnvVar); mutateImage != "" {
 		c.MutateImageContainerTemplate.Image = mutateImage
+	}
+
+	if githubRewrite := os.Getenv(githubRewriteRule); githubRewrite != "" {
+		if strings.ToLower(githubRewrite) == "yes" {
+			c.GitRewriteRule = true
+		}
 	}
 
 	if bundleContainerTemplate := os.Getenv(bundleContainerTemplateEnvVar); bundleContainerTemplate != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,7 +88,7 @@ var (
 type Config struct {
 	CtxTimeOut time.Duration
 	GitContainerTemplate,
-	MutateImageContainerTemplate corev1.Container
+	MutateImageContainerTemplate  corev1.Container
 	BundleContainerTemplate       corev1.Container
 	RemoteArtifactsContainerImage string
 	TerminationLogPath            string
@@ -259,7 +259,7 @@ func (c *Config) SetConfigFromEnv() error {
 	}
 
 	if githubRewrite := os.Getenv(githubRewriteRule); githubRewrite != "" {
-		if strings.ToLower(githubRewrite) == "yes" {
+		if strings.ToLower(githubRewrite) == "true" {
 			c.GitRewriteRule = true
 		}
 	}

--- a/pkg/reconciler/buildrun/resources/sources/git.go
+++ b/pkg/reconciler/buildrun/resources/sources/git.go
@@ -63,6 +63,14 @@ func AppendGitStep(
 		)
 	}
 
+	// Check if the git rewrite url is specified or not
+	if cfg.GitRewriteRule {
+		gitStep.Container.Args = append(
+			gitStep.Container.Args,
+			"--git-url-rewrite-rule",
+		)
+	}
+
 	if source.Credentials != nil {
 		// ensure the value is there
 		AppendSecretVolume(taskSpec, source.Credentials.Name)


### PR DESCRIPTION
# Changes
## Is your feature request related to a problem? Please describe.
Based on user feedback, there could be a scenario where someone defines a Git repository as the build source that contains a submodule that uses a different Git URL style. There are two known styles:

    HTTPS style, e.g. https://github.com/shipwright-io/build.git
    Git+SSH style, e.g. git@github.com:shipwright-io/build.git

For the HTTPS style, we assume users configure publicly available repositories that do not require any authorization. For the sake of completeness, the HTTPS URLs can be used with deploy key credentials, but we do not openly advertise this options in the docs. The Git+SSH style must come with credentials that contain SSH keys, obviously.

## Describe the solution you'd like
When working with GitHub Enterprise (or any other private Git instance for that matter), developers often implement a rewrite rule to use the somewhat more readable HTTPS URLs while Git is working via SSH under the cover. For this, users run the following command once:

git config --global url.ssh://git@github.ibm.com/.insteadOf https://github.ibm.com/

This makes for a smoother working as you do not have to check the style each time, however, it covers a bit of the actual things that happen. Now, we could introduce the same "magic" in the Git step used by Shipwright build. However, this needs to be generic, as we work with different Git services, like GitHub, or GitLab. Also, we should not make that the default behavior right from the start, so I would suggest to make it configurable via a command line flag (--git-url-rewrite-rule).

The flag would be set by our controller setting up the Git step. And the controller would look-up the setting by checking an environment variable (since we have no config map for this).

Describe alternatives you've considered
Provide documentation about this pit-fall and reference it whenever someone runs into it.

Additional context

References:

- [Git command code](https://github.com/shipwright-io/build/tree/main/cmd/git)
- [Configuration](https://github.com/shipwright-io/build/blob/main/pkg/config/config.go)
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
