### PR TITLE
Use BuildAh --digestfile argument to store digest of pushed image

### DIFF
--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -145,22 +145,10 @@ spec:
           # Push the image
           echo "[INFO] Pushing image ${image}"
           buildah push \
+            --digestfile='$(results.shp-image-digest.path)' \
             --tls-verify="${tlsVerify}" \
             "${image}" \
             "docker://${image}"
-
-          # Store the digest result. This is more complex than expected. BuildAh locally calculates a wrong digest.
-          # We therefore tag the image to a dummy name so that the layers are still present. Then we remove the local
-          # tag. Then we pull again. Then the local digest is correct.
-          # This should be validated again with a newer BuildAh version.
-          # https://github.com/containers/buildah/issues/3866
-          buildah tag "${image}" dummy
-          buildah rmi "${image}"
-          buildah pull --tls-verify="${tlsVerify}" "${image}"
-          buildah inspect \
-            --type=image \
-            --format='{{.FromImageDigest}}' \
-            "${image}" > '$(results.shp-image-digest.path)'
         # That's the separator between the shell script and its args
         - --
         - --context

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -109,21 +109,9 @@ spec:
           # Push the image
           echo "[INFO] Pushing image ${image}"
           buildah push \
+            --digestfile='$(results.shp-image-digest.path)' \
             --tls-verify="${tlsVerify}" \
             "docker://${image}"
-          
-          # Store the digest result. This is more complex than expected. BuildAh locally calculates a wrong digest.
-          # We therefore tag the image to a dummy name so that the layers are still present. Then we remove the local
-          # tag. Then we pull again. Then the local digest is correct.
-          # This should be validated again with a newer BuildAh version.
-          # https://github.com/containers/buildah/issues/3866
-          buildah tag "${image}" dummy
-          buildah rmi "${image}"
-          buildah pull --tls-verify="${tlsVerify}" "${image}"
-          buildah inspect \
-            --type=image \
-            --format='{{.FromImageDigest}}' \
-            "${image}" > '$(results.shp-image-digest.path)'
         # That's the separator between the shell script and its args
         - --
         - --image


### PR DESCRIPTION
# Changes

Fixes #1028

Using the proposed approach by @nalind to store the digest of the pushed image in the BuildRun result. Much simpler than the previous workaround. :-)

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Use BuildAh's `--digestfile` argument in the sample build strategies
```