### PR TITLE
Enable multi-platform builds for BuildKit sample build strategy

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -15,9 +15,11 @@ SPDX-License-Identifier: Apache-2.0
   - [Installing Buildpacks v3 Strategy](#installing-buildpacks-v3-strategy)
 - [Kaniko](#kaniko)
   - [Installing Kaniko Strategy](#installing-kaniko-strategy)
-  - [Scanning with Trivy](#scanning-with-trivy)
+    - [Scanning with Trivy](#scanning-with-trivy)
 - [BuildKit](#buildkit)
   - [Cache Exporters](#cache-exporters)
+  - [Build-args and secrets](#build-args-and-secrets)
+  - [Multi-platform builds](#multi-platform-builds)
   - [Known Limitations](#known-limitations)
   - [Usage in Clusters with Pod Security Standards](#usage-in-clusters-with-pod-security-standards)
   - [Installing BuildKit Strategy](#installing-buildkit-strategy)
@@ -36,6 +38,7 @@ SPDX-License-Identifier: Apache-2.0
   - [How does Tekton Pipelines handle resources](#how-does-tekton-pipelines-handle-resources)
   - [Examples of Tekton resources management](#examples-of-tekton-resources-management)
 - [Annotations](#annotations)
+- [Volumes and VolumeMounts](#volumes-and-volumemounts)
 
 ## Overview
 
@@ -140,17 +143,20 @@ kubectl apply -f samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
 
 ### Cache Exporters
 
-By default, the `buildkit` ClusterBuildStrategy will use caching to optimize the build times. When pushing an image to a registry, it will use the inline export cache, which appends cache information to the image that is built. Please refer to [export-cache docs](https://github.com/moby/buildkit#export-cache) for more information. Caching can be disabled by setting the `cache` parameter to disabled. See [Defining ParamValues](build.md#defining-paramvalues) for more information.
+By default, the `buildkit` ClusterBuildStrategy will use caching to optimize the build times. When pushing an image to a registry, it will use the inline export cache, which appends cache information to the image that is built. Please refer to [export-cache docs](https://github.com/moby/buildkit#export-cache) for more information. Caching can be disabled by setting the `cache` parameter to `"disabled"`. See [Defining ParamValues](build.md#defining-paramvalues) for more information.
 
 ### Build-args and secrets
 
 The sample build strategy contains array parameters to set values for [`ARG`s in your Dockerfile](https://docs.docker.com/engine/reference/builder/#arg), and for [mounts with type=secret](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information). The parameter names are `build-args` and `secrets`. [Defining ParamValues](build.md#defining-paramvalues) contains example usage.
 
+### Multi-platform builds
+
+The sample build strategy contains a `platforms` array parameter that you can set to leverage [BuildKit's support to build multi-platform images](https://github.com/moby/buildkit/blob/master/docs/multi-platform.md). If you do not set this value, the image is built for the platform that is supported by the `FROM` image. If that image supports multiple platforms, then the image will be built for the platform of your Kubernetes node.
+
 ### Known Limitations
 
 The `buildkit` ClusterBuildStrategy currently locks the following parameters:
 
-- Exporter caches are enabled by default, this is currently not configurable.
 - To allow running rootless, it requires both [AppArmor](https://kubernetes.io/docs/tutorials/clusters/apparmor/) as well as [SecComp](https://kubernetes.io/docs/tutorials/clusters/seccomp/) to be disabled using the `unconfined` profile.
 
 ### Usage in Clusters with Pod Security Standards

--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -21,8 +21,12 @@ spec:
     default: registry
   - name: insecure-registry
     type: string
-    description: "enables the push to an insecure registry"
+    description: "Enables the push to an insecure registry"
     default: "false"
+  - name: platforms
+    description: "Build the image for different platforms. By default, the image is built for the platform used by the FROM image. If that is present for multiple platforms, then it is built for the environment's platform."
+    type: array
+    defaults: []
   - name: secrets
     description: "The secrets to pass to the build. Values must be in the format ID=FILE_CONTENT."
     type: array
@@ -99,14 +103,23 @@ spec:
           fi
 
           stage=""
+          platforms=""
           for a in "$@"
           do
             if [ "${a}" == "--build-args" ]; then
               stage=build-args
+            elif [ "${a}" == "--platforms" ]; then
+              stage=platforms
             elif [ "${a}" == "--secrets" ]; then
               stage=secrets
             elif [ "${stage}" == "build-args" ]; then
               echo "--opt=\"build-arg:${a}\" \\" >> /tmp/run.sh
+            elif [ "${stage}" == "platforms" ]; then
+              if [ "${platforms}" == "" ]; then
+                platforms="${a}"
+              else
+                platforms="${platforms},${a}"
+              fi
             elif [ "${stage}" == "secrets" ]; then
               # Split ID=FILE_CONTENT into variables id and data
 
@@ -129,6 +142,10 @@ spec:
             fi
           done
 
+          if [ "${platforms}" != "" ]; then
+            echo "--opt=\"platform=${platforms}\" \\" >> /tmp/run.sh
+          fi
+
           echo "--metadata-file /tmp/image-metadata.json" >> /tmp/run.sh
 
           chmod +x /tmp/run.sh
@@ -140,5 +157,7 @@ spec:
         - --
         - --build-args
         - $(params.build-args[*])
+        - --platforms
+        - $(params.platforms[*])
         - --secrets
         - $(params.secrets[*])

--- a/test/data/build_buildkit_cr_insecure_registry.yaml
+++ b/test/data/build_buildkit_cr_insecure_registry.yaml
@@ -12,6 +12,10 @@ spec:
   paramValues:
   - name: insecure-registry
     value: "true"
+  - name: platforms
+    values:
+    - value: linux/amd64
+    - value: linux/arm64
   strategy:
     name: buildkit
     kind: ClusterBuildStrategy

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,6 +7,7 @@ package e2e_test
 import (
 	"os"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -465,6 +466,16 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 
 			validateBuildRunToSucceed(testBuild, buildRun)
 			validateBuildRunResultsFromGitSource(buildRun)
+			validateImagePlatformsExist(build, []v1.Platform{
+				{
+					Architecture: "amd64",
+					OS:           "linux",
+				},
+				{
+					Architecture: "arm64",
+					OS:           "linux",
+				},
+			})
 		})
 	})
 

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -23,6 +23,9 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/utils/pointer"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/shipwright-io/build/pkg/apis"
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/test/utils"
@@ -367,4 +370,25 @@ func getTimeoutMultiplier() int64 {
 	intValue, err := strconv.ParseInt(value, 10, 64)
 	Expect(err).ToNot(HaveOccurred(), "Failed to parse EnvVarTimeoutMultiplier to integer")
 	return intValue
+}
+
+func validateImagePlatformsExist(build *buildv1alpha1.Build, expectedPlatforms []gcrv1.Platform) {
+	// In the GitHub action, we are using a registry inside the cluster to
+	// push the image created by `buildRun`. The registry inside the cluster
+	// is not directly accessible from the local, so that we have mapped
+	// the cluster registry port to the local system
+	// by providing `test/kind/config.yaml` config to the kind
+	image := strings.Replace(
+		build.Spec.Output.Image,
+		"registry.registry.svc.cluster.local",
+		"localhost", 1,
+	)
+
+	ref, err := name.ParseReference(image)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, expectedPlatform := range expectedPlatforms {
+		_, err := remote.Image(ref, remote.WithAuth(getRegistryAuthentication(build, ref)), remote.WithPlatform(expectedPlatform))
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to validate %s/%s", expectedPlatform.OS, expectedPlatform.Architecture))
+	}
 }


### PR DESCRIPTION
# Changes

Adding the platforms parameter to the BuildKit sample build strategy to support multi-platform builds.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The BuildKit sample build strategy now supports a `platforms` parameter to enable multi-platform builds
```