### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,11 +12,9 @@ approvers:
 reviewers:
 - adambkaplan
 - coreydaley
-- sbose78
 - otaviof
 - qu1queee
 - SaschaSchwarze0
-- gabemontero
 - HeavyWombat
 - ImJasonH
 


### PR DESCRIPTION
# Changes

I think we have to remove Shoubhik and Gabe also from reviewers, otherwise they'll continue to get reviews as it happened in https://github.com/shipwright-io/build/pull/1108

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```