### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Our sample build strategies are all functional on linux/amd64. Their support on 
 
 We host weekly meetings for users, contributors, maintainers and anyone interested in the project. The weekly meetings take place on Mondays at 1pm UTC.
 
-* Meeting [minutes](https://github.com/shipwright-io/community/issues?q=is%3Aopen+is%3Aissue+label%3Acommunity+label%3Ameeting)
+* Meeting [minutes](https://github.com/shipwright-io/community/issues?q=is%3Aissue+label%3Acommunity+label%3Ameeting)
 * Public calendar [invite](https://calendar.google.com/calendar/u/1?cid=Y19iMWVndjc3anUyczJkbWNkM2R1ZnAxazhuNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
 
 ### Want to contribute

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -49,7 +49,7 @@ Well-known strategies can be bootstrapped from [here](../samples/buildstrategy).
 
 | Name | Supported platforms |
 | ---- | ------------------- |
-| [buildah](../samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml) | linux/amd64 only |
+| [buildah](../samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml) | all |
 | [BuildKit](../samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml) | all |
 | [buildpacks-v3-heroku](../samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml) | linux/amd64 only |
 | [buildpacks-v3](../samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml) | linux/amd64 only |


### PR DESCRIPTION
# Changes

Two small documentation updates:

1. Our README containes a link to the meeting minutes. I am removing the is:open condition from the query because otherwise one only sees an empty list most of the time.
2. [BuildAh is supported on all platforms that we also support](https://quay.io/repository/buildah/stable?tab=tags), I also ran it on arm64 at some point in the past. Therefore adjusting the supported platforms.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
