### PR TITLE
Use golangci-lint in CI

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -10,34 +10,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17.x
-
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v2
       with:
-        path: go/src/github.com/shipwright-io/build
-
-    - name: Install Tools
-      run: |
-        go install github.com/gordonklaus/ineffassign@latest
-        go install golang.org/x/lint/golint@latest
-        go install github.com/client9/misspell/cmd/misspell@latest
-        go install honnef.co/go/tools/cmd/staticcheck@latest
-        go install github.com/maxbrunsfeld/counterfeiter/v6@latest
-        go install github.com/securego/gosec/v2/cmd/gosec@latest
-
-    - name: Checks
-      env:
-        GOPATH: "/home/runner/work/build/build/go"
-      run: |
-        make -C $GOPATH/src/github.com/shipwright-io/build \
-          sanity-check \
-          verify-generate
+        args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,24 @@
+linters:
+  enable:
+    - ineffassign
+    - revive
+    - gosec
+    - govet
+    - misspell
+    - staticcheck
+  disable:
+    - errcheck
+
+linters-settings:
+  gosec:
+    excludes:
+      - G101 # Look for hard coded credentials
+      - G305 # File traversal when extracting zip/tar archive
+      - G306 # Poor file permissions used when writing to a new file
+      - G601 # Implicit memory aliasing of items from a range statement
+
+issues:
+  exclude-rules:
+    - path: test
+      linters:
+        - revive

--- a/Makefile
+++ b/Makefile
@@ -148,44 +148,10 @@ endif
 install-counterfeiter:
 	hack/install-counterfeiter.sh
 
-.PHONY: govet
-govet:
-	@echo "Checking go vet"
-	@go vet ./...
-
-# Install it via: go install github.com/gordonklaus/ineffassign@latest
-.PHONY: ineffassign
-ineffassign:
-	@echo "Checking ineffassign"
-	@ineffassign ./...
-
-# Install it via: go install golang.org/x/lint/golint@latest
-# See https://github.com/golang/lint/issues/320 for details regarding the grep
-.PHONY: golint
-golint:
-	@echo "Checking golint"
-	@go list ./... | grep -v -e /vendor -e /test | xargs -L1 golint -set_exit_status
-
-# Install it via: go install github.com/securego/gosec/v2/cmd/gosec@latest
-.PHONY: gosec
-gosec:
-	@echo "Checking gosec"
-	gosec -confidence medium -severity high ./...
-
-# Install it via: go install github.com/client9/misspell/cmd/misspell@latest
-.PHONY: misspell
-misspell:
-	@echo "Checking misspell"
-	@find . -type f -not -path './vendor/*' -not -path './.git/*' -not -path './build/*' -print0 | xargs -0 misspell -source=text -error
-
-# Install it via: go install honnef.co/go/tools/cmd/staticcheck@latest
-.PHONY: staticcheck
-staticcheck:
-	@echo "Checking staticcheck"
-	@go list ./... | grep -v /test | xargs staticcheck
-
+# Install golangci-lint via: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 .PHONY: sanity-check
-sanity-check: ineffassign golint gosec govet misspell staticcheck
+sanity-check:
+	golangci-lint run
 
 # https://github.com/shipwright-io/build/issues/123
 test: test-unit


### PR DESCRIPTION
# Changes

Use [golangci-lint](https://golangci-lint.run/) in [verify.yaml](https://github.com/shipwright-io/build/blob/main/.github/workflows/verify.yaml)

Fixes #948 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
