### PR TITLE
Add additional versions to image mirror list

### DIFF
--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -19,9 +19,14 @@ jobs:
         run: |
           for IMAGE in \
             library/golang:1.16 \
+            library/golang:1.17 \
+            library/golang:1.18 \
             library/maven:3-jdk-8-openj9 \
             library/node:12 \
+            library/node:14 \
+            library/node:16 \
             library/python:3.8 \
+            library/python:3.9 \
             openliberty/open-liberty:kernel-java8-openj9-ubi \
             ; do
             crane cp "${IMAGE}" "${REPO}/$(cut -d/ -f2 <<<"${IMAGE}")"


### PR DESCRIPTION
# Changes

In order to seamlessly update for example the Go version in the samples, we have to make sure that old and newer versions are mirrored.

Add Go version `1.17` and `1.18`.

Add Node.js version `14` and `16`.

Add Python version `3.9`.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
