### PR TITLE
Introduce Git config URL rewrite option

### DIFF
--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -251,6 +251,25 @@ var _ = Describe("Git Resource", func() {
 				})
 			})
 		})
+
+		It("should Git clone a private repository using a SSH private key that contains a HTTPS submodule", func() {
+			withTempDir(func(secret string) {
+				// Mock the filesystem state of `kubernetes.io/ssh-auth` type secret volume mount
+				file(filepath.Join(secret, "ssh-privatekey"), 0400, []byte(sshPrivateKey))
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", "git@github.com:shipwright-io/sample-submodule-private.git",
+						"--secret-path", secret,
+						"--target", target,
+						"--git-url-rewrite",
+					)).ToNot(HaveOccurred())
+
+					Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+					Expect(filepath.Join(target, "src", "sample-nodejs-private", "README.md")).To(BeAnExistingFile())
+				})
+			})
+		})
 	})
 
 	Context("cloning private repositories using basic auth", func() {

--- a/deploy/500-controller.yaml
+++ b/deploy/500-controller.yaml
@@ -34,6 +34,8 @@ spec:
               value: "shipwright-build"
             - name: GIT_CONTAINER_IMAGE
               value: ko://github.com/shipwright-io/build/cmd/git
+            - name: GIT_ENABLE_REWRITE_RULE
+              value: "false"
             - name: MUTATE_IMAGE_CONTAINER_IMAGE
               value: ko://github.com/shipwright-io/build/cmd/mutate-image
             - name: BUNDLE_CONTAINER_IMAGE

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,3 +29,4 @@ The following environment variables are available:
 | `KUBE_API_BURST` | Burst to use for the Kubernetes API client. See [Config.Burst](https://pkg.go.dev/k8s.io/client-go/rest#Config.Burst). A value of 0 or lower will use the default from client-go, which currently is 10. Default is 0. |
 | `KUBE_API_QPS` | QPS to use for the Kubernetes API client. See [Config.QPS](https://pkg.go.dev/k8s.io/client-go/rest#Config.QPS). A value of 0 or lower will use the default from client-go, which currently is 5. Default is 0. |
 | `TERMINATION_LOG_PATH` | Path of the termination log. This is where controller application will write the reason of its termination. Default value is `/dev/termination-log`. |
+| `GIT_ENABLE_REWRITE_RULE` | Enable Git wrapper to setup a URL `insteadOf` Git config rewrite rule for the respective source URL hostname. Default is `false`. |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,9 @@ const (
 
 	terminationLogPathDefault = "/dev/termination-log"
 	terminationLogPathEnvVar  = "TERMINATION_LOG_PATH"
+
+	// environment variable for the Git rewrite setting
+	useGitRewriteRule = "GIT_ENABLE_REWRITE_RULE"
 )
 
 var (
@@ -93,6 +96,7 @@ type Config struct {
 	ManagerOptions                ManagerOptions
 	Controllers                   Controllers
 	KubeAPIOptions                KubeAPIOptions
+	GitRewriteRule                bool
 }
 
 // PrometheusConfig contains the specific configuration for the
@@ -209,6 +213,7 @@ func NewDefaultConfig() *Config {
 			Burst: 0,
 		},
 		TerminationLogPath: terminationLogPathDefault,
+		GitRewriteRule:     false,
 	}
 }
 
@@ -251,6 +256,11 @@ func (c *Config) SetConfigFromEnv() error {
 	// what is defined in the mutate image container template
 	if mutateImage := os.Getenv(mutateImageEnvVar); mutateImage != "" {
 		c.MutateImageContainerTemplate.Image = mutateImage
+	}
+
+	// Mark that the Git wrapper is suppose to use Git rewrite rule
+	if useGitRewriteRule := os.Getenv(useGitRewriteRule); useGitRewriteRule != "" {
+		c.GitRewriteRule = strings.ToLower(useGitRewriteRule) == "true"
 	}
 
 	if bundleContainerTemplate := os.Getenv(bundleContainerTemplateEnvVar); bundleContainerTemplate != "" {

--- a/pkg/reconciler/buildrun/resources/sources/git.go
+++ b/pkg/reconciler/buildrun/resources/sources/git.go
@@ -69,6 +69,11 @@ func AppendGitStep(
 		)
 	}
 
+	// If configure, use Git URL rewrite flag
+	if cfg.GitRewriteRule {
+		gitStep.Container.Args = append(gitStep.Container.Args, "--git-url-rewrite-rule")
+	}
+
 	if source.Credentials != nil {
 		// ensure the value is there
 		AppendSecretVolume(taskSpec, source.Credentials.Name)


### PR DESCRIPTION
# Changes

There is use case that pops up more often than others and this is that a user wants to build a private repository that contains a submodule, which itself is also a private repository. Sometimes, the submodule is configured using a HTTPS URL while the main repository uses Git+SSH. This leads to errors in the Git step, because the private submodule cannot be loaded due to missing access credentials. Obviously, the HTTPS URL does not accept the Git private key that is configured. The typical local solution is to setup an `insteadOf` URL rewrite rule in the Git config to dynamically translate the URL types. This PR brings the same feature to the Git step. It is disabled by default.

- Add Git wrapper command line flag to enable setting up Git config URL rewrite.

- Add environment variable `GIT_ENABLE_REWRITE_RULE` to enable the feature for
the step in the build strategy.

- Add code to set the Git wrapper CLI flag if configured.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Git step now supports setting an optional rewrite rule so that HTTPS URLs are translated into Git+SSH URLs during the Git clone and Git submodule operations.
```
