### PR TITLE
Run gosec as part of the verify action

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -6,11 +6,9 @@ on:
       - '**'
     branches:
       - main
-      - master
   pull_request:
     branches:
       - main
-      - master
 
 jobs:
   verify:
@@ -34,15 +32,12 @@ jobs:
         go install github.com/client9/misspell/cmd/misspell@latest
         go install honnef.co/go/tools/cmd/staticcheck@latest
         go install github.com/maxbrunsfeld/counterfeiter/v6@latest
+        go install github.com/securego/gosec/v2/cmd/gosec@latest
 
     - name: Checks
       env:
         GOPATH: "/home/runner/work/build/build/go"
       run: |
         make -C $GOPATH/src/github.com/shipwright-io/build \
-          govet \
-          ineffassign \
-          golint \
-          misspell \
-          staticcheck \
+          sanity-check \
           verify-codegen

--- a/Makefile
+++ b/Makefile
@@ -151,33 +151,39 @@ govet:
 	@echo "Checking go vet"
 	@go vet ./...
 
-# Install it via: go get -u github.com/gordonklaus/ineffassign
+# Install it via: go install github.com/gordonklaus/ineffassign@latest
 .PHONY: ineffassign
 ineffassign:
 	@echo "Checking ineffassign"
 	@ineffassign ./...
 
-# Install it via: go get -u golang.org/x/lint/golint
+# Install it via: go install golang.org/x/lint/golint@latest
 # See https://github.com/golang/lint/issues/320 for details regarding the grep
 .PHONY: golint
 golint:
 	@echo "Checking golint"
 	@go list ./... | grep -v -e /vendor -e /test | xargs -L1 golint -set_exit_status
 
-# Install it via: go get -u github.com/client9/misspell/cmd/misspell
+# Install it via: go install github.com/securego/gosec/v2/cmd/gosec@latest
+.PHONY: gosec
+gosec:
+	@echo "Checking gosec"
+	gosec -confidence medium -severity high ./...
+
+# Install it via: go install github.com/client9/misspell/cmd/misspell@latest
 .PHONY: misspell
 misspell:
 	@echo "Checking misspell"
 	@find . -type f -not -path './vendor/*' -not -path './.git/*' -not -path './build/*' -print0 | xargs -0 misspell -source=text -error
 
-# Install it via: go get -u honnef.co/go/tools/cmd/staticcheck
+# Install it via: go install honnef.co/go/tools/cmd/staticcheck@latest
 .PHONY: staticcheck
 staticcheck:
 	@echo "Checking staticcheck"
 	@go list ./... | grep -v /test | xargs staticcheck
 
 .PHONY: sanity-check
-sanity-check: ineffassign golint govet misspell staticcheck
+sanity-check: ineffassign golint gosec govet misspell staticcheck
 
 # https://github.com/shipwright-io/build/issues/123
 test: test-unit


### PR DESCRIPTION
# Changes

Downstream, we got a new tool we need to use for complience checks: [gosec](https://github.com/securego/gosec). Shipwright Build is looking fine. Adding it to our verification so that it stays green.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
