### PR TITLE
Restore files that were temporarily deleted

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,4 +27,5 @@ KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" GOFLAGS="${GO_FLAGS} -tags=ppr
 
 # Bundle the sample cluster build strategies, remove namespace strategies first
 find samples/buildstrategy -type f -print0 | xargs -0 grep -l "kind: BuildStrategy" | xargs rm -f
-KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" ko resolve -R -f samples/buildstrategy/ > sample-strategies.yaml
+ko resolve -R -f samples/buildstrategy/ > sample-strategies.yaml
+git restore samples/buildstrategy


### PR DESCRIPTION
# Changes

In the release process, we delete namespaced build strategies to exclude them from the sample-strategies.yaml. This deletion caused the readme pr creation to pick up those deletions. I am changing the release script to restore those files.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
