### PR TITLE
Fix Git URL rewrite issue for HTTPS URLs

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -450,8 +450,12 @@ func checkCredentials() (credentialType, error) {
 	// in which case there is a file called ssh-privatekey
 	hasPrivateKey := hasFile(flagValues.secretPath, "ssh-privatekey")
 	isSSHGitURL := sshGitURLRegEx.MatchString(flagValues.url)
+	isGitURLRewriteSet := flagValues.gitURLRewrite
 	switch {
 	case hasPrivateKey && isSSHGitURL:
+		return typePrivateKey, nil
+
+	case hasPrivateKey && !isSSHGitURL && isGitURLRewriteSet:
 		return typePrivateKey, nil
 
 	case hasPrivateKey && !isSSHGitURL:

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -252,7 +252,25 @@ var _ = Describe("Git Resource", func() {
 			})
 		})
 
-		It("should Git clone a private repository using a SSH private key that contains a HTTPS submodule", func() {
+		It("should Git clone a private repository using HTTPS URL and a SSH private key provided via a secret when Git URL rewrite is enabled", func() {
+			withTempDir(func(secret string) {
+				// Mock the filesystem state of `kubernetes.io/ssh-auth` type secret volume mount
+				file(filepath.Join(secret, "ssh-privatekey"), 0400, []byte(sshPrivateKey))
+
+				withTempDir(func(target string) {
+					Expect(run(
+						"--url", "https://github.com/shipwright-io/sample-nodejs-private.git",
+						"--secret-path", secret,
+						"--target", target,
+						"--git-url-rewrite",
+					)).ToNot(HaveOccurred())
+
+					Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+				})
+			})
+		})
+
+		It("should Git clone a private repository using a SSH private key that contains a HTTPS submodule when Git URL rewrite is enabled", func() {
 			withTempDir(func(secret string) {
 				// Mock the filesystem state of `kubernetes.io/ssh-auth` type secret volume mount
 				file(filepath.Join(secret, "ssh-privatekey"), 0400, []byte(sshPrivateKey))


### PR DESCRIPTION
# Changes

## Avoid using git config

Using `git config` has the disadvantage that it also changes the Git config
in the development system when running the test cases.

Rename `addtlCredArgs` to `addtlGitArgs` to be more generic.

Use `-c` Git flag to supply specific configuration instead of using Git config.

##  Move Git URL rewrite into private key section

The Git URL rewrite logic was located outside of the credentials section of the
code, which means it was used in any case. However, it does not make sense to
be used in combination with a HTTPS URL and basic auth.

Move section as-is into the private key section and setup.

##  Fix Git URL rewrite issue for HTTPS URLs

Fix credentials checks to allow for the combination of:
- HTTPS URL,
- private SSH key, and
- Git URL rewrite enabled.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixed issue where a HTTPS URL and private SSH key could not be used due to the credentials verification routine not taking the Git URL rewrite flag into account.
```
