### PR TITLE
Update BuildAh to 1.23.3

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -900,7 +900,7 @@ metadata:
 spec:
   buildSteps:
     - name: build
-      image: quay.io/containers/buildah:v1.23.1
+      image: quay.io/containers/buildah:v1.23.3
       workingDir: $(params.shp-source-root)
       command:
         - buildah

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: quay.io/containers/buildah:v1.23.1
+      image: quay.io/containers/buildah:v1.23.3
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -21,7 +21,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah
-      image: quay.io/containers/buildah:v1.23.1
+      image: quay.io/containers/buildah:v1.23.3
       workingDir: /s2i
       securityContext:
         privileged: true


### PR DESCRIPTION
# Changes

There is finally a new BuildAh version on quay, https://quay.io/repository/containers/buildah?tab=tags&tag=latest. Picking that and hoping that it resolves the problem with our hanging BuildRuns in the e2e test in GitHub actions.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The sample build strategies have been updated to use the most recent BuildAh image, v1.23.3
```