### PR TITLE
Fix accessing non-terminated steps for failures

### DIFF
--- a/pkg/reconciler/buildrun/resources/failure_details_test.go
+++ b/pkg/reconciler/buildrun/resources/failure_details_test.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 
-
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	buildfakes "github.com/shipwright-io/build/pkg/controller/fakes"
 )
@@ -43,8 +42,9 @@ var _ = Describe("Surfacing errors", func() {
 			message, _ := json.Marshal([]pipelinev1beta1.PipelineResourceResult{errorReason, errorMessage, unrelated})
 
 			failedStep.Terminated = &corev1.ContainerStateTerminated{Message: string(message)}
+			followUpStep := pipelinev1beta1.StepState{}
 
-			redTaskRun.Status.Steps = append(redTaskRun.Status.Steps, failedStep)
+			redTaskRun.Status.Steps = append(redTaskRun.Status.Steps, failedStep, followUpStep)
 			redBuild := buildv1alpha1.BuildRun{}
 
 			UpdateBuildRunUsingTaskFailures(ctx, client, &redBuild, &redTaskRun)
@@ -77,7 +77,7 @@ var _ = Describe("Surfacing errors", func() {
 		It("does not surface error results if the container terminated without failure", func() {
 			greenTaskRun := pipelinev1beta1.TaskRun{}
 			greenTaskRun.Status.Conditions = append(greenTaskRun.Status.Conditions,
-				apis.Condition{Type: apis.ConditionSucceeded, Reason: pipelinev1beta1. TaskRunReasonSuccessful.String()})
+				apis.Condition{Type: apis.ConditionSucceeded, Reason: pipelinev1beta1.TaskRunReasonSuccessful.String()})
 			failedStep := pipelinev1beta1.StepState{}
 
 			errorReasonValue := "PullBaseImageFailed"


### PR DESCRIPTION
The cause of this bug is the assumption that `v1beta1.TaskRunReasonFailed` means that all steps are terminated. However, it only guarantees that at least on step is terminated with non-zero exit code.

Adds extra non-terminated step to test to capture the scenario above.
Adds new condition to avoid accessing non-terminated steps.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

/kind bug