### PR TITLE
Move ko-related artifacts to ko-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
           cache: true
           check-latest: true
       - name: Install Ko
-        # This sha corresponds to v0.5
-        uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
+        # This sha corresponds to v0.6
+        uses: imjasonh/setup-ko@c682db27121307b4d02d11694318530ec9041d4c
         with:
-          version: v0.11.2
+          version: v0.12.0
       - name: Install kubectl
         uses: azure/setup-kubectl@v1
         with:
@@ -147,10 +147,10 @@ jobs:
           kubectl apply -f test/data/registry.yaml
           kubectl -n registry rollout status deployment registry --timeout=1m
       - name: Install Ko
-        # This sha corresponds to v0.5
-        uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
+        # This sha corresponds to v0.6
+        uses: imjasonh/setup-ko@c682db27121307b4d02d11694318530ec9041d4c
         with:
-          version: v0.11.2
+          version: v0.12.0
       - name: Install Shipwright Build
         run: |
           make install-controller-kind

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,10 +27,10 @@ jobs:
         check-latest: true
 
     # Install tools
-    # This sha corresponds to v0.5
-    - uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
+    # This sha corresponds to v0.6
+    - uses: imjasonh/setup-ko@c682db27121307b4d02d11694318530ec9041d4c
       with:
-        version: v0.11.2
+        version: v0.12.0
     - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4
     - uses: sigstore/cosign-installer@v2.5.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,10 +35,10 @@ jobs:
         check-latest: true
 
     # Install tools
-    # This sha corresponds to v0.5
-    - uses: imjasonh/setup-ko@78eea08f10db87a7a23a666a4a6fe2734f2eeb8d
+    # This sha corresponds to v0.6
+    - uses: imjasonh/setup-ko@c682db27121307b4d02d11694318530ec9041d4c
       with:
-        version: v0.11.2
+        version: v0.12.0
     - uses: sigstore/cosign-installer@v2.5.0
 
     - name: Build Release Changelog

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,7 +81,7 @@ You must install these tools:
 1.  [`go`](https://golang.org/doc/install): The language Shipwright Build is
     built in
 1.  [`git`](https://help.github.com/articles/set-up-git/): For source control
-1   [`ko`](https://github.com/google/ko): To build and deploy changes.
+1   [`ko`](https://github.com/ko-build/ko): To build and deploy changes.
 1.  [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
     interacting with your kube cluster
 
@@ -108,7 +108,7 @@ export GOPATH="$HOME/go"
 export PATH="${PATH}:${GOPATH}/bin"
 ```
 
-Make sure to configure [authentication](https://github.com/google/ko#authenticating) if required. To be able to push images to the container registry, you need to run this once:
+Make sure to configure [authentication](https://github.com/ko-build/ko#authenticating) if required. To be able to push images to the container registry, you need to run this once:
 
 ```sh
 ko login [OPTIONS] [SERVER]

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -184,7 +184,7 @@ kubectl apply -f samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
 
 ## ko
 
-The `ko` ClusterBuilderStrategy is using [ko](https://github.com/google/ko)'s publish command to build an image from a Golang main package.
+The `ko` ClusterBuilderStrategy is using [ko](https://github.com/ko-build/ko)'s publish command to build an image from a Golang main package.
 
 ### Installing ko Strategy
 
@@ -202,7 +202,7 @@ The build strategy provides the following parameters that you can set in a Build
 | -- | -- | -- |
 | `go-flags` | Value for the GOFLAGS environment variable. | Empty |
 | `go-version` | Version of Go, must match a tag from [the golang image](https://hub.docker.com/_/golang?tab=tags) | `1.18` |
-| `ko-version` | Version of ko, must be either `latest` for the newest release, or a [ko release name](https://github.com/google/ko/releases) | `latest` |
+| `ko-version` | Version of ko, must be either `latest` for the newest release, or a [ko release name](https://github.com/ko-build/ko/releases) | `latest` |
 | `package-directory` | The directory inside the context directory containing the main package. | `.` |
 | `target-platform` | Target platform to be built. For example: `linux/arm64`. Multiple platforms can be provided separated by comma, for example: `linux/arm64,linux/amd64`. The value `all` will build all platforms supported by the base image. The value `current` will build the platform on which the build runs. | `current` |
 

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -12,7 +12,7 @@ spec:
       description: "Version of Go, must match a tag from https://hub.docker.com/_/golang?tab=tags"
       default: "1.18"
     - name: ko-version
-      description: "Version of ko, must be either 'latest', or a release name from https://github.com/google/ko/releases"
+      description: "Version of ko, must be either 'latest', or a release name from https://github.com/ko-build/ko/releases"
       default: latest
     - name: package-directory
       description: "The directory inside the context directory containing the main package."
@@ -110,7 +110,7 @@ spec:
           # Determine the ko version
           KO_VERSION="${PARAM_KO_VERSION}"
           if [ "${KO_VERSION}" == "latest" ]; then
-            KO_VERSION=$(curl --silent "https://api.github.com/repos/google/ko/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+            KO_VERSION=$(curl --silent "https://api.github.com/repos/ko-build/ko/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
           fi
 
           # Create one variable with v-suffix and one without as we need both for the download URL
@@ -123,7 +123,7 @@ spec:
           fi
 
           # Download ko to the temp directory
-          curl -f -s -L "https://github.com/google/ko/releases/download/${KO_VERSION_WITH_V}/ko_${KO_VERSION_WITHOUT_V}_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | tar xzf - -C /tmp ko
+          curl -f -s -L "https://github.com/ko-build/ko/releases/download/${KO_VERSION_WITH_V}/ko_${KO_VERSION_WITHOUT_V}_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | tar xzf - -C /tmp ko
 
           # Determine the platform
           PLATFORM="${PARAM_TARGET_PLATFORM}"


### PR DESCRIPTION
# Changes

The ko project moved from the google to the ko-build organization. Adopting Shipwright.

The current ko build strategy is broken because `curl --silent "https://api.github.com/repos/google/ko/releases/latest"` now causes a redirect to happen and therefore using `latest` does not work anymore with our build strategy. Specifying the release still worked because the download curl command always included `-L` (follow redirects) because GitHub imo always redirects them.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The ko sample build strategy was fixed to download from the ko-build organization.
```