### PR TITLE
Replace `quay.io` source-bundle with `ghcr.io`

### DIFF
--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Bundle Loader", func() {
 	})
 
 	Context("Pulling image anonymously", func() {
-		const exampleImage = "quay.io/shipwright/source-bundle:latest"
+		const exampleImage = "ghcr.io/shipwright-io/sample-go/source-bundle:latest"
 
 		It("should pull and unbundle an image from a public registry", func() {
 			withTempDir(func(target string) {

--- a/pkg/reconciler/buildrun/resources/results_test.go
+++ b/pkg/reconciler/buildrun/resources/results_test.go
@@ -72,7 +72,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 		It("should surface the TaskRun results emitting from default(bundle) source step", func() {
 			bundleImageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
 			br.Status.BuildSpec.Source.BundleContainer = &build.BundleContainer{
-				Image: "quay.io/shipwright/source-bundle:latest",
+				Image: "ghcr.io/shipwright-io/sample-go/source-bundle:latest",
 			}
 
 			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,

--- a/test/e2e/e2e_bundle_test.go
+++ b/test/e2e/e2e_bundle_test.go
@@ -49,7 +49,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		BeforeEach(func() {
 			testID = generateTestID("bundle")
 
-			inputImage = "quay.io/shipwright/source-bundle:latest"
+			inputImage = "ghcr.io/shipwright-io/sample-go/source-bundle:latest"
 			outputImage = fmt.Sprintf("%s/%s:%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,


### PR DESCRIPTION
# Changes

With https://github.com/shipwright-io/sample-go/pull/9 merged and the image available, the `quay.io` based image can be discontinued.

Use `ghcr.io/shipwright-io/sample-go/source-bundle:latest` as the default source bundle example image.

Fixes #991

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
