### PR TITLE
Adjust ignore statements for golangci-lint and fix failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             kubernetes:
               - v1.20.7
               - v1.21.2
-          max-parallel: 1
+          max-parallel: 2
         runs-on: ubuntu-latest
         steps:
         - name: Install Go
@@ -89,7 +89,7 @@ jobs:
             kubernetes:
               - v1.20.7
               - v1.21.2
-          max-parallel: 1
+          max-parallel: 2
         runs-on: ubuntu-latest
         steps:
         - name: Install Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             kubernetes:
               - v1.20.7
               - v1.21.2
-          max-parallel: 2
+          max-parallel: 1
         runs-on: ubuntu-latest
         steps:
         - name: Install Go
@@ -89,7 +89,7 @@ jobs:
             kubernetes:
               - v1.20.7
               - v1.21.2
-          max-parallel: 2
+          max-parallel: 1
         runs-on: ubuntu-latest
         steps:
         - name: Install Go

--- a/pkg/reconciler/buildrun/resources/conditions.go
+++ b/pkg/reconciler/buildrun/resources/conditions.go
@@ -82,11 +82,11 @@ func UpdateBuildRunUsingTaskRunCondition(ctx context.Context, client client.Clie
 				return err
 			}
 
-			//lint:ignore SA1019 we want to give users some time to adopt to failureDetails
+			//nolint:staticcheck // SA1019 we want to give users some time to adopt to failureDetails
 			buildRun.Status.FailedAt = &buildv1alpha1.FailedAt{Pod: pod.Name}
 
 			if failedContainer != nil {
-			  	//lint:ignore SA1019 we want to give users some time to adopt to failureDetails
+				//nolint:staticcheck // SA1019 we want to give users some time to adopt to failureDetails
 				buildRun.Status.FailedAt.Container = failedContainer.Name
 				message = fmt.Sprintf("buildrun step %s failed in pod %s, for detailed information: kubectl --namespace %s logs %s --container=%s",
 					failedContainer.Name,

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -20,12 +20,6 @@ import (
 	"github.com/shipwright-io/build/test"
 )
 
-const (
-	BUILD    = "build-"
-	BUILDRUN = "buildrun-"
-	STRATEGY = "strategy-"
-)
-
 var _ = Describe("Integration tests Build and BuildRuns", func() {
 
 	var (

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
@@ -333,7 +334,9 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 
 			tr.Spec.Status = "TaskRunCancelled"
 
-			_, err = tb.UpdateTaskRun(tr)
+			_, err = tb.UpdateTaskRun(tr.Name, func(tr *v1beta1.TaskRun) {
+				tr.Spec.Status = "TaskRunCancelled"
+			})
 			Expect(err).To(BeNil())
 
 			expectedReason := "TaskRunCancelled"

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -177,8 +177,8 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 					taskRun, err := tb.GetTaskRunFromBuildRun(buildRun.Name)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(buildRun.Status.FailedAt.Pod).To(Equal(taskRun.Status.PodName))
-					Expect(buildRun.Status.FailedAt.Container).To(Equal("step-step-build-and-push"))
+					Expect(buildRun.Status.FailureDetails.Location.Pod).To(Equal(taskRun.Status.PodName))
+					Expect(buildRun.Status.FailureDetails.Location.Container).To(Equal("step-step-build-and-push"))
 
 					condition := buildRun.Status.GetCondition(v1alpha1.Succeeded)
 					Expect(condition.Status).To(Equal(corev1.ConditionFalse))

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -14,6 +14,12 @@ import (
 	"github.com/shipwright-io/build/test/utils"
 )
 
+const (
+	BUILD    = "build-"
+	BUILDRUN = "buildrun-"
+	STRATEGY = "strategy-"
+)
+
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration Suite")


### PR DESCRIPTION
# Changes

Adjusted ignore messages for staticcheck to also work for golangci-lint. Refactored tests to no longer use the deprecated API and deal with the errors in decoding watch events.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
