### PR TITLE
Fail in case there is an error event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             kubernetes:
               - v1.20.7
               - v1.21.2
-          max-parallel: 1
+          max-parallel: 2
         runs-on: ubuntu-latest
         steps:
         - name: Install Go


### PR DESCRIPTION
# Changes

Investigated why integration tests failed in GitHub action. As discussed below, changed some test cases to use polling instead.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
