### PR TITLE
Adds branchName in buildrun results if revision is not specified

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -50,6 +50,7 @@ type settings struct {
 	target                 string
 	resultFileCommitSha    string
 	resultFileCommitAuthor string
+	resultFileBranchName   string
 	secretPath             string
 	skipValidation         bool
 }
@@ -73,6 +74,7 @@ func init() {
 	pflag.StringVar(&flagValues.target, "target", "", "The target directory of the clone operation")
 	pflag.StringVar(&flagValues.resultFileCommitSha, "result-file-commit-sha", "", "A file to write the commit sha to.")
 	pflag.StringVar(&flagValues.resultFileCommitAuthor, "result-file-commit-author", "", "A file to write the commit author to.")
+	pflag.StringVar(&flagValues.resultFileBranchName, "result-file-branch-name", "", "A file to write the branch name to.")
 	pflag.StringVar(&flagValues.secretPath, "secret-path", "", "A directory that contains a secret. Either username and password for basic authentication. Or a SSH private key and optionally a known hosts file. Optional.")
 
 	// Optional flag to be able to override the default shallow clone depth,
@@ -152,6 +154,17 @@ func runGitClone(ctx context.Context) error {
 		}
 
 		if err = ioutil.WriteFile(flagValues.resultFileCommitAuthor, []byte(output), 0644); err != nil {
+			return err
+		}
+	}
+
+	if strings.TrimSpace(flagValues.revision) == "" && strings.TrimSpace(flagValues.resultFileBranchName) != "" {
+		output, err := git(ctx, "-C", flagValues.target, "rev-parse", "--abbrev-ref", "HEAD")
+		if err != nil {
+			return err
+		}
+
+		if err := ioutil.WriteFile(flagValues.resultFileBranchName, []byte(output), 0644); err != nil {
 			return err
 		}
 	}

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -376,5 +376,20 @@ var _ = Describe("Git Resource", func() {
 				})
 			})
 		})
+
+		It("should store branch-name into file specified in --result-file-branch-name flag", func() {
+			withTempFile("branch-name", func(filename string) {
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", exampleRepo,
+						"--target", target,
+						"--result-file-branch-name", filename,
+					)).ToNot(HaveOccurred())
+
+					Expect(filecontent(filename)).To(Equal("main"))
+				})
+			})
+		})
 	})
 })

--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -495,6 +495,9 @@ spec:
                     git:
                       description: Git holds the results emitted from from the step definition of a git source
                       properties:
+                        branchName:
+                          description: BranchName holds the default branch name of the git source this will be set only when revision is not specified in Build object
+                          type: string
                         commitAuthor:
                           description: CommitAuthor holds the commit author of a git source
                           type: string

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -278,7 +278,7 @@ After the successful completion of a `BuildRun`, the `.status` field contains th
 The results from the source step will be surfaced to the `.status.sources` and the results from 
 the [output step](buildstrategies.md#system-results) will be surfaced to the `.status.output` field of a `BuildRun`.
 
-Example of a `BuildRun` with surfaced results for `git` source:
+Example of a `BuildRun` with surfaced results for `git` source (note that the `branchName` is only included if the Build does not specify any `revision`):
 
 ```yaml
 # [...]
@@ -293,6 +293,7 @@ status:
     git:
       commitAuthor: xxx xxxxxx
       commitSha: f25822b85021d02059c9ac8a211ef3804ea8fdde
+      branchName: main
 ```
 
 Another example of a `BuildRun` with surfaced results for local source code(`bundle`) source:

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -99,6 +99,10 @@ type GitSourceResult struct {
 
 	// CommitAuthor holds the commit author of a git source
 	CommitAuthor string `json:"commitAuthor,omitempty"`
+
+	// BranchName holds the default branch name of the git source
+	// this will be set only when revision is not specified in Build object
+	BranchName string `json:"branchName,omitempty"`
 }
 
 // Output holds the results emitted from the output step (build-and-push)

--- a/pkg/reconciler/buildrun/resources/sources/git_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/git_test.go
@@ -34,10 +34,11 @@ var _ = Describe("Git", func() {
 			}, "default")
 		})
 
-		It("adds results for the commit sha and commit author", func() {
-			Expect(len(taskSpec.Results)).To(Equal(2))
+		It("adds results for the commit sha, commit author and branch name", func() {
+			Expect(len(taskSpec.Results)).To(Equal(3))
 			Expect(taskSpec.Results[0].Name).To(Equal("shp-source-default-commit-sha"))
 			Expect(taskSpec.Results[1].Name).To(Equal("shp-source-default-commit-author"))
+			Expect(taskSpec.Results[2].Name).To(Equal("shp-source-default-branch-name"))
 		})
 
 		It("adds a step", func() {
@@ -53,6 +54,8 @@ var _ = Describe("Git", func() {
 				"$(results.shp-source-default-commit-sha.path)",
 				"--result-file-commit-author",
 				"$(results.shp-source-default-commit-author.path)",
+				"--result-file-branch-name",
+				"$(results.shp-source-default-branch-name.path)",
 			}))
 		})
 	})
@@ -74,10 +77,11 @@ var _ = Describe("Git", func() {
 			}, "default")
 		})
 
-		It("adds results for the commit sha and commit author", func() {
-			Expect(len(taskSpec.Results)).To(Equal(2))
+		It("adds results for the commit sha, commit author and branch name", func() {
+			Expect(len(taskSpec.Results)).To(Equal(3))
 			Expect(taskSpec.Results[0].Name).To(Equal("shp-source-default-commit-sha"))
 			Expect(taskSpec.Results[1].Name).To(Equal("shp-source-default-commit-author"))
+			Expect(taskSpec.Results[2].Name).To(Equal("shp-source-default-branch-name"))
 		})
 
 		It("adds a volume for the secret", func() {
@@ -100,6 +104,8 @@ var _ = Describe("Git", func() {
 				"$(results.shp-source-default-commit-sha.path)",
 				"--result-file-commit-author",
 				"$(results.shp-source-default-commit-author.path)",
+				"--result-file-branch-name",
+				"$(results.shp-source-default-branch-name.path)",
 				"--secret-path",
 				"/workspace/shp-source-secret",
 			}))

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -12,7 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -92,6 +92,8 @@ var _ = Describe("GenerateTaskrun", func() {
 					"$(results.shp-source-default-commit-sha.path)",
 					"--result-file-commit-author",
 					"$(results.shp-source-default-commit-author.path)",
+					"--result-file-branch-name",
+					"$(results.shp-source-default-branch-name.path)",
 				}))
 			})
 

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -164,6 +164,8 @@ func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) 
 				Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitSha))
 			case "shp-source-default-commit-author":
 				Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.CommitAuthor))
+			case "shp-source-default-branch-name":
+				Expect(result.Value).To(Equal(testBuildRun.Status.Sources[0].Git.BranchName))
 			case "shp-image-digest":
 				Expect(result.Value).To(Equal(testBuildRun.Status.Output.Digest))
 			case "shp-image-size":


### PR DESCRIPTION
If user doesn't specify revision in Build object, then default
branch is used.
This patch adds support for adding the branch name in BuildRun results
if revision is not specified in Build Object.

Fixes #923

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Adds branchName in buildrun results if revision is not specified in Build
```

