### PR TITLE
Actually mirror images using crane

### DIFF
--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -24,6 +24,5 @@ jobs:
             library/python:3.8 \
             openliberty/open-liberty:kernel-java8-openj9-ubi \
             ; do
-
-            echo crane cp "${IMAGE}" "${REPO}/$(cut -d/ -f2 <<<"${IMAGE}")"
+            crane cp "${IMAGE}" "${REPO}/$(cut -d/ -f2 <<<"${IMAGE}")"
           done


### PR DESCRIPTION
Signed-off-by: Jason Hall <jasonhall@redhat.com>

# Changes

Well this is embarrassing. 🤦 

It turns out it's much more reliable to mirror images using `crane cp` than it is just `echo`ing the `crane cp` command to stdout.

Progress toward #913

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```