### PR TITLE
Update Trivy to 0.22.0, update go-containerregistry/crane to 0.8.0

### DIFF
--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
@@ -54,7 +54,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: trivy-scan
-      image: docker.io/aquasec/trivy:0.21.2
+      image: docker.io/aquasec/trivy:0.22.0
       volumeMounts:
       - mountPath: /image/
         name: tar
@@ -76,7 +76,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: crane-push
-      image: gcr.io/go-containerregistry/crane:v0.6.0
+      image: gcr.io/go-containerregistry/crane:v0.8.0
       securityContext:
         runAsUser: 0
       volumeMounts:


### PR DESCRIPTION
# Changes

Updating our outdated sample build strategy tools to recent versions before our upcoming release.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Update build strategy tool: Trivy to 0.22.0, go-containerregistry/crane to 0.8.0
```