### PR TITLE
Update BuildAh, Kaniko, Trivy, Crane, UBI in sample build strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 
 ### Platform support
 
-We are building container images of the Shipwright Build controller for all platforms supported by the base image that we are using which is [registry.access.redhat.com/ubi8/ubi-minimal](https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8). Those are:
+We are building container images of the Shipwright Build controller for all platforms supported by the base image that we are using which is [registry.access.redhat.com/ubi9/ubi-minimal](https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5). Those are:
 
 - linux/amd64
 - linux/arm64

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -567,7 +567,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -611,7 +611,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -906,7 +906,7 @@ metadata:
 spec:
   buildSteps:
     - name: build
-      image: quay.io/containers/buildah:v1.26.0
+      image: quay.io/containers/buildah:v1.27.0
       workingDir: $(params.shp-source-root)
       command:
         - buildah

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: quay.io/containers/buildah:v1.26.0
+      image: quay.io/containers/buildah:v1.27.0
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
@@ -14,7 +14,7 @@ spec:
       emptyDir: {}
   buildSteps:
     - name: kaniko-build
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -61,7 +61,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: trivy-scan
-      image: docker.io/aquasec/trivy:0.28.1
+      image: docker.io/aquasec/trivy:0.31.3
       volumeMounts:
       - mountPath: /image/
         name: tar
@@ -84,7 +84,7 @@ spec:
           cpu: 250m
           memory: 65Mi
     - name: crane-push
-      image: gcr.io/go-containerregistry/crane:v0.9.0
+      image: gcr.io/go-containerregistry/crane:v0.11.0
       securityContext:
         runAsUser: 0
       volumeMounts:
@@ -100,7 +100,7 @@ spec:
         - name: HOME
           value: /tekton/home
     - name: results
-      image: registry.access.redhat.com/ubi8/ubi-minimal
+      image: registry.access.redhat.com/ubi9/ubi-minimal
       command:
         - /bin/bash
       args:

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -9,7 +9,7 @@ spec:
       emptyDir: {}
   buildSteps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -54,7 +54,7 @@ spec:
         - name: layout
           mountPath: /kaniko/oci-image-layout
     - name: results
-      image: registry.access.redhat.com/ubi8/ubi-minimal
+      image: registry.access.redhat.com/ubi9/ubi-minimal
       command:
         - /bin/bash
       args:

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -21,7 +21,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah
-      image: quay.io/containers/buildah:v1.26.0
+      image: quay.io/containers/buildah:v1.27.0
       workingDir: /s2i
       securityContext:
         privileged: true

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -44,7 +44,7 @@ spec:
           value: NOT_SET
         - name: AWS_SECRET_KEY
           value: NOT_SET
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       name: build-and-push
       securityContext:
         runAsUser: 0
@@ -65,7 +65,7 @@ spec:
           mountPath: /kaniko/oci-image-layout
       workingDir: /gen-source
     - name: results
-      image: registry.access.redhat.com/ubi8/ubi-minimal
+      image: registry.access.redhat.com/ubi9/ubi-minimal
       command:
         - /bin/bash
       args:

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -131,7 +131,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -180,7 +180,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0
@@ -298,7 +298,7 @@ metadata:
 spec:
   buildSteps:
     - name: step-build-and-push
-      image: gcr.io/kaniko-project/executor:v1.8.1
+      image: gcr.io/kaniko-project/executor:v1.9.0
       workingDir: $(params.shp-source-root)
       securityContext:
         runAsUser: 0

--- a/test/e2e/e2e_params_test.go
+++ b/test/e2e/e2e_params_test.go
@@ -113,7 +113,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 						ForBuild(build).
 						Name(testID).
 						GenerateServiceAccount().
-						StringParamValue("image", "registry.access.redhat.com/ubi8/ubi-minimal").
+						StringParamValue("image", "registry.access.redhat.com/ubi9/ubi-minimal").
 						StringParamValueFromSecret("env3", "a-secret", "number2", nil).
 						ArrayParamValueFromSecret("args", "a-secret", "number3", pointer.String("${SECRET_VALUE}9")).
 						ArrayParamValue("args", "47").


### PR DESCRIPTION
# Changes

Regular build strategy updates before we release v0.11.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Sample build strategies updated to use BuildAh v1.27, Kaniko v1.9, Crane v0.11, Trivy v0.31.3, and UBI9
```