### PR TITLE
Fix image override bug for mutate-image in config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -243,7 +243,7 @@ func (c *Config) SetConfigFromEnv() error {
 	}
 
 	if mutateImageContainerTemplate := os.Getenv(mutateImageContainerTemplateEnvVar); mutateImageContainerTemplate != "" {
-		c.GitContainerTemplate = corev1.Container{}
+		c.MutateImageContainerTemplate = corev1.Container{}
 		if err := json.Unmarshal([]byte(mutateImageContainerTemplate), &c.MutateImageContainerTemplate); err != nil {
 			return err
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -157,6 +157,43 @@ var _ = Describe("Config", func() {
 				}))
 			})
 		})
+
+		It("should allow for an override of the Mutate-Image container template", func() {
+			overrides := map[string]string{
+				"MUTATE_IMAGE_CONTAINER_TEMPLATE": `{"image":"myregistry/custom/mutate-image","resources":{"requests":{"cpu":"0.5","memory":"128Mi"}}}`,
+			}
+
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(config.MutateImageContainerTemplate).To(Equal(corev1.Container{
+					Image: "myregistry/custom/mutate-image",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0.5"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				}))
+			})
+		})
+
+		It("should allow for an override of the Mutate-Image container template and image", func() {
+			overrides := map[string]string{
+				"MUTATE_IMAGE_CONTAINER_TEMPLATE": `{"image":"myregistry/custom/mutate-image","resources":{"requests":{"cpu":"0.5","memory":"128Mi"}}}`,
+				"MUTATE_IMAGE_CONTAINER_IMAGE":    "myregistry/custom/mutate-image:override",
+			}
+
+			configWithEnvVariableOverrides(overrides, func(config *Config) {
+				Expect(config.MutateImageContainerTemplate).To(Equal(corev1.Container{
+					Image: "myregistry/custom/mutate-image:override",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0.5"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				}))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
# Changes

Minimal example to reproduce: 

```go
package config

import (
	"os"
	"testing"
)

func TestOverrideBug(t *testing.T) {
	cfg := NewDefaultConfig()

	os.Setenv("GIT_CONTAINER_IMAGE", "git-image")
	cfg.SetConfigFromEnv()

	if cfg.GitContainerTemplate.Image != "git-image" {
		t.Fatal("override did not set git image")
	}

	os.Setenv("MUTATE_IMAGE_CONTAINER_TEMPLATE", `{"image":"mutate-image"`)
	cfg.SetConfigFromEnv()

	if cfg.GitContainerTemplate.Image != "git-image" {
		t.Fatalf("mutate image overrides git-template")
	}
}
```

Fixes bug by overriding the right entry of `config` instead of the `GitContainerTemplate`.
It additionally adds previously missing unit tests to make sure that override for `mutate-image` is sound.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixes override bug for `pkg/config`: Setting the environment variabel `MUTATE_IMAGE_CONTAINER_TEMPLATE` now works as intended and does not override `config.GitContainerTemplate`.
```

/kind bug
