### PR TITLE
Add the list of environments to be blocked on the creation of files inside /platform/env

### DIFF
--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -44,12 +44,27 @@ spec:
 
           envs=($(env))
 
+          # Denying the creation of non required files from system environments.
+          # The creation of a file named PATH (corresponding to PATH system environment)
+          # caused failure for python source during pip install (https://github.com/Azure-Samples/python-docs-hello-world)
+          block_list=("PATH" "HOSTNAME" "PWD" "_" "SHLVL" "HOME" "")
+
           for env in "${envs[@]}"; do
-              IFS='=' read -r key value string <<< "$env"
-              if [[ "$key" != "" ]]; then
-                  path="${ENV_DIR}/${key}"
-                  echo -n "$value" > "$path"
+            blocked=false
+
+            IFS='=' read -r key value string <<< "$env"
+
+            for str in "${block_list[@]}"; do
+              if [[ "$key" == "$str" ]]; then
+                blocked=true
+                break
               fi
+            done
+
+            if [ "$blocked" == "false" ]; then
+              path="${ENV_DIR}/${key}"
+              echo -n "$value" > "$path"
+            fi
           done
 
           /cnb/lifecycle/creator \

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -44,12 +44,27 @@ spec:
 
           envs=($(env))
 
+          # Denying the creation of non required files from system environments.
+          # The creation of a file named PATH (corresponding to PATH system environment)
+          # caused failure for python source during pip install (https://github.com/Azure-Samples/python-docs-hello-world)
+          block_list=("PATH" "HOSTNAME" "PWD" "_" "SHLVL" "HOME" "")
+
           for env in "${envs[@]}"; do
-              IFS='=' read -r key value string <<< "$env"
-              if [[ "$key" != "" ]]; then
-                  path="${ENV_DIR}/${key}"
-                  echo -n "$value" > "$path"
+            blocked=false
+
+            IFS='=' read -r key value string <<< "$env"
+
+            for str in "${block_list[@]}"; do
+              if [[ "$key" == "$str" ]]; then
+                blocked=true
+                break
               fi
+            done
+
+            if [ "$blocked" == "false" ]; then
+              path="${ENV_DIR}/${key}"
+              echo -n "$value" > "$path"
+            fi
           done
 
           /cnb/lifecycle/creator \

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -44,12 +44,27 @@ spec:
 
           envs=($(env))
 
+          # Denying the creation of non required files from system environments.
+          # The creation of a file named PATH (corresponding to PATH system environment)
+          # caused failure for python source during pip install (https://github.com/Azure-Samples/python-docs-hello-world)
+          block_list=("PATH" "HOSTNAME" "PWD" "_" "SHLVL" "HOME" "")
+
           for env in "${envs[@]}"; do
-              IFS='=' read -r key value string <<< "$env"
-              if [[ "$key" != "" ]]; then
-                  path="${ENV_DIR}/${key}"
-                  echo -n "$value" > "$path"
+            blocked=false
+
+            IFS='=' read -r key value string <<< "$env"
+
+            for str in "${block_list[@]}"; do
+              if [[ "$key" == "$str" ]]; then
+                blocked=true
+                break
               fi
+            done
+
+            if [ "$blocked" == "false" ]; then
+              path="${ENV_DIR}/${key}"
+              echo -n "$value" > "$path"
+            fi
           done
 
           mkdir /tmp/cache /tmp/layers

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -46,12 +46,27 @@ spec:
 
           envs=($(env))
 
+          # Denying the creation of non required files from system environments.
+          # The creation of a file named PATH (corresponding to PATH system environment)
+          # caused failure for python source during pip install (https://github.com/Azure-Samples/python-docs-hello-world)
+          block_list=("PATH" "HOSTNAME" "PWD" "_" "SHLVL" "HOME" "")
+
           for env in "${envs[@]}"; do
-              IFS='=' read -r key value string <<< "$env"
-              if [[ "$key" != "" ]]; then
-                  path="${ENV_DIR}/${key}"
-                  echo -n "$value" > "$path"
+            blocked=false
+
+            IFS='=' read -r key value string <<< "$env"
+
+            for str in "${block_list[@]}"; do
+              if [[ "$key" == "$str" ]]; then
+                blocked=true
+                break
               fi
+            done
+
+            if [ "$blocked" == "false" ]; then
+              path="${ENV_DIR}/${key}"
+              echo -n "$value" > "$path"
+            fi
           done
 
           /cnb/lifecycle/creator \


### PR DESCRIPTION
# Changes

The creation of a file named PATH (corresponding to `PATH` system environment) inside `/platform/env` caused failure for [python source with requirements.txt](https://github.com/Azure-Samples/python-docs-hello-world) when building with the Buildpack strategy.

Update scripts in the Buildpack strategies samples with an array of blocklist system environments.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fix the Buildpack build strategies failing for python source with a requirements.txt that failed during pip install
```