### PR TITLE
Sign nightly released images

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,6 @@ name: Nightly Release
 
 on:
   workflow_dispatch:  # Manual trigger
-
   schedule:
   - cron: '0 5 * * *' # 5 AM UTC = Midnight EST
 
@@ -10,9 +9,15 @@ jobs:
   nightly:
     if: ${{ github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # To be able to get OIDC ID token to sign images.
+      contents: write  # To be able to update releases.
+      packages: write  # To be able to push images and signatures.
+
     env:
       IMAGE_HOST: ghcr.io
       IMAGE_NAMESPACE: ${{ github.repository }}
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
@@ -22,6 +27,7 @@ jobs:
     # Install tools
     - uses: imjasonh/setup-ko@20b7695b536c640edfafdd378d96c760460f29d6
     - uses: imjasonh/setup-crane@01d26682810dcd47bfc8eb1efe791558123a9373
+    - uses: sigstore/cosign-installer@v1.2.0
 
     - name: Get current date
       id: date
@@ -44,10 +50,28 @@ jobs:
 
         mv sample-strategies.yaml nightly-${{ steps.date.outputs.date }}-sample-strategies.yaml
         gh release upload nightly nightly-${{ steps.date.outputs.date }}-sample-strategies.yaml
+
     - name: Update latest tag of supporting images
       working-directory: ./cmd
       run: |
         for command in *
         do
           crane copy "${IMAGE_HOST}/${IMAGE_NAMESPACE}/${command}:nightly-${{ steps.date.outputs.date }}" "${IMAGE_HOST}/${IMAGE_NAMESPACE}/${command}:latest"
+        done
+
+    - name: Sign released images
+      env:
+        # This enables keyless mode
+        # (https://github.com/sigstore/cosign/blob/main/KEYLESS.md) which signs
+        # images using an ephemeral key tied to the GitHub Actions identity via
+        # OIDC.
+        COSIGN_EXPERIMENTAL: "true"
+      run: |
+        for f in \
+          nightly-${{ steps.date.outputs.date }}.yaml \
+          nightly-${{ steps.date.outputs.date }}-debug.yaml; do
+          grep -o "ghcr.io[^\"]*" $f | xargs cosign sign \
+              -a sha=${{ github.sha }} \
+              -a run_id=${{ github.run_id }} \
+              -a run_attempt=${{ github.run_attempt }}
         done


### PR DESCRIPTION
# Changes

Progress toward #907 

Now that nightly released images are pushed to ghcr.io, we can sign them using `cosign`. This also annotates the signature with the commit SHA and GitHub run ID and attempt number (in case there are multiple attempts), so consumers can trace back to the workflow run that produced the image and signature.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

/kind feature