### PR TITLE
Ensure volume name does not end with a trailing dash

### DIFF
--- a/pkg/reconciler/buildrun/resources/sources/utils.go
+++ b/pkg/reconciler/buildrun/resources/sources/utils.go
@@ -7,6 +7,7 @@ package sources
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,9 @@ func SanitizeVolumeNameForSecretName(secretName string) string {
 	if len(sanitizedName) > 63 {
 		sanitizedName = sanitizedName[:63]
 	}
+
+	// trim trailing dashes because the last character must be alphanumeric
+	sanitizedName = strings.TrimSuffix(sanitizedName, "-")
 
 	return sanitizedName
 }

--- a/pkg/reconciler/buildrun/resources/sources/utils_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/utils_test.go
@@ -13,8 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Utils", func() {	
-	Context("for different candidate volume names", func() {	
+var _ = Describe("Utils", func() {
+	Context("for different candidate volume names", func() {
 		It("adds only the prefix if the name is okay", func() {
 			Expect(sources.SanitizeVolumeNameForSecretName("okay-name")).To(Equal("shp-okay-name"))
 		})
@@ -26,9 +26,14 @@ var _ = Describe("Utils", func() {
 		It("adds the prefix and reduces the length if needed", func() {
 			Expect(sources.SanitizeVolumeNameForSecretName("long-name-long-name-long-name-long-name-long-name-long-name-long-name-")).To(Equal("shp-long-name-long-name-long-name-long-name-long-name-long-name"))
 		})
+
+		It("ensures that the volume name ends with an alpha-numeric character", func() {
+			// "shp-" + "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcd-efgh" reduced to 63 characters would be "shp-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcd-"
+			Expect(sources.SanitizeVolumeNameForSecretName("abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcd-efgh")).To(Equal("shp-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcd"))
+		})
 	})
 
-	Context("when a TaskSpec does not contain any volume", func() {	
+	Context("when a TaskSpec does not contain any volume", func() {
 		var taskSpec *tektonv1beta1.TaskSpec
 
 		BeforeEach(func() {
@@ -45,7 +50,7 @@ var _ = Describe("Utils", func() {
 		})
 	})
 
-	Context("when a TaskSpec already contains a volume secret", func() {		
+	Context("when a TaskSpec already contains a volume secret", func() {
 		var taskSpec *tektonv1beta1.TaskSpec
 
 		BeforeEach(func() {


### PR DESCRIPTION
# Changes

In certain use cases, for example for a bundle source, we need to turn a secret name into a volume name to mount its data in the container. For this we have a translation function. But that had a problem.

Assuming the secret name is `abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcd-efgh`.

It prefixed `shp-` -> `shp-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcd-efgh`.

It trimmed to at most 63 characters -> `shp-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcd-`.

And that was it.

But now the volume name ended with a dash which is not allowed. Adding code to trim trailing dashes.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Secret names which had a dash at the 59th characters could not be used for a bundle source because of an error in the translation of secret into volume names
```