### PR TITLE
Auto-update of tools versions in the sample build strategies

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -1,0 +1,47 @@
+name: Update images in sample build strategies
+on:
+  schedule:
+  - cron: '0 0 * * *'
+  issue_comment:
+    types: [created, edited]
+jobs:
+  check-new-versions:
+    if: contains(github.event.comment.body, '/rebase') || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: gcr.io/kaniko-project/executor
+            latest-release-url: https://api.github.com/repos/GoogleContainerTools/kaniko/releases/latest
+          - image: docker.io/aquasec/trivy
+            latest-release-url: https://api.github.com/repos/aquasecurity/trivy/releases/latest
+          - image: quay.io/containers/buildah
+            latest-release-url: https://quay.io/api/v1/repository/containers/buildah/tag/
+          - image: gcr.io/go-containerregistry/crane
+            latest-release-url: https://api.github.com/repos/google/go-containerregistry/releases/latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check and modify ${{ matrix.image }}
+        env:
+          IMAGE: ${{ matrix.image }}
+          LATEST_RELEASE_URL: ${{ matrix.latest-release-url }}
+        run: |
+          for directory in samples test; do hack/check-latest-images.sh ${IMAGE} ${LATEST_RELEASE_URL} ${directory}; done
+      - name: Check image change
+        run: |
+          echo "FROM=$(git diff --unified=0 | grep '^[-].*image: .*/.*/.*:' | cut --delimiter=':' --fields='3')" >> $GITHUB_OUTPUT
+          echo "TO=$(git diff --unified=0 | grep '^[+].*image: .*/.*/.*:' | cut --delimiter=':' --fields='3')" >> $GITHUB_OUTPUT
+        id: image-diff
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Bump ${{ matrix.image }}
+          title: Bump ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}
+          body: |
+            Bumps ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}.
+
+            You can trigger a rebase manually by commenting `/rebase` and resolve any conflicts with this PR.
+          labels: kind/dependency-change
+          branch: ${{ matrix.image }}
+          delete-branch: true

--- a/hack/check-latest-images.sh
+++ b/hack/check-latest-images.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Check the latest release tag name using a URL and replace it for an image
+
+# Usage
+# ./check-latest-image.sh <IMAGE> <LATEST_RELEASE_URL> <DIRECTORY>
+
+set -euo pipefail
+
+function usage() {
+        cat <<USAGE
+Usage: ${0} <IMAGE> <LATEST_RELEASE_URL> <DIRECTORY>
+
+Options:
+    <IMAGE>:                Image URL
+    <LATEST_RELEASE_URL>:   Lastest available release
+    <DIRECTORY>:            Directory to be used for the search and replace
+
+Example:
+    ${0} quay.io/containers/buildah https://quay.io/api/v1/repository/containers/buildah/tag/ ./samples
+USAGE
+exit 1
+}
+
+function validate() {
+        if [ $# -lt 3 ]; then
+                usage
+        fi
+}
+
+function update() {
+        # Search the image URL recursively and parse the current image tag
+        CURRENT_TAG=$(grep --no-filename --recursive --max-count=1 "image: ${IMAGE}:"  | cut --delimiter=':' --fields='3')
+
+        # Fetch the latest release tag name from release URL
+        LATEST_TAG=$(curl --silent --retry 3 ${LATEST_RELEASE_URL} | jq --raw-output '.name')
+
+        # Trivy image tag (0.31.3) is different from release tag name (v0.31.3)
+        if [[ ${IMAGE} == *trivy* ]]; then
+                LATEST_TAG=$(curl --silent --retry 3 ${LATEST_RELEASE_URL} | jq --raw-output '.name')
+                LATEST_TAG="${LATEST_TAG:1}"
+        fi
+
+        # Buildah release URL needs different jq filter
+        if [[ ${IMAGE} == *buildah* ]]; then
+                LATEST_TAG=$(curl --silent --retry 3 ${LATEST_RELEASE_URL} | jq --raw-output '.tags | .[0].name')
+        fi
+
+        # Search and modify the image tag with the latest
+        find ${DIRECTORY} -type f -exec sed --in-place "s%${IMAGE}\:${CURRENT_TAG}%${IMAGE}\:${LATEST_TAG}%g" {} \;
+}
+
+validate "${@}"
+
+IMAGE="${1}"
+LATEST_RELEASE_URL="${2}"
+DIRECTORY="${3}"
+
+update


### PR DESCRIPTION
# Changes

Execute `hack/check-latest-images.sh` and update Kaniko, Trivy, Buildah and Crane container images used in the [sample build strategies](https://github.com/shipwright-io/build/tree/main/samples/buildstrategy) to their latest versions via GitHub actions.

Fixes #1039 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

# Release Notes
```release-note
NONE
```