### PR TITLE
Usage of paths-ignore in github actions to reduce time check in e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
       - main
       - master
     push:
+      paths-ignore:
+      - 'README.md'
+      - 'docs/**'
       branches: 
       - main
       - master


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

In this PR, the use of paths-ignore is introduced to reduce time check on the files that don't play any role with controller code space! Since Github actions allow to have a paths-ignore while running the actions, here the changes have been made to the `ci.yml` file, which deals with Unit, Integration, and E2E Tests.
Being a newbie at this and the project, there must be more files that need to be added that's why leaving this as a WIP for more discussion on this issue!

Fixes #921 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```
