### PR TITLE
Remove compatability code to remove service account with -sa suffix

### DIFF
--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -13,6 +13,7 @@ SPDX-License-Identifier: Apache-2.0
   - [Defining ParamValues](#defining-paramvalues)
   - [Defining the ServiceAccount](#defining-the-serviceaccount)
 - [Canceling a `BuildRun`](#canceling-a-buildrun)
+  - [Specifying Environment Variables](#specifying-environment-variables)
 - [BuildRun Status](#buildrun-status)
   - [Understanding the state of a BuildRun](#understanding-the-state-of-a-buildrun)
   - [Understanding failed BuildRuns](#understanding-failed-buildruns)
@@ -132,9 +133,9 @@ spec:
     name: pipeline
 ```
 
-You can also use set the `spec.serviceAccount.generate` path to `true`. This will generate the service account during runtime for you.
+You can also use set the `spec.serviceAccount.generate` path to `true`. This will generate the service account during runtime for you. The name of the generated service account is the name of the BuildRun.
 
-_**Note**_: When the SA is not defined, the `BuildRun` will default to the `default` SA in the namespace.
+_**Note**_: When the service account is not defined, the `BuildRun` will use the `pipeline` service account if it exists in the namespace, and fall back to the `default` service account.
 
 ## Canceling a `BuildRun`
 

--- a/pkg/reconciler/buildrun/resources/service_accounts.go
+++ b/pkg/reconciler/buildrun/resources/service_accounts.go
@@ -34,12 +34,6 @@ func GetGeneratedServiceAccountName(buildRun *buildv1alpha1.BuildRun) string {
 	return buildRun.Name
 }
 
-// GetHeritageGeneratedServiceAccountName return the name of the generated service account for
-// a build run as it was used in older releases of Shipwright Build
-func GetHeritageGeneratedServiceAccountName(buildRun *buildv1alpha1.BuildRun) string {
-	return buildRun.Name + "-sa"
-}
-
 // IsGeneratedServiceAccountUsed checks if a build run uses a generated service account
 func IsGeneratedServiceAccountUsed(buildRun *buildv1alpha1.BuildRun) bool {
 	return buildRun.Spec.ServiceAccount != nil && buildRun.Spec.ServiceAccount.Generate
@@ -103,16 +97,8 @@ func DeleteServiceAccount(ctx context.Context, client client.Client, completedBu
 	serviceAccount.Namespace = completedBuildRun.Namespace
 
 	ctxlog.Info(ctx, "deleting service account", namespace, completedBuildRun.Namespace, name, completedBuildRun.Name, "serviceAccount", serviceAccount.Name)
-	if err := client.Delete(ctx, serviceAccount); err != nil {
-		if apierrors.IsNotFound(err) {
-			serviceAccount.Name = GetHeritageGeneratedServiceAccountName(completedBuildRun)
-			ctxlog.Info(ctx, "deleting service account", namespace, completedBuildRun.Namespace, name, completedBuildRun.Name, "serviceAccount", serviceAccount.Name)
-			err = client.Delete(ctx, serviceAccount)
-		}
-
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
+	if err := client.Delete(ctx, serviceAccount); err != nil && !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	return nil

--- a/pkg/reconciler/buildrun/resources/service_accounts_test.go
+++ b/pkg/reconciler/buildrun/resources/service_accounts_test.go
@@ -133,7 +133,6 @@ var _ = Describe("Operating service accounts", func() {
 
 		It("should provide a generated sa name", func() {
 			Expect(resources.GetGeneratedServiceAccountName(buildRunSample)).To(Equal(buildRunSample.Name))
-			Expect(resources.GetHeritageGeneratedServiceAccountName(buildRunSample)).To(Equal(buildRunSample.Name + "-sa"))
 		})
 
 		It("should return a generated sa with a label, ownerreference and a ref secret if it does not exists", func() {


### PR DESCRIPTION
# Changes

Fixes #892 

This removes the compatibility code that removes a generated service account with the `-sa` suffix on BuildRun completion created by old releases. Should a user have a running old BuildRun or make a large version jump, then the owner reference will make sure the service account gets deleted on BuildRun deletion.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Removing compatibility code that deleted generated service accounts with the naming pattern from before v0.6
```