### PR TITLE
Fix incorrect flag name

### DIFF
--- a/pkg/reconciler/buildrun/resources/sources/git.go
+++ b/pkg/reconciler/buildrun/resources/sources/git.go
@@ -71,7 +71,7 @@ func AppendGitStep(
 
 	// If configure, use Git URL rewrite flag
 	if cfg.GitRewriteRule {
-		gitStep.Container.Args = append(gitStep.Container.Args, "--git-url-rewrite-rule")
+		gitStep.Container.Args = append(gitStep.Container.Args, "--git-url-rewrite")
 	}
 
 	if source.Credentials != nil {


### PR DESCRIPTION
# Changes

The flag name was changed during the initial commit, but not updated in the
controller code.

Fix name to be `"--git-url-rewrite"`.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixed incorrect flag name for Git step in controller code.
```

