### PR TITLE
Expose GOCACHE as volume in ko build strategy

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -206,6 +206,12 @@ The build strategy provides the following parameters that you can set in a Build
 | `package-directory` | The directory inside the context directory containing the main package. | `.` |
 | `target-platform` | Target platform to be built. For example: `linux/arm64`. Multiple platforms can be provided separated by comma, for example: `linux/arm64,linux/amd64`. The value `all` will build all platforms supported by the base image. The value `current` will build the platform on which the build runs. | `current` |
 
+### Volumes
+
+| Volume  | Description |
+| ------- | ----------- |
+| gocache | Volume to contain the GOCACHE. Can be set to a persistent volume to optimize compilation performance for rebuilds. The default is an emptyDir volume which means that the cached data is discarded at the end of a BuildRun. |
+
 ## Source to Image
 
 This BuildStrategy is composed by [`source-to-image`][s2i] and [`kaniko`][kaniko] in order to generate a `Dockerfile` and prepare the application to be built later on with a builder.

--- a/samples/build/build_ko_cr.yaml
+++ b/samples/build/build_ko_cr.yaml
@@ -4,7 +4,7 @@ kind: Build
 metadata:
   name: ko-build
   annotations:
-    build.build.dev/build-run-deletion: "false"
+    build.shipwright.io/build-run-deletion: "false"
 spec:
   paramValues:
     - name: go-flags

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -20,6 +20,11 @@ spec:
     - name: target-platform
       description: "Target platform to be built. For example: 'linux/arm64'. Multiple platforms can be provided separated by comma, for example: 'linux/arm64,linux/amd64'. The value 'all' will build all platforms supported by the base image. The value 'current' will build the platform on which the build runs."
       default: current
+  volumes:
+    - name: gocache
+      description: "Volume to contain the GOCACHE. Can be set to a persistent volume to optimize compilation performance for rebuilds."
+      overridable: true
+      emptyDir: {}
   buildSteps:
     - name: prepare
       image: golang:$(params.go-version)
@@ -49,6 +54,10 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      volumeMounts:
+        - mountPath: /gocache
+          name: gocache
+          readOnly: false
       env:
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
@@ -56,6 +65,8 @@ spec:
           value: /tekton/home
         - name: GOFLAGS
           value: $(params.go-flags)
+        - name: GOCACHE
+          value: /gocache
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
         - name: PARAM_SOURCE_CONTEXT


### PR DESCRIPTION
# Changes

Extending the ko build strategy with volume support for GOCACHE. This speeds up rebuilds dramatically when a Build user enables it. The build strategy by default uses an emptyDir which means that no caching happens. A Build user can assign any writable volume type to enable caching.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The ko sample build strategy now supports a gocache volume that you can assign a writable volume in your Build to speed up rebuilds
```