### PR TITLE
Correct controller-gen version in HACK.md

### DIFF
--- a/HACK.md
+++ b/HACK.md
@@ -41,7 +41,7 @@ In the near future, the above would be setup by the controller.
 make clean && make build
 ```
 
-* This project uses Golang 1.17+ and controller-gen v0.9.7.
+* This project uses Golang 1.17+ and controller-gen v0.6.2.
 * The controllers create/watch Tekton objects.
 
 # Testing


### PR DESCRIPTION
# Changes

When I recently updated the Kubernetes dependency and with it controller-gen and controller-runtime, I by mistake put the controller-runtime version into HACK.md where we mention the controller-gen version. :-( Correcting this.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```