### PR TITLE
Avoid Unnecessary `go mod vendor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,14 +76,10 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 default: build
 
-.PHONY: vendor
-vendor: go.mod go.sum
-	go mod vendor
-
-.PHONY: build
 build: $(CONTROLLER)
 
-$(CONTROLLER): vendor
+.PHONY: $(CONTROLLER)
+$(CONTROLLER):
 	go build -trimpath $(GO_FLAGS) -o $(CONTROLLER) cmd/shipwright-build-controller/main.go
 
 .PHONY: build-plain
@@ -240,11 +236,11 @@ install-controller-kind: install-apis
 install-strategies: install-apis
 	kubectl apply -R -f samples/buildstrategy/
 
-local: vendor install-strategies
+local: install-strategies
 	CONTROLLER_NAME=shipwright-build-controller \
 	go run cmd/shipwright-build-controller/main.go $(ZAP_FLAGS)
 
-local-plain: vendor
+local-plain:
 	CONTROLLER_NAME=shipwright-build-controller \
 	go run cmd/shipwright-build-controller/main.go $(ZAP_FLAGS)
 
@@ -266,4 +262,3 @@ kind-tekton:
 kind:
 	./hack/install-kind.sh
 	./hack/install-registry.sh
-


### PR DESCRIPTION
# Changes

Stop running `go mod vendor` before `build` and `local` targets.

# Submitter Checklist

- [x] ~Includes tests if functionality changed/was added~
- [x] ~Includes docs if changes are user-facing~
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```