### PR TITLE
allow action required release notes

### DIFF
--- a/.github/draft_release_notes.sh
+++ b/.github/draft_release_notes.sh
@@ -77,7 +77,7 @@ while IFS= read -r pr; do
    # if we are at this point, we have a PR with a release note to add
    AUTHOR=$(echo $pr | cut -d';' -f2)
    PR_NUM=$(echo $pr | cut -d';' -f3)
-   echo "Examining from ${AUTHOR} PR ${PR_NUM}"
+   echo "Examining from @${AUTHOR} PR ${PR_NUM}"
    PR_BODY=$(wget -q -O- https://api.github.com/repos/shipwright-io/build/issues/${PR_NUM:1})
    echo $PR_BODY | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' > /dev/null 2>&1
    rc=$?
@@ -101,37 +101,37 @@ while IFS= read -r pr; do
    rc=$?
    if [ ${rc} -eq 0 ]; then
       echo >> Fixes.md
-      echo "$PR_NUM by $AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Fixes.md
+      echo "$PR_NUM by @$AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Fixes.md
       MISC=no
    fi
    echo $pr | grep 'kind/api-change'
    rc=$?
    if [ ${rc} -eq 0 ]; then
       echo >> API.md
-      echo "$PR_NUM by $AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> API.md
+      echo "$PR_NUM by @$AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> API.md
       MISC=no
    fi
    echo $pr | grep 'kind/feature'
    rc=$?
    if [ ${rc} -eq 0 ]; then
       echo >> Features.md
-      echo "$PR_NUM by $AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Features.md
+      echo "$PR_NUM by @$AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Features.md
       MISC=no
    fi
    echo $pr | grep 'kind/documentation'
    rc=$?
    if [ ${rc} -eq 0 ]; then
       echo >> Docs.md
-      echo "$PR_NUM by $AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Docs.md
+      echo "$PR_NUM by @$AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Docs.md
       MISC=no
    fi
    if [ "$MISC" == "yes" ]; then
       echo >> Misc.md
-      echo "$PR_NUM by $AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Misc.md
+      echo "$PR_NUM by @$AUTHOR: $PR_RELEASE_NOTE_NO_NEWLINES" >> Misc.md
    fi
    # update the PR template if our greps etc. for pulling the release note changes
    #PR_RELEASE_NOTE=$(wget -q -O- https://api.github.com/repos/shipwright-io/build/issues/${PR_NUM:1} | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' | grep -avP '\W*(Your release note here|action required: your release note here|NONE)\W*')
-   echo "Added from ${AUTHOR} PR ${PR_NUM:1} to the release note draft"
+   echo "Added from @${AUTHOR} PR ${PR_NUM:1} to the release note draft"
 done < last-300-prs-with-release-note.txt
 
 cat Features.md >> Changes.md

--- a/.github/draft_release_notes.sh
+++ b/.github/draft_release_notes.sh
@@ -42,10 +42,10 @@ echo "COMMON_ANCESTOR is ${COMMON_ANCESTOR}"
 
 # use of 'hub', which is an extension of the 'git' CLI, allows for pulling of PRs, though we can't search based on commits
 # associated with those PRs, so we grab a super big number, 300, which should guarantee grabbing all the PRs back to
-# github.events.inputs.tags; we use grep -v to filter out release-note-none and release-note-action-required.
+# github.events.inputs.tags; we use grep -v to filter out release-note-none.
 # NOTE: investigated using the new 'gh' cli command, but its 'gh pr list' does not currently support the -f option so
 # staying with 'hub' for now.
-hub pr list --state merged -L 300 -f "%sm;%au;%i;%t;%L%n" | grep -E ", release-note|release-note," | grep -v release-note-none | grep -v release-note-action-required > last-300-prs-with-release-note.txt
+hub pr list --state merged -L 300 -f "%sm;%au;%i;%t;%L%n" | grep -E ", release-note|release-note," | grep -v release-note-none > last-300-prs-with-release-note.txt
 # this is for debug while we sort out env differences between Gabe's fedora and GitHub Actions' ubuntu
 echo "start dump last-300-prs-with-release-note.txt for potential debug"
 cat last-300-prs-with-release-note.txt
@@ -87,14 +87,14 @@ while IFS= read -r pr; do
       continue
    fi
    PR_BODY_FILTER_ONE=$(echo $PR_BODY | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)')
-   echo $PR_BODY_FILTER_ONE | grep -avP '\W*(Your release note here|action required: your release note here|NONE)\W*' > /dev/null 2>&1
+   echo $PR_BODY_FILTER_ONE | grep -avP '\W*(Your release note here|NONE)\W*' > /dev/null 2>&1
    rc=$?
    if [ ${rc} -eq 1 ]; then
       echo "Second validation:  the release-note field for PR ${PR_NUM} was not properly formatted.  Until it is fixed, it will be skipped for release note inclusion."
       echo "See the PR template at https://raw.githubusercontent.com/shipwright-io/build/master/.github/pull_request_template.md for verification steps"
       continue
    fi
-   PR_RELEASE_NOTE=$(echo $PR_BODY_FILTER_ONE | grep -avP '\W*(Your release note here|action required: your release note here|NONE)\W*')
+   PR_RELEASE_NOTE=$(echo $PR_BODY_FILTER_ONE | grep -avP '\W*(Your release note here|NONE)\W*')
    PR_RELEASE_NOTE_NO_NEWLINES=$(echo $PR_RELEASE_NOTE | sed 's/\\n//g' | sed 's/\\r//g')
    MISC=yes
    echo $pr | grep 'kind/bug'


### PR DESCRIPTION
# Changes

During v0.8.0 release generation, the community decided we wanted to break away from Tekton's practice and add action required release notes to the release notes.

/kind cleanup

# Submitter Checklist

- [n/a ] Includes tests if functionality changed/was added
- [ n/a ] Includes docs if changes are user-facing
- [ /] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [/ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
