### PR TITLE
Omit output during unit test

### DIFF
--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -23,7 +23,14 @@ import (
 
 var _ = Describe("Bundle Loader", func() {
 	var run = func(args ...string) error {
+		// discard log output
 		log.SetOutput(ioutil.Discard)
+
+		// discard stderr output
+		var tmp = os.Stderr
+		os.Stderr = nil
+		defer func() { os.Stderr = tmp }()
+
 		os.Args = append([]string{"tool"}, args...)
 		return Do(context.Background())
 	}

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -21,7 +21,14 @@ import (
 
 var _ = Describe("Git Resource", func() {
 	var run = func(args ...string) error {
+		// discard log output
 		log.SetOutput(ioutil.Discard)
+
+		// discard stderr output
+		var tmp = os.Stderr
+		os.Stderr = nil
+		defer func() { os.Stderr = tmp }()
+
 		os.Args = append([]string{"tool", "--skip-validation"}, args...)
 		return Execute(context.TODO())
 	}


### PR DESCRIPTION
# Changes

Add temporary redirect so that the output of the `--help` flag is omitted.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

