### PR TITLE
Tweak `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,8 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit:
-	rm -rf build/coverage
-	mkdir build/coverage
+	@rm -rf build/coverage
+	@mkdir build/coverage
 	go test \
 		./cmd/... \
 		./pkg/... \
@@ -172,7 +172,7 @@ test-unit-coverage: test-unit gocov
 
 .PHONY: test-unit-ginkgo
 test-unit-ginkgo: ginkgo
-	GO111MODULE=on $(GINKGO) \
+	$(GINKGO) \
 		--randomize-all \
 		--randomize-suites \
 		--fail-on-pending \
@@ -186,7 +186,7 @@ test-unit-ginkgo: ginkgo
 # Based on https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/integration-tests.md
 .PHONY: test-integration
 test-integration: install-apis ginkgo
-	GO111MODULE=on $(GINKGO) \
+	$(GINKGO) \
 		--randomize-all \
 		--randomize-suites \
 		--fail-on-pending \
@@ -200,7 +200,6 @@ test-e2e: install-strategies test-e2e-plain
 
 .PHONY: test-e2e-plain
 test-e2e-plain: ginkgo
-	GO111MODULE=on \
 	TEST_CONTROLLER_NAMESPACE=${TEST_NAMESPACE} \
 	TEST_WATCH_NAMESPACE=${TEST_NAMESPACE} \
 	TEST_E2E_SERVICEACCOUNT_NAME=${TEST_E2E_SERVICEACCOUNT_NAME} \


### PR DESCRIPTION
# Changes

Remove `GO111MODULE` variables as this is the default now.

Add annotation to omit command print for `rm` and `mkdir`.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
