### PR TITLE
Fix unit test suite when using Ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,10 +175,14 @@ test-unit-coverage: test-unit gocov
 
 .PHONY: test-unit-ginkgo
 test-unit-ginkgo: ginkgo
+	rm -f build/coverage/*unit.coverprofile
 	$(GINKGO) \
+		--coverprofile=unit.coverprofile \
+		--output-dir=build/coverage \
 		--randomize-all \
 		--randomize-suites \
 		--fail-on-pending \
+		--keep-going \
 		--slow-spec-threshold=4m \
 		-compilers=2 \
 		-race \

--- a/pkg/env/env_suite_test.go
+++ b/pkg/env/env_suite_test.go
@@ -1,0 +1,17 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package env_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Env Suite")
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,12 +1,13 @@
 // Copyright The Shipwright Contributors
 //
 // SPDX-License-Identifier: Apache-2.0
-package env
+package env_test
 
 import (
 	"reflect"
 	"testing"
 
+	"github.com/shipwright-io/build/pkg/env"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -283,7 +284,7 @@ func TestMergeEnvVars(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MergeEnvVars(tt.args.new, tt.args.into, tt.args.overwriteValues)
+			got, err := env.MergeEnvVars(tt.args.new, tt.args.into, tt.args.overwriteValues)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MergeEnvVars() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/volumes/volumes_suite_test.go
+++ b/pkg/volumes/volumes_suite_test.go
@@ -1,0 +1,17 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package volumes_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Volumes Suite")
+}

--- a/pkg/volumes/volumes_test.go
+++ b/pkg/volumes/volumes_test.go
@@ -1,7 +1,7 @@
 // Copyright The Shipwright Contributors
 //
 // SPDX-License-Identifier: Apache-2.0
-package volumes
+package volumes_test
 
 import (
 	"encoding/json"
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/volumes"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -274,7 +275,7 @@ func TestMergeVolumes(t *testing.T) {
 
 	for _, td := range testingData {
 		t.Run(td.name, func(t *testing.T) {
-			res, err := MergeBuildVolumes(td.into, td.mergers)
+			res, err := volumes.MergeBuildVolumes(td.into, td.mergers)
 
 			if (err != nil) != td.expectErr {
 				t.Errorf("%s: expected error %v, got %v", td.name, td.expectErr, err)


### PR DESCRIPTION
# Changes

While implementing shipwright-managed push, I wanted to check my code coverage in unit tests. As usual, I was using Ginkgo. Some missing suites caused Ginkgo to fail once I enabled the coverage measurement. Fixing this here.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```