### PR TITLE
[Hacktoberfest]: Update Doc to mention support for tokens

### DIFF
--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -8,7 +8,6 @@ SPDX-License-Identifier: Apache-2.0
 
 The following document provides an introduction around the different authentication methods that can take place during an image build when using the Build controller.
 
-- [Understanding authentication at runtime](#understanding-authentication-at-runtime)
   - [Overview](#overview)
   - [Build Secrets Annotation](#build-secrets-annotation)
   - [Authentication for Git](#authentication-for-git)

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -81,7 +81,7 @@ The Basic authentication is very similar to the ssh one, but with the following 
 - The `stringData` should host your user and personal access token in clear text.
 
 Note: GitHub and GitLab no longer accept account passwords when authenticating Git operations.
-Instead, token-based authentication will be required for all authenticated Git operations. You can create your own personal access token on [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
+Instead, you must use token-based authentication for all authenticated Git operations. You can create your own personal access token on [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 
 ```yaml
 apiVersion: v1

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -8,16 +8,17 @@ SPDX-License-Identifier: Apache-2.0
 
 The following document provides an introduction around the different authentication methods that can take place during an image build when using the Build controller.
 
-- [Overview](#overview)
-- [Build Secrets Annotation](#build-secrets-annotation)
-- [Authentication for Git](#authentication-for-git)
-  - [Basic authentication](#basic-authentication)
-  - [SSH authentication](#ssh-authentication)
-  - [Usage of git secret](#usage-of-git-secret)
-- [Authentication to container registries](#authentication-to-container-registries)
-  - [Docker Hub](#docker-hub)
-  - [Usage of registry secret](#usage-of-registry-secret)
-- [References](#references)
+- [Understanding authentication at runtime](#understanding-authentication-at-runtime)
+  - [Overview](#overview)
+  - [Build Secrets Annotation](#build-secrets-annotation)
+  - [Authentication for Git](#authentication-for-git)
+    - [SSH authentication](#ssh-authentication)
+    - [Basic authentication](#basic-authentication)
+    - [Usage of git secret](#usage-of-git-secret)
+  - [Authentication to container registries](#authentication-to-container-registries)
+    - [Docker Hub](#docker-hub)
+    - [Usage of registry secret](#usage-of-registry-secret)
+  - [References](#references)
 
 ## Overview
 
@@ -78,7 +79,10 @@ data:
 The Basic authentication is very similar to the ssh one, but with the following differences:
 
 - The Kubernetes secret should be of the type `kubernetes.io/basic-auth`
-- The `stringData` should host your user and password in clear text.
+- The `stringData` should host your user and personal access token in clear text.
+
+Note: GitHub and GitLab no longer accepts account passwords when authenticating Git operations.
+Instead, token-based authentication will be required for all authenticated Git operations. You can create your own personal access token on [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 
 ```yaml
 apiVersion: v1
@@ -90,7 +94,7 @@ metadata:
 type: kubernetes.io/basic-auth
 stringData:
   username: <cleartext username>
-  password: <cleartext password>
+  password: <cleartext token>
 ```
 
 ### Usage of git secret

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -8,16 +8,16 @@ SPDX-License-Identifier: Apache-2.0
 
 The following document provides an introduction around the different authentication methods that can take place during an image build when using the Build controller.
 
-  - [Overview](#overview)
-  - [Build Secrets Annotation](#build-secrets-annotation)
-  - [Authentication for Git](#authentication-for-git)
-    - [SSH authentication](#ssh-authentication)
-    - [Basic authentication](#basic-authentication)
-    - [Usage of git secret](#usage-of-git-secret)
-  - [Authentication to container registries](#authentication-to-container-registries)
-    - [Docker Hub](#docker-hub)
-    - [Usage of registry secret](#usage-of-registry-secret)
-  - [References](#references)
+- [Overview](#overview)
+- [Build Secrets Annotation](#build-secrets-annotation)
+- [Authentication for Git](#authentication-for-git)
+  - [SSH authentication](#ssh-authentication)
+  - [Basic authentication](#basic-authentication)
+  - [Usage of git secret](#usage-of-git-secret)
+- [Authentication to container registries](#authentication-to-container-registries)
+  - [Docker Hub](#docker-hub)
+  - [Usage of registry secret](#usage-of-registry-secret)
+- [References](#references)
 
 ## Overview
 

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -80,7 +80,7 @@ The Basic authentication is very similar to the ssh one, but with the following 
 - The Kubernetes secret should be of the type `kubernetes.io/basic-auth`
 - The `stringData` should host your user and personal access token in clear text.
 
-Note: GitHub and GitLab no longer accepts account passwords when authenticating Git operations.
+Note: GitHub and GitLab no longer accept account passwords when authenticating Git operations.
 Instead, token-based authentication will be required for all authenticated Git operations. You can create your own personal access token on [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 
 ```yaml


### PR DESCRIPTION
Hacktoberfest PR!

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Since GitHub dropped support for passwords last year and encouraged the use of personal access tokens (PATs) instead, the shipwright [doc needs to be updated](https://github.com/shipwright-io/build/blob/main/docs/development/authentication.md#basic-authentication) for the same. The "Basic authentication" method to authenticate with Git currently specifies putting `<password>` under the `stringData.password` field. This PR updates the doc to suggest using tokens instead.

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->
Fixes #968 

## Screenshot for reference
![image](https://user-images.githubusercontent.com/43273420/193416533-36831d1e-8071-4869-b343-ca6ffdc00aee.png)


# Release Notes

```release-note
Deprecated support for passwords. Use Personal Access Tokens instead.
```

