### PR TITLE
Fix container location of openliberty mirror

### DIFF
--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -17,12 +17,12 @@ jobs:
         env:
           REPO: ghcr.io/${{ github.repository_owner }}/shipwright-samples
         run: |
-          for img in \
-            golang:1.16 \
-            maven:3-jdk-8-openj9 \
-            node:12 \
-            open-liberty:kernel-java8-openj9-ubi \
+          for IMAGE in \
+            library/golang:1.16 \
+            library/maven:3-jdk-8-openj9 \
+            library/node:12 \
+            openliberty/open-liberty:kernel-java8-openj9-ubi \
             ; do
 
-            crane cp ${img} ${REPO}/${img}
+            echo crane cp "${IMAGE}" "${REPO}/$(cut -d/ -f2 <<<"${IMAGE}")"
           done


### PR DESCRIPTION
# Changes

Fix location of open liberty by adding the namespace.

Unify all container images by specifying the default namespace.

Add `cut` to remove the namespace from the image location for the target.
# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
