### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/base-images.yaml
+++ b/.github/workflows/base-images.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to container registry
         env:

--- a/.github/workflows/base-images.yaml
+++ b/.github/workflows/base-images.yaml
@@ -9,6 +9,13 @@ jobs:
   build:
     if: ${{ github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - git
+          - waiter
+      max-parallel: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -22,19 +29,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to container registry
-        env:
-          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY_USERNAME: ${{ github.repository_owner }}
-        run: echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USERNAME}" --password-stdin ghcr.io
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.repository_owner }} --password-stdin ghcr.io
 
-      - name: Build Git Base Image
+      - name: Build Image
+        working-directory: images/${{ matrix.image }}
         run: |
-          pushd images/git
-            IMAGE=ghcr.io/${{ github.repository_owner }}/base-git docker buildx bake --push -f ../docker-bake.hcl
-          popd
-
-      - name: Build Waiter Base Image
-        run: |
-          pushd images/waiter
-            IMAGE=ghcr.io/${{ github.repository_owner }}/base-waiter docker buildx bake --push -f ../docker-bake.hcl
-          popd
+          NAMESPACE=$(tr '[:upper:]' '[:lower:]' <<<${{ github.repository_owner }})
+          IMAGE=ghcr.io/${NAMESPACE}/base-${{ matrix.image }} docker buildx bake --push -f ../docker-bake.hcl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,14 @@ jobs:
     unit:
         runs-on: ubuntu-latest
         steps:
-        - name: Install Go
-          uses: actions/setup-go@v2
-          with:
-            go-version: 1.18.x
         - name: Check out code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
+        - name: Install Go
+          uses: actions/setup-go@v3
+          with:
+            go-version: '1.18.x'
+            cache: true
+            check-latest: true
         - name: Build
           run: make build
         - name: Test
@@ -34,23 +36,25 @@ jobs:
           max-parallel: 2
         runs-on: ubuntu-latest
         steps:
+        - name: Check out code
+          uses: actions/checkout@v3
         - name: Install Go
-          uses: actions/setup-go@v2
+          uses: actions/setup-go@v3
           with:
-            go-version: 1.18.x
+            go-version: '1.18.x'
+            cache: true
+            check-latest: true
         - name: Install Ko
-          # This sha corresponds to v0.4
-          uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675
+          # This sha corresponds to v0.5
+          uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
           with:
             version: v0.11.2
-        - name: Check out code
-          uses: actions/checkout@v2
         - name: Install kubectl
           uses: azure/setup-kubectl@v1
           with:
             version: ${{ matrix.kubernetes }}
         - name: Create kind cluster
-          uses: helm/kind-action@v1.2.0
+          uses: helm/kind-action@v1.3.0
           with:
             version: v0.11.1
             node_image: kindest/node:${{ matrix.kubernetes }}
@@ -93,18 +97,20 @@ jobs:
           max-parallel: 2
         runs-on: ubuntu-latest
         steps:
-        - name: Install Go
-          uses: actions/setup-go@v2
-          with:
-            go-version: 1.18.x
         - name: Check out code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
+        - name: Install Go
+          uses: actions/setup-go@v3
+          with:
+            go-version: '1.18.x'
+            cache: true
+            check-latest: true
         - name: Install kubectl
           uses: azure/setup-kubectl@v1
           with:
             version: ${{ matrix.kubernetes }}
         - name: Create kind cluster
-          uses: helm/kind-action@v1.2.0
+          uses: helm/kind-action@v1.3.0
           with:
             version: v0.11.1
             node_image: kindest/node:${{ matrix.kubernetes }}
@@ -140,8 +146,8 @@ jobs:
             kubectl apply -f test/data/registry.yaml
             kubectl -n registry rollout status deployment registry --timeout=1m
         - name: Install Ko
-          # This sha corresponds to v0.4
-          uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675
+          # This sha corresponds to v0.5
+          uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
           with:
             version: v0.11.2
         - name: Install Shipwright Build

--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: imjasonh/setup-crane@01d26682810dcd47bfc8eb1efe791558123a9373
+      - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4
 
       - name: Mirror images
         env:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,18 +19,20 @@ jobs:
       IMAGE_NAMESPACE: ${{ github.repository }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: '1.18.x'
+        cache: true
+        check-latest: true
 
     # Install tools
-    # This sha corresponds to v0.4
-    - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675
+    # This sha corresponds to v0.5
+    - uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
       with:
         version: v0.11.2
-    - uses: imjasonh/setup-crane@01d26682810dcd47bfc8eb1efe791558123a9373
-    - uses: sigstore/cosign-installer@v1.2.0
+    - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4
+    - uses: sigstore/cosign-installer@v2.5.0
 
     - name: Get current date
       id: date

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,19 +25,21 @@ jobs:
       TAG: ${{ github.event.inputs.release }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Fetch all history, needed for release note generation.
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: '1.18.x'
+        cache: true
+        check-latest: true
 
     # Install tools
-    # This sha corresponds to v0.4
-    - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675
+    # This sha corresponds to v0.5
+    - uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
       with:
         version: v0.11.2
-    - uses: sigstore/cosign-installer@v1.2.0
+    - uses: sigstore/cosign-installer@v2.5.0
 
     - name: Build Release Changelog
       env:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,16 +18,19 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: go/src/github.com/shipwright-io/build
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.18.x'
+        cache: true
+        check-latest: true
+        cache-dependency-path: go/src/github.com/shipwright-io/build
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         working-directory: go/src/github.com/shipwright-io/build
         args: --timeout=10m


### PR DESCRIPTION
# Changes

Updating GitHub actions in our workflows.

Notably is the oob cache support for Go that I am enabling. Maybe it speeds up builds. For this, I had to move the checkout step to before the Go setup step as it was looking for our go.mod.

The base image build I changed to guarantee a lower-case repository name as I wanted to try it out in my fork. And then quickly changed it to a matrix to run the two image builds in parallel. Can be seen here: https://github.com/SaschaSchwarze0/build/actions/runs/2804547984 (I had temporarily commented the `if` clause).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
