### PR TITLE
Run make generate to make files consistent

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -120,13 +120,14 @@ spec:
                           type: string
                         value:
                           description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
                           type: string
                         valueFrom:
                           description: Source for the environment variable's value.
@@ -360,6 +361,13 @@ spec:
                         properties:
                           image:
                             description: Image reference, i.e. quay.io/org/image:tag
+                            type: string
+                          prune:
+                            description: "Prune specifies whether the image is suppose
+                              to be deleted. Allowed values are 'Never' (no deletion)
+                              and `AfterPull` (removal after the image was successfully
+                              pulled from the registry). \n If not defined, it defaults
+                              to 'Never'."
                             type: string
                         required:
                         - image


### PR DESCRIPTION
# Changes

Not sure where the mistake happened, but somehow the `prune` flag seems to have disappeared from the BuildRun OpenAPI.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```