### PR TITLE
Update BuildAh to v1.26.0

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -906,7 +906,7 @@ metadata:
 spec:
   buildSteps:
     - name: build
-      image: quay.io/containers/buildah:v1.23.3
+      image: quay.io/containers/buildah:v1.26.0
       workingDir: $(params.shp-source-root)
       command:
         - buildah

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: quay.io/containers/buildah:v1.23.3
+      image: quay.io/containers/buildah:v1.26.0
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -21,7 +21,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah
-      image: quay.io/containers/buildah:v1.23.3
+      image: quay.io/containers/buildah:v1.26.0
       workingDir: /s2i
       securityContext:
         privileged: true


### PR DESCRIPTION
# Changes

Every new BuildAh version let's me hope that the intermittent hanging tests are resolved. Let's see what's happening here.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The sample build strategies are using the latest v1.26.0 BuildAh version.
```