### PR TITLE
Turn of parallel tests in test-unit-ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,6 @@ test-unit-ginkgo: ginkgo
 		-randomizeAllSpecs \
 		-randomizeSuites \
 		-failOnPending \
-		-p \
 		-compilers=2 \
 		-slowSpecThreshold=240 \
 		-race \


### PR DESCRIPTION
# Changes

The [Waiter test cases](https://github.com/shipwright-io/build/blob/main/cmd/waiter/main_test.go) cannot run in parallel because they use a lock file with a hard-coded name. Because of this I am turning off parallel runs in `make test-unit-ginkgo`. We should undo this again with Ginkgo 2. See https://github.com/shipwright-io/build/issues/874#issuecomment-1017531311

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```