### PR TITLE
Update base images to UBI 9

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal
+defaultBaseImage: registry.access.redhat.com/ubi9/ubi-minimal
 
 baseImageOverrides:
   github.com/shipwright-io/build/cmd/git: ghcr.io/shipwright-io/base-git:latest

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 RUN \
   microdnf --nodocs update && \

--- a/images/waiter/Dockerfile
+++ b/images/waiter/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 RUN \
   microdnf --nodocs update && \


### PR DESCRIPTION
# Changes

Not too much to add to the title. I am running locally with ubi9 already and have not observed any issues.

Fixes #1076

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The base image of our released images are now based on UBI 9
```