### PR TITLE
Update BuildAh to v1.23.1

### DIFF
--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: quay.io/containers/buildah:v1.20.1
+      image: quay.io/containers/buildah:v1.23.1
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -17,9 +17,34 @@ spec:
         - |
           set -euo pipefail
 
+          echo "Creating registries config file..."
+
+          format(){
+              array=(`echo $1 | tr ',' ' '`)
+              str=""
+              for m in "${array[@]}"; do
+                  str=$str"'${m}', "
+              done
+
+              echo ${str%??}
+          }
+
+          cat <<EOF >/tmp/registries.conf
+          [registries.search]
+          registries = [$(format "$(params.registry-search)")]
+
+          [registries.insecure]
+          registries = [$(format "$(params.registry-insecure)")]
+
+          [registries.block]
+          registries = [$(format "$(params.registry-block)")]
+
+          EOF
+
           # Building the image
           echo '[INFO] Building image $(params.shp-output-image)'
           buildah bud \
+            --registries-conf='/tmp/registries.conf' \
             --tag='$(params.shp-output-image)' \
             --file='$(build.dockerfile)' \
             '$(params.shp-source-context)'
@@ -37,8 +62,18 @@ spec:
             '$(params.shp-output-image)' | tr -d "\n" > '$(results.shp-image-digest.path)'
       resources:
         limits:
-          cpu: 500m
-          memory: 1Gi
+          cpu: "1"
+          memory: 2Gi
         requests:
           cpu: 250m
           memory: 65Mi
+  parameters:
+    - description: The registries for searching short name images such as `golang:latest`, separated by commas.
+      name: registry-search
+      default: docker.io,quay.io
+    - description: The fully-qualified name of insecure registries. An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
+      name: registry-insecure
+      default: ""
+    - description: The registries that need to block pull access.
+      name: registry-block
+      default: ""

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -18,7 +18,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah
-      image: quay.io/containers/buildah:v1.20.1
+      image: quay.io/containers/buildah:v1.23.1
       workingDir: /s2i
       securityContext:
         privileged: true
@@ -29,9 +29,35 @@ spec:
         - |
           set -euo pipefail
 
+          echo "Creating registries config file..."
+
+          format(){
+              array=(`echo $1 | tr ',' ' '`)
+              str=""
+              for m in "${array[@]}"; do
+                  str=$str"'${m}', "
+              done
+
+              echo ${str%??}
+          }
+
+          cat <<EOF >/tmp/registries.conf
+          [registries.search]
+          registries = [$(format "$(params.registry-search)")]
+
+          [registries.insecure]
+          registries = [$(format "$(params.registry-insecure)")]
+
+          [registries.block]
+          registries = [$(format "$(params.registry-block)")]
+
+          EOF
+
           # Building the image
           echo '[INFO] Building image $(params.shp-output-image)'
-          buildah bud --tag='$(params.shp-output-image)'
+          buildah bud \
+            --registries-conf='/tmp/registries.conf' \
+            --tag='$(params.shp-output-image)'
 
           # Push the image
           echo '[INFO] Pushing image $(params.shp-output-image)'
@@ -46,3 +72,13 @@ spec:
       volumeMounts:
         - name: s2i
           mountPath: /s2i
+  parameters:
+    - description: The registries for searching short name images such as `golang:latest`, separated by commas.
+      name: registry-search
+      default: docker.io,quay.io
+    - description: The fully-qualified name of insecure registries. An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
+      name: registry-insecure
+      default: ""
+    - description: The registries that need to block pull access.
+      name: registry-block
+      default: ""


### PR DESCRIPTION
# Changes

I cherry-picked the changes from [update buildah image to v1.23.1 #951](https://github.com/shipwright-io/build/pull/951). In my local tries, the BuildAh build was hanging as well like in the GitHub action runs. No indication for me why. Low resources was my guess, and with more resources it succeeded.

fyi @wanjunlei

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Update Buildah to 1.23.1, introduce parameters to setup registry configuration
```
