### PR TITLE
Quote the schedule.time for dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: /
   schedule:
     interval: daily
-    time: 06:00
+    time: "06:00"
   labels:
   - kind/dependency-change
   - release-note-none


### PR DESCRIPTION
# Changes

Dependabot checks are currently failing when merging PR's, this should fix it. `time` needs to be quote as it is taken as a string.


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```
