### PR TITLE
Add parameterized CNB_PLATFORM_API to buildpacks strategy

### DIFF
--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -4,6 +4,10 @@ kind: ClusterBuildStrategy
 metadata:
   name: buildpacks-v3-heroku
 spec:
+  parameters:
+    - name: platform-api-version
+      description: The referenced version is the minimum version that all relevant buildpack implementations support.
+      default: "0.4"
   buildSteps:
     - name: prepare
       image: heroku/buildpacks:18
@@ -30,14 +34,15 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      env: 
+        - name: CNB_PLATFORM_API
+          value: $(params.platform-api-version)
       command:
         - /bin/bash
       args:
         - -c
         - |
           set -euo pipefail
-
-          mkdir /tmp/cache /tmp/layers
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"
@@ -67,12 +72,32 @@ spec:
             fi
           done
 
-          /cnb/lifecycle/creator \
-            '-app=$(params.shp-source-context)' \
-            -cache-dir=/tmp/cache \
-            -layers=/tmp/layers \
-            -report=/tmp/report.toml \
-            '$(params.shp-output-image)'
+          LAYERS_DIR=/tmp/layers
+          CACHE_DIR=/tmp/cache
+
+          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+
+          function anounce_phase {
+            printf "===> %s\n" "$1" 
+          }
+
+          anounce_phase "DETECTING"
+          /cnb/lifecycle/detector -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          anounce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "$(params.shp-output-image)"
+
+          anounce_phase "RESTORING"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+
+          anounce_phase "BUILDING"
+          /cnb/lifecycle/builder -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="$(params.shp-source-context)")
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+
+          anounce_phase "EXPORTING"
+          /cnb/lifecycle/exporter "${exporter_args[@]}" "$(params.shp-output-image)" 
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -4,6 +4,10 @@ kind: BuildStrategy
 metadata:
   name: buildpacks-v3-heroku
 spec:
+  parameters:
+    - name: platform-api-version
+      description: The referenced version is the minimum version that all relevant buildpack implementations support.
+      default: "0.4"
   buildSteps:
     - name: prepare
       image: heroku/buildpacks:18
@@ -30,14 +34,15 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      env: 
+        - name: CNB_PLATFORM_API
+          value: $(params.platform-api-version)
       command:
         - /bin/bash
       args:
         - -c
         - |
           set -euo pipefail
-
-          mkdir /tmp/cache /tmp/layers
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"
@@ -67,12 +72,32 @@ spec:
             fi
           done
 
-          /cnb/lifecycle/creator \
-            '-app=$(params.shp-source-context)' \
-            -cache-dir=/tmp/cache \
-            -layers=/tmp/layers \
-            -report=/tmp/report.toml \
-            '$(params.shp-output-image)'
+          LAYERS_DIR=/tmp/layers
+          CACHE_DIR=/tmp/cache
+
+          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+
+          function anounce_phase {
+            printf "===> %s\n" "$1" 
+          }
+
+          anounce_phase "DETECTING"
+          /cnb/lifecycle/detector -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          anounce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "$(params.shp-output-image)"
+
+          anounce_phase "RESTORING"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+
+          anounce_phase "BUILDING"
+          /cnb/lifecycle/builder -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="$(params.shp-source-context)")
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+
+          anounce_phase "EXPORTING"
+          /cnb/lifecycle/exporter "${exporter_args[@]}" "$(params.shp-output-image)" 
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -4,6 +4,10 @@ kind: ClusterBuildStrategy
 metadata:
   name: buildpacks-v3
 spec:
+  parameters:
+    - name: platform-api-version
+      description: The referenced version is the minimum version that all relevant buildpack implementations support.
+      default: "0.4"
   buildSteps:
     - name: prepare
       image: docker.io/paketobuildpacks/builder:full
@@ -32,6 +36,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      env: 
+        - name: CNB_PLATFORM_API
+          value: $(params.platform-api-version)
       command:
         - /bin/bash
       args:
@@ -67,14 +74,32 @@ spec:
             fi
           done
 
-          mkdir /tmp/cache /tmp/layers
+          LAYERS_DIR=/tmp/layers
+          CACHE_DIR=/tmp/cache
 
-          /cnb/lifecycle/creator \
-            '-app=$(params.shp-source-context)' \
-            -cache-dir=/tmp/cache \
-            -layers=/tmp/layers \
-            -report=/tmp/report.toml \
-            '$(params.shp-output-image)'
+          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+
+          function anounce_phase {
+            printf "===> %s\n" "$1" 
+          }
+
+          anounce_phase "DETECTING"
+          /cnb/lifecycle/detector -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          anounce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "$(params.shp-output-image)"
+
+          anounce_phase "RESTORING"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+
+          anounce_phase "BUILDING"
+          /cnb/lifecycle/builder -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="$(params.shp-source-context)")
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+
+          anounce_phase "EXPORTING"
+          /cnb/lifecycle/exporter "${exporter_args[@]}" "$(params.shp-output-image)" 
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -4,6 +4,10 @@ kind: BuildStrategy
 metadata:
   name: buildpacks-v3
 spec:
+  parameters:
+    - name: platform-api-version
+      description: The referenced version is the minimum version that all relevant buildpack implementations support.
+      default: "0.4"
   buildSteps:
     - name: prepare
       image: docker.io/paketobuildpacks/builder:full
@@ -32,14 +36,15 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      env: 
+        - name: CNB_PLATFORM_API
+          value: $(params.platform-api-version)
       command:
         - /bin/bash
       args:
         - -c
         - |
           set -euo pipefail
-
-          mkdir /tmp/cache /tmp/layers
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"
@@ -69,12 +74,32 @@ spec:
             fi
           done
 
-          /cnb/lifecycle/creator \
-            '-app=$(params.shp-source-context)' \
-            -cache-dir=/tmp/cache \
-            -layers=/tmp/layers \
-            -report=/tmp/report.toml \
-            '$(params.shp-output-image)'
+          LAYERS_DIR=/tmp/layers
+          CACHE_DIR=/tmp/cache
+
+          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+
+          function anounce_phase {
+            printf "===> %s\n" "$1" 
+          }
+
+          anounce_phase "DETECTING"
+          /cnb/lifecycle/detector -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          anounce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "$(params.shp-output-image)"
+
+          anounce_phase "RESTORING"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+
+          anounce_phase "BUILDING"
+          /cnb/lifecycle/builder -app="$(params.shp-source-context)" -layers="$LAYERS_DIR"
+
+          exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="$(params.shp-source-context)")
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+
+          anounce_phase "EXPORTING"
+          /cnb/lifecycle/exporter "${exporter_args[@]}" "$(params.shp-output-image)" 
 
           # Store the image digest
           grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"


### PR DESCRIPTION
# Changes

Buildpacks defines versioned api specification that allows them to bridge the knowledge gap between the [lifecycle](https://buildpacks.io/docs/concepts/components/lifecycle/) and the independent buildpack implementations. More specifically it allows the lifecycle utility to enable features based on the known api version and thus staying backward-compatible.

The lifecycle utility receives the api version from the environment variable `CNB_PLATFORM_API`. Whenever this variable is not present, it assumes per default that the version is `0.3`. Consequently, the lifecycle&rsquo;s exporter ignores the default process determined in the build step and sets the entrypoint of the resulting image to the lifecycle&rsquo;s launcher executable ([code reference](https://github.com/buildpacks/lifecycle/blob/2186200870193ffca3f0ae4da536e94110023596/exporter.go#L377)). The launcher itself is called without an argument and thus assumes that the default process is `web`. 

The interactions above break simple programs such as https://github.com/IBM/CodeEngine/tree/main/job.

The PR proposes a minimum version of `0.4` based on evaluating the api version of all buildpacks in the [paketo organization](https://github.com/paketo-buildpacks). The version introduces [multicall-launchers](https://buildpacks.io/docs/reference/spec/migration/platform-api-0.3-0.4) and produces non-broken images for the example above.

For buildpacks that do not set a default process, the 0.3 version of the api assigned the `web` process as default. This is not producible with the previous approach of using `creator` and the version `0.4`. Thus this PR splits the creator into its subcomponents to achieve a flexible point to inject the default process. As a side-effect, the changes remain compatible with paketo and heroku. 

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The buildpacks strategy now assumes the version "0.4" as its platform api version. The buildpacks strategies are more granular in their build process and chose "web" as a default process.
```

/kind bug