### PR TITLE
Remove usage of deprecated io/ioutil package

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -36,7 +36,7 @@ jobs:
         args: --timeout=10m
     - name: Install Counterfeiter
       run: |
-        go install github.com/maxbrunsfeld/counterfeiter/v6@latest
+        make -C go/src/github.com/shipwright-io/build install-counterfeiter
     - name: Run verify-generate
       run: |
         export GOPATH="${GITHUB_WORKSPACE}"/go

--- a/cmd/bundle/main.go
+++ b/cmd/bundle/main.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -101,7 +101,7 @@ func Do(ctx context.Context) error {
 	}
 
 	if flagValues.resultFileImageDigest != "" {
-		if err = ioutil.WriteFile(flagValues.resultFileImageDigest, []byte(digest.String()), 0644); err != nil {
+		if err = os.WriteFile(flagValues.resultFileImageDigest, []byte(digest.String()), 0644); err != nil {
 			return err
 		}
 	}
@@ -327,7 +327,7 @@ func dockerHubLogin(username string, password string) (string, error) {
 
 	defer resp.Body.Close()
 
-	bodyData, err := ioutil.ReadAll(resp.Body)
+	bodyData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -365,7 +365,7 @@ func dockerHubRepoDelete(token string, ref name.Reference) error {
 
 	defer resp.Body.Close()
 
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -413,7 +413,7 @@ func icrLogin(registry, username, apikey string) (string, string, error) {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", err
 	}
@@ -498,7 +498,7 @@ func icrDelete(token string, accountID string, ref name.Reference) error {
 
 	defer resp.Body.Close()
 
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -156,7 +155,7 @@ func runGitClone(ctx context.Context) error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(flagValues.resultFileCommitSha, []byte(output), 0644); err != nil {
+		if err := os.WriteFile(flagValues.resultFileCommitSha, []byte(output), 0644); err != nil {
 			return err
 		}
 	}
@@ -167,7 +166,7 @@ func runGitClone(ctx context.Context) error {
 			return err
 		}
 
-		if err = ioutil.WriteFile(flagValues.resultFileCommitAuthor, []byte(output), 0644); err != nil {
+		if err = os.WriteFile(flagValues.resultFileCommitAuthor, []byte(output), 0644); err != nil {
 			return err
 		}
 	}
@@ -178,7 +177,7 @@ func runGitClone(ctx context.Context) error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(flagValues.resultFileBranchName, []byte(output), 0644); err != nil {
+		if err := os.WriteFile(flagValues.resultFileBranchName, []byte(output), 0644); err != nil {
 			return err
 		}
 	}
@@ -269,19 +268,19 @@ func clone(ctx context.Context) error {
 			// permissions, it will end up failing due to SSH sanity checks.
 			// Therefore, create a temporary replacement with the right
 			// file permissions.
-			data, err := ioutil.ReadFile(filepath.Join(flagValues.secretPath, "ssh-privatekey"))
+			data, err := os.ReadFile(filepath.Join(flagValues.secretPath, "ssh-privatekey"))
 			if err != nil {
 				return err
 			}
 
-			sshPrivateKeyFile, err := ioutil.TempFile(os.TempDir(), "ssh-private-key")
+			sshPrivateKeyFile, err := os.CreateTemp(os.TempDir(), "ssh-private-key")
 			if err != nil {
 				return err
 			}
 
 			defer os.Remove(sshPrivateKeyFile.Name())
 
-			if err := ioutil.WriteFile(sshPrivateKeyFile.Name(), data, 0400); err != nil {
+			if err := os.WriteFile(sshPrivateKeyFile.Name(), data, 0400); err != nil {
 				return err
 			}
 
@@ -346,26 +345,26 @@ func clone(ctx context.Context) error {
 				return err
 			}
 
-			username, err := ioutil.ReadFile(filepath.Join(flagValues.secretPath, "username"))
+			username, err := os.ReadFile(filepath.Join(flagValues.secretPath, "username"))
 			if err != nil {
 				return err
 			}
 
-			password, err := ioutil.ReadFile(filepath.Join(flagValues.secretPath, "password"))
+			password, err := os.ReadFile(filepath.Join(flagValues.secretPath, "password"))
 			if err != nil {
 				return err
 			}
 
 			repoURL.User = url.UserPassword(string(username), string(password))
 
-			credHelperFile, err := ioutil.TempFile(os.TempDir(), "cred-helper-file")
+			credHelperFile, err := os.CreateTemp(os.TempDir(), "cred-helper-file")
 			if err != nil {
 				return err
 			}
 
 			defer os.Remove(credHelperFile.Name())
 
-			if err := ioutil.WriteFile(credHelperFile.Name(), []byte(repoURL.String()), 0400); err != nil {
+			if err := os.WriteFile(credHelperFile.Name(), []byte(repoURL.String()), 0400); err != nil {
 				return err
 			}
 

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -6,7 +6,7 @@ package main_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -23,7 +23,7 @@ import (
 var _ = Describe("Git Resource", func() {
 	var run = func(args ...string) error {
 		// discard log output
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 
 		// discard stderr output
 		var tmp = os.Stderr
@@ -35,7 +35,7 @@ var _ = Describe("Git Resource", func() {
 	}
 
 	var withTempDir = func(f func(target string)) {
-		path, err := ioutil.TempDir(os.TempDir(), "git")
+		path, err := os.MkdirTemp(os.TempDir(), "git")
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(path)
 
@@ -43,7 +43,7 @@ var _ = Describe("Git Resource", func() {
 	}
 
 	var withTempFile = func(pattern string, f func(filename string)) {
-		file, err := ioutil.TempFile(os.TempDir(), pattern)
+		file, err := os.CreateTemp(os.TempDir(), pattern)
 		Expect(err).ToNot(HaveOccurred())
 		defer os.Remove(file.Name())
 
@@ -51,13 +51,13 @@ var _ = Describe("Git Resource", func() {
 	}
 
 	var filecontent = func(path string) string {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		Expect(err).ToNot(HaveOccurred())
 		return string(data)
 	}
 
 	var file = func(path string, mode os.FileMode, data []byte) {
-		Expect(ioutil.WriteFile(path, data, mode)).ToNot(HaveOccurred())
+		Expect(os.WriteFile(path, data, mode)).ToNot(HaveOccurred())
 	}
 
 	Context("validations and error cases", func() {
@@ -428,7 +428,7 @@ var _ = Describe("Git Resource", func() {
 						lfsFile := filepath.Join(target, "assets", "shipwright-logo-lightbg-512.png")
 						Expect(lfsFile).To(BeAnExistingFile())
 
-						data, err := ioutil.ReadFile(lfsFile)
+						data, err := os.ReadFile(lfsFile)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(http.DetectContentType(data)).To(Equal("image/png"))
 					})

--- a/cmd/mutate-image/main.go
+++ b/cmd/mutate-image/main.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -214,7 +213,7 @@ func runMutateImage(ctx context.Context) error {
 
 	// Writing image digest to file
 	if resultFileImageDigest := flagValues.resultFileImageDigest; resultFileImageDigest != "" {
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			resultFileImageDigest, []byte(digest.String()), 0644,
 		); err != nil {
 			return err
@@ -228,7 +227,7 @@ func runMutateImage(ctx context.Context) error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			resultFileImageSize, []byte(strconv.FormatInt(size, 10)), 0644,
 		); err != nil {
 			return err

--- a/cmd/mutate-image/main_test.go
+++ b/cmd/mutate-image/main_test.go
@@ -7,7 +7,7 @@ package main_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -26,7 +26,7 @@ import (
 
 var _ = Describe("Image Mutate Resource", func() {
 	run := func(args ...string) error {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 
 		// `pflag.Parse()` parses the command-line flags from os.Args[1:]
 		// appending `tool`(can be anything) at beginning of args array
@@ -117,7 +117,7 @@ var _ = Describe("Image Mutate Resource", func() {
 	}
 
 	withTempFile := func(pattern string, f func(filename string)) {
-		file, err := ioutil.TempFile(os.TempDir(), pattern)
+		file, err := os.CreateTemp(os.TempDir(), pattern)
 		Expect(err).ToNot(HaveOccurred())
 		defer os.Remove(file.Name())
 
@@ -125,7 +125,7 @@ var _ = Describe("Image Mutate Resource", func() {
 	}
 
 	filecontent := func(path string) string {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		Expect(err).ToNot(HaveOccurred())
 		return string(data)
 	}

--- a/cmd/shipwright-build-controller/main.go
+++ b/cmd/shipwright-build-controller/main.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -110,7 +109,7 @@ func main() {
 
 		// we also want to put this into the termination log
 		// so that user can see this message as the reason pod failed
-		if err := ioutil.WriteFile(buildCfg.TerminationLogPath, []byte(msg), 0644); err != nil {
+		if err := os.WriteFile(buildCfg.TerminationLogPath, []byte(msg), 0644); err != nil {
 			ctxlog.Error(ctx, err, "Error while trying to write to termination log")
 		}
 

--- a/hack/install-counterfeiter.sh
+++ b/hack/install-counterfeiter.sh
@@ -3,6 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -eu
+set -euo pipefail
 
-GO111MODULE=off go get -u github.com/maxbrunsfeld/counterfeiter
+go install github.com/maxbrunsfeld/counterfeiter/v6@latest

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -5,7 +5,6 @@
 package bundle_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -22,7 +21,7 @@ var _ = Describe("Bundle", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(r).ToNot(BeNil())
 
-			tempDir, err := ioutil.TempDir("", "bundle")
+			tempDir, err := os.MkdirTemp("", "bundle")
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll(tempDir)
 

--- a/test/e2e/validators_test.go
+++ b/test/e2e/validators_test.go
@@ -6,7 +6,6 @@ package e2e_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -280,7 +279,7 @@ func readAndDecode(filePath string) (runtime.Object, error) {
 		return nil, err
 	}
 
-	payload, err := ioutil.ReadFile(filepath.Join("..", "..", filePath))
+	payload, err := os.ReadFile(filepath.Join("..", "..", filePath))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Changes

Staticcheck started to mark the usage of io/ioutil as findings. Such as in https://github.com/shipwright-io/build/runs/7740689867?check_suite_focus=true. Fixing this to get back to green PRs.

Some small changes regarding counterfeiter installation are included as that made trouble because the wrong Go version (1.19) was getting installed (fixed by #1085) and then I hunted things there and noticed inconsistent installations in the action vs the hack script.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
