### PR TITLE
Add integration test for failure reasons

### DIFF
--- a/pkg/reconciler/buildrun/resources/failure_details.go
+++ b/pkg/reconciler/buildrun/resources/failure_details.go
@@ -36,7 +36,7 @@ func UpdateBuildRunUsingTaskFailures(ctx context.Context, client client.Client, 
 
 func extractFailureReasonAndMessage(taskRun *v1beta1.TaskRun) (errorReason string, errorMessage string) {
 	for _, step := range taskRun.Status.Steps {
-		if step.Terminated == nil || step.Terminated.ExitCode != 0 {
+		if step.Terminated == nil || step.Terminated.ExitCode == 0 {
 			continue
 		}
 

--- a/pkg/reconciler/buildrun/resources/failure_details_test.go
+++ b/pkg/reconciler/buildrun/resources/failure_details_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Surfacing errors", func() {
 
 			message, _ := json.Marshal([]pipelinev1beta1.PipelineResourceResult{errorReason, errorMessage, unrelated})
 
-			failedStep.Terminated = &corev1.ContainerStateTerminated{Message: string(message)}
+			failedStep.Terminated = &corev1.ContainerStateTerminated{Message: string(message), ExitCode: 1}
 			followUpStep := pipelinev1beta1.StepState{}
 
 			redTaskRun.Status.Steps = append(redTaskRun.Status.Steps, failedStep, followUpStep)

--- a/test/buildstrategy_samples.go
+++ b/test/buildstrategy_samples.go
@@ -236,3 +236,24 @@ spec:
     args:
     - $(params.sleep-time)
 `
+
+// BuildStrategyWithErrorResult is a strategy that always fails
+// and surfaces and error reason and message to the user
+const BuildStrategyWithErrorResult = `
+apiVersion: build.dev/v1alpha1
+kind: BuildStrategy
+metadata:
+  name: strategy-with-error-results
+spec:
+  buildSteps:
+  - name: fail-with-error-result
+    image: alpine:latest
+    command:
+    - sh
+    args:
+    - -c
+    - |
+      printf "integration test error reason" > $(results.shp-error-reason.path);
+      printf "integration test error message" > $(results.shp-error-message.path);
+      return 1
+`


### PR DESCRIPTION
Currently the failure extraction is faulty. It triggers on containers with exit code 0. However, a failed container has a non-zero exit code. It adds integration test with custom strategy that guarantees failure and error results to further strengthen confidence in the feature.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

/kind bug