### PR TITLE
Update Kaniko to 1.8.1, update Trivy to 0.25.3

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -561,7 +561,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -605,7 +605,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   buildSteps:
     - name: kaniko-build
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -54,7 +54,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: trivy-scan
-      image: docker.io/aquasec/trivy:0.25.0
+      image: docker.io/aquasec/trivy:0.25.3
       volumeMounts:
       - mountPath: /image/
         name: tar

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -37,7 +37,7 @@ spec:
           value: NOT_SET
         - name: AWS_SECRET_KEY
           value: NOT_SET
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       name: build-and-push
       securityContext:
         runAsUser: 0

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -123,7 +123,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -172,7 +172,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -286,7 +286,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.0
+      image: gcr.io/kaniko-project/executor:v1.8.1
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
# Changes

Updating build strategy tools

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The sample build strategies now use Kaniko v1.8.1 and Trivy v0.25.3
```