### PR TITLE
Modernize Buildah sample build strategy

### DIFF
--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -17,49 +17,158 @@ spec:
         - |
           set -euo pipefail
 
-          echo "Creating registries config file..."
+          # Parse parameters
+          context=
+          dockerfile=
+          image=
+          buildArgs=()
+          inBuildArgs=false
+          registriesBlock=""
+          inRegistriesBlock=false
+          registriesInsecure=""
+          inRegistriesInsecure=false
+          registriesSearch=""
+          inRegistriesSearch=false
+          tlsVerify=true
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
 
-          format(){
-              array=(`echo $1 | tr ',' ' '`)
-              str=""
-              for m in "${array[@]}"; do
-                  str=$str"'${m}', "
-              done
+            if [ "${arg}" == "--context" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              context="$1"
+              shift
+            elif [ "${arg}" == "--dockerfile" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              dockerfile="$1"
+              shift
+            elif [ "${arg}" == "--image" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              image="$1"
+              shift
+            elif [ "${arg}" == "--build-args" ]; then
+              inBuildArgs=true
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+            elif [ "${arg}" == "--registries-block" ]; then
+              inRegistriesBlock=true
+              inBuildArgs=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+            elif [ "${arg}" == "--registries-insecure" ]; then
+              inRegistriesInsecure=true
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesSearch=false
+            elif [ "${arg}" == "--registries-search" ]; then
+              inRegistriesSearch=true
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+            elif [ "${inBuildArgs}" == "true" ]; then
+              buildArgs+=("--build-arg" "${arg}")
+            elif [ "${inRegistriesBlock}" == "true" ]; then
+              registriesBlock="${registriesBlock}'${arg}', "
+            elif [ "${inRegistriesInsecure}" == "true" ]; then
+              registriesInsecure="${registriesInsecure}'${arg}', "
 
-              echo ${str%??}
-          }
+              # This assumes that the image is passed before the insecure registries which is fair in this context
+              if [[ ${image} == ${arg}/* ]]; then
+                tlsVerify=false
+              fi
+            elif [ "${inRegistriesSearch}" == "true" ]; then
+              registriesSearch="${registriesSearch}'${arg}', "
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
 
-          cat <<EOF >/tmp/registries.conf
+          # Verify the existence of the context directory
+          if [ ! -d "${context}" ]; then
+            echo -e "The context directory '${context}' does not exist."
+            echo -n "ContextDirNotFound" > '$(results.shp-error-reason.path)'
+            echo -n "The context directory '${context}' does not exist." > '$(results.shp-error-message.path)'
+            exit 1
+          fi
+          cd "${context}"
+
+          # Verify the existence of the Dockerfile
+          if [ ! -f "${dockerfile}" ]; then
+            echo -e "The Dockerfile '${dockerfile}' does not exist."
+            echo -n "DockerfileNotFound" > '$(results.shp-error-reason.path)'
+            echo -n "The Dockerfile '${dockerfile}' does not exist." > '$(results.shp-error-message.path)'
+            exit 1
+          fi
+
+          echo "[INFO] Creating registries config file..."
+          if [ "${registriesSearch}" != "" ]; then
+            cat <<EOF >>/tmp/registries.conf
           [registries.search]
-          registries = [$(format "$(params.registry-search)")]
-
-          [registries.insecure]
-          registries = [$(format "$(params.registry-insecure)")]
-
-          [registries.block]
-          registries = [$(format "$(params.registry-block)")]
+          registries = [${registriesSearch::-2}]
 
           EOF
+          fi
+          if [ "${registriesInsecure}" != "" ]; then
+            cat <<EOF >>/tmp/registries.conf
+          [registries.insecure]
+          registries = [${registriesInsecure::-2}]
+
+          EOF
+          fi
+          if [ "${registriesBlock}" != "" ]; then
+            cat <<EOF >>/tmp/registries.conf
+          [registries.block]
+          registries = [${registriesBlock::-2}]
+
+          EOF
+          fi
 
           # Building the image
-          echo '[INFO] Building image $(params.shp-output-image)'
-          buildah bud \
-            --registries-conf='/tmp/registries.conf' \
-            --tag='$(params.shp-output-image)' \
-            --file='$(build.dockerfile)' \
-            '$(params.shp-source-context)'
+          echo "[INFO] Building image ${image}"
+          buildah bud "${buildArgs[@]}" \
+            --registries-conf=/tmp/registries.conf \
+            --tag="${image}" \
+            --file="${dockerfile}" \
+            .
 
           # Push the image
-          echo '[INFO] Pushing image $(params.shp-output-image)'
+          echo "[INFO] Pushing image ${image}"
           buildah push \
-            --tls-verify=false \
-            '$(params.shp-output-image)' \
-            'docker://$(params.shp-output-image)'
-          
+            --tls-verify="${tlsVerify}" \
+            "${image}" \
+            "docker://${image}"
+
           # Store the digest result
           buildah images \
             --format='{{.Digest}}' \
-            '$(params.shp-output-image)' | tr -d "\n" > '$(results.shp-image-digest.path)'
+            "${image}" | tr -d "\n" > '$(results.shp-image-digest.path)'
+        # That's the separator between the shell script and its args
+        - --
+        - --context
+        - $(params.shp-source-context)
+        - --dockerfile
+        - $(build.dockerfile)
+        - --image
+        - $(params.shp-output-image)
+        - --build-args
+        - $(params.build-args[*])
+        - --registries-block
+        - $(params.registries-block[*])
+        - --registries-insecure
+        - $(params.registries-insecure[*])
+        - --registries-search
+        - $(params.registries-search[*])
       resources:
         limits:
           cpu: "1"
@@ -68,12 +177,21 @@ spec:
           cpu: 250m
           memory: 65Mi
   parameters:
-    - description: The registries for searching short name images such as `golang:latest`, separated by commas.
-      name: registry-search
-      default: docker.io,quay.io
-    - description: The fully-qualified name of insecure registries. An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
-      name: registry-insecure
-      default: ""
-    - description: The registries that need to block pull access.
-      name: registry-block
-      default: ""
+    - name: build-args
+      description: "The values for the args in the Dockerfile. Values must be in the format KEY=VALUE."
+      type: array
+      defaults: []
+    - name: registries-block
+      description: The registries that need to block pull access.
+      type: array
+      defaults: []
+    - name: registries-insecure
+      description: The fully-qualified name of insecure registries. An insecure registry is one that does not have a valid SSL certificate or only supports HTTP.
+      type: array
+      defaults: []
+    - name: registries-search
+      description: The registries for searching short name images such as `golang:latest`.
+      type: array
+      defaults:
+        - docker.io
+        - quay.io

--- a/test/e2e/e2e_image_mutate_test.go
+++ b/test/e2e/e2e_image_mutate_test.go
@@ -22,6 +22,7 @@ import (
 
 var _ = Describe("For a Kubernetes cluster with Tekton and build installed", func() {
 	var (
+		err      error
 		testID   string
 		build    *buildv1alpha1.Build
 		buildRun *buildv1alpha1.BuildRun
@@ -59,11 +60,12 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 
 		It("should mutate an image with annotation and label", func() {
-			buildRun, err := buildRunTestData(
+			buildRun, err = buildRunTestData(
 				testBuild.Namespace, testID,
 				"test/data/buildrun_buildah_cr_mutate.yaml",
 			)
 			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
+			appendRegistryInsecureParamValue(build, buildRun)
 
 			validateBuildRunToSucceed(testBuild, buildRun)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -60,6 +60,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		It("successfully runs a build and surface results to BuildRun", func() {
 			buildRun, err = buildRunTestData(testBuild.Namespace, testID, "samples/buildrun/buildrun_buildah_cr.yaml")
 			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
+			appendRegistryInsecureParamValue(build, buildRun)
 
 			validateBuildRunToSucceed(testBuild, buildRun)
 			validateBuildRunResultsFromGitSource(buildRun)
@@ -82,6 +83,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		It("successfully runs a build", func() {
 			buildRun, err = buildRunTestData(testBuild.Namespace, testID, "test/data/buildrun_buildah_cr_custom_context+dockerfile.yaml")
 			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
+			appendRegistryInsecureParamValue(build, buildRun)
 
 			validateBuildRunToSucceed(testBuild, buildRun)
 		})

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -339,6 +340,21 @@ func buildRunTestData(ns string, identifier string, filePath string) (*buildv1al
 	}
 
 	return buildRun, nil
+}
+
+func appendRegistryInsecureParamValue(build *buildv1alpha1.Build, buildRun *buildv1alpha1.BuildRun) {
+	if strings.Contains(build.Spec.Output.Image, "cluster.local") {
+		parts := strings.Split(build.Spec.Output.Image, "/")
+		host := parts[0]
+		buildRun.Spec.ParamValues = append(buildRun.Spec.ParamValues, buildv1alpha1.ParamValue{
+			Name: "registries-insecure",
+			Values: []buildv1alpha1.SingleValue{
+				{
+					Value: &host,
+				},
+			},
+		})
+	}
 }
 
 func getTimeoutMultiplier() int64 {


### PR DESCRIPTION
# Changes

I am changing the recently added registry configuration related parameters to arrays. I am adding build-arg support. I am using registries-insecure to also define whether tlsVerify on push should be set to false. And I am writing error details when the context dir or the Dockerfile do not exist.

Fixes #988

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
action required: The Buildah sample build strategy now supports build-args. The registry related parameters were changed to arrays in favor of comma-separated strings. You need to update your builds accordingly.
```