### PR TITLE
Fix failing integration test

### DIFF
--- a/test/integration/buildstrategy_to_taskruns_test.go
+++ b/test/integration/buildstrategy_to_taskruns_test.go
@@ -392,7 +392,7 @@ var _ = Describe("Integration tests BuildStrategies and TaskRuns", func() {
 		})
 		Context("when a taskrun fails with an error result", func() {
 			It("surfaces the result to the buildrun", func() {
-				// Create a BuildStrategy that guarantees a failure 
+				// Create a BuildStrategy that guarantees a failure
 				cbsObject, err := tb.Catalog.LoadBuildStrategyFromBytes(
 					[]byte(test.BuildStrategyWithErrorResult),
 				)
@@ -401,7 +401,7 @@ var _ = Describe("Integration tests BuildStrategies and TaskRuns", func() {
 				err = tb.CreateBuildStrategy(cbsObject)
 				Expect(err).To(BeNil())
 
-				buildObject, err := tb.Catalog.LoadBuildWithNameAndStrategy(
+				buildObject, err = tb.Catalog.LoadBuildWithNameAndStrategy(
 					BUILD+tb.Namespace,
 					cbsObject.Name,
 					[]byte(test.BuildBSMinimal),
@@ -410,10 +410,10 @@ var _ = Describe("Integration tests BuildStrategies and TaskRuns", func() {
 
 				Expect(tb.CreateBuild(buildObject)).To(BeNil())
 
-				_, err = tb.GetBuildTillValidation(buildObject.Name)
+				buildObject, err = tb.GetBuildTillValidation(buildObject.Name)
 				Expect(err).To(BeNil())
 
-				buildRunObject, err := tb.Catalog.LoadBRWithNameAndRef(
+				buildRunObject, err = tb.Catalog.LoadBRWithNameAndRef(
 					BUILDRUN+tb.Namespace,
 					BUILD+tb.Namespace,
 					[]byte(test.MinimalBuildRun),


### PR DESCRIPTION
# Changes

Removes unintended [shadowing](https://github.com/shipwright-io/build/blob/517165e62f4b1deba49c02af590ab047fb69dcb1/test/integration/buildstrategy_to_taskruns_test.go#L404) of global variable that lead to nil pointer dereferencing in the [cleanup](https://github.com/shipwright-io/build/blob/main/test/integration/buildstrategy_to_taskruns_test.go#L37) call in of the integration tests.

Observed in CI pipeline: https://github.com/shipwright-io/build/runs/4738311179?check_suite_focus=true#step:9:98.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```