### PR TITLE
Re-add verify-generate target

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,9 +18,23 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        path: go/src/github.com/shipwright-io/build
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
+        working-directory: go/src/github.com/shipwright-io/build
         args: --timeout=10m
+    - name: Install Counterfeiter
+      run: |
+        go install github.com/maxbrunsfeld/counterfeiter/v6@latest
+    - name: Run verify-generate
+      run: |
+        export GOPATH="${GITHUB_WORKSPACE}"/go
+        make -C $GOPATH/src/github.com/shipwright-io/build verify-generate


### PR DESCRIPTION
# Changes

We need this check to verify if a PR is missing updates on
CRDs, pkg/apis and pkg/clients. Somehow this got removed on
a previous PR.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
