### PR TITLE
Use `/tekton/home` as `HOME` in strategy steps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,24 +14,28 @@ The following environment variables are available:
 
 | Environment Variable | Description |
 | --- | --- |
-| `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. |
-| `REMOTE_ARTIFACTS_CONTAINER_IMAGE` | Specify the container image used for the `.spec.sources` remote artifacts download, by default it uses `busybox:latest`. |
-| `GIT_CONTAINER_TEMPLATE` | JSON representation of a [Container](https://pkg.go.dev/k8s.io/api/core/v1#Container) template that is used for steps that clone a Git repository. Default is `{"image":"ghcr.io/shipwright-io/build/git:latest", "command":["/ko-app/git"], "securityContext":{"runAsUser":1000,"runAsGroup":1000}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. Default is 5 (seconds). |
+| `REMOTE_ARTIFACTS_CONTAINER_IMAGE` | Specify the container image used for the `.spec.sources` remote artifacts download, by default it uses `quay.io/quay/busybox:latest`. |
+| `TERMINATION_LOG_PATH` | Path of the termination log. This is where controller application will write the reason of its termination. Default value is `/dev/termination-log`. |
+| `GIT_ENABLE_REWRITE_RULE` | Enable Git wrapper to setup a URL `insteadOf` Git config rewrite rule for the respective source URL hostname. Default is `false`. |
+| `GIT_CONTAINER_TEMPLATE` | JSON representation of a [Container] template that is used for steps that clone a Git repository. Default is `{"image":"ghcr.io/shipwright-io/build/git:latest", "command":["/ko-app/git"], "env": [{"name": "HOME","value": "/tekton/home"}], "securityContext":{"runAsUser":1000,"runAsGroup":1000}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
 | `GIT_CONTAINER_IMAGE` | Custom container image for Git clone steps. If `GIT_CONTAINER_TEMPLATE` is also specifying an image, then the value for `GIT_CONTAINER_IMAGE` has precedence. |
-| `MUTATE_IMAGE_CONTAINER_TEMPLATE` | JSON representation of a [Container](https://pkg.go.dev/k8s.io/api/core/v1#Container) template that is used for steps that mutates an image if a `Build` has annotations or labels defined in the output. Default is `{"image": "ghcr.io/shipwright-io/build/mutate-image:latest", "command": ["/ko-app/mutate-image"], "env": [{"name": "HOME","value": "/tekton/home"}], "securityContext": {"runAsUser": 0, "capabilities": {"add": ["DAC_OVERRIDE"]}}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `BUNDLE_IMAGE_CONTAINER_TEMPLATE` | JSON representation of a [Container] template that is used for steps that pulls a bundle image to obtain the packaged source code. Default is `{"image": "ghcr.io/shipwright-io/build/bundle:latest", "command": ["/ko-app/bundle"], "env": [{"name": "HOME","value": "/tekton/home"}], "securityContext":{"runAsUser":1000,"runAsGroup":1000}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `BUNDLE_IMAGE_CONTAINER_IMAGE` | Custom container image that pulls a bundle image to obtain the packaged source code. If `BUNDLE_IMAGE_CONTAINER_TEMPLATE` is also specifying an image, then the value for `BUNDLE_IMAGE_CONTAINER_IMAGE` has precedence. |
+| `MUTATE_IMAGE_CONTAINER_TEMPLATE` | JSON representation of a [Container] template that is used for steps that mutates an image if a `Build` has annotations or labels defined in the output. Default is `{"image": "ghcr.io/shipwright-io/build/mutate-image:latest", "command": ["/ko-app/mutate-image"], "env": [{"name": "HOME","value": "/tekton/home"}], "securityContext": {"runAsUser": 0, "capabilities": {"add": ["DAC_OVERRIDE"]}}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
 | `MUTATE_IMAGE_CONTAINER_IMAGE` | Custom container image that is used for steps that mutates an image if a `Build` has annotations or labels defined in the output. If `MUTATE_IMAGE_CONTAINER_TEMPLATE` is also specifying an image, then the value for `MUTATE_IMAGE_CONTAINER_IMAGE` has precedence. |
+| `WAITER_IMAGE_CONTAINER_TEMPLATE` | JSON representation of a [Container] template that waits for local source code to be uploaded to it. Default is `{"image":"ghcr.io/shipwright-io/build/waiter:latest", "command": ["/ko-app/waiter"], "args": ["start"], "env": [{"name": "HOME","value": "/tekton/home"}], "securityContext":{"runAsUser":1000,"runAsGroup":1000}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `WAITER_IMAGE_CONTAINER_IMAGE` | Custom container image that waits for local source code to be uploaded to it. If `WAITER_IMAGE_CONTAINER_TEMPLATE` is also specifying an image, then the value for `WAITER_IMAGE_CONTAINER_IMAGE` has precedence. |
 | `BUILD_CONTROLLER_LEADER_ELECTION_NAMESPACE` |  Set the namespace to be used to store the `shipwright-build-controller` lock, by default it is in the same namespace as the controller itself. |
 | `BUILD_CONTROLLER_LEASE_DURATION` |  Override the `LeaseDuration`, which is the duration that non-leader candidates will wait to force acquire leadership. |
 | `BUILD_CONTROLLER_RENEW_DEADLINE` |  Override the `RenewDeadline`, which is the duration that the acting leader will retry refreshing leadership before giving up. |
 | `BUILD_CONTROLLER_RETRY_PERIOD` |  Override the `RetryPeriod`, which is the duration the LeaderElector clients should wait between tries of actions. |
-| `BUILD_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the build controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `BUILDRUN_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the buildrun controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `BUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the buildstrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `CLUSTERBUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the clusterbuildstrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `KUBE_API_BURST` | Burst to use for the Kubernetes API client. See [Config.Burst](https://pkg.go.dev/k8s.io/client-go/rest#Config.Burst). A value of 0 or lower will use the default from client-go, which currently is 10. Default is 0. |
-| `KUBE_API_QPS` | QPS to use for the Kubernetes API client. See [Config.QPS](https://pkg.go.dev/k8s.io/client-go/rest#Config.QPS). A value of 0 or lower will use the default from client-go, which currently is 5. Default is 0. |
-| `TERMINATION_LOG_PATH` | Path of the termination log. This is where controller application will write the reason of its termination. Default value is `/dev/termination-log`. |
-| `GIT_ENABLE_REWRITE_RULE` | Enable Git wrapper to setup a URL `insteadOf` Git config rewrite rule for the respective source URL hostname. Default is `false`. |
+| `BUILD_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the build controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `BUILDRUN_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the BuildRun controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `BUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the BuildStrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `CLUSTERBUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the ClusterBuildStrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `KUBE_API_BURST` | Burst to use for the Kubernetes API client. See [Config.Burst]. A value of 0 or lower will use the default from client-go, which currently is 10. Default is 0. |
+| `KUBE_API_QPS` | QPS to use for the Kubernetes API client. See [Config.QPS]. A value of 0 or lower will use the default from client-go, which currently is 5. Default is 0. |
 
 ## Role-based Access Control
 
@@ -40,11 +44,19 @@ The following roles are installed:
 
 - `shpwright-build-aggregate-view`: this role grants read access (get, list, watch) to most Shipwright Build objects.
   This includes `BuildStrategy`, `ClusterBuildStrategy`, `Build`, and `BuildRun` objects.
-  This role is aggregated to the [Kubernetes "view" role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings).
+  This role is aggregated to the [Kubernetes "view" role].
 - `shipwright-build-aggregate-edit`: this role grants write access (create, update, patch, delete) to Shipwright objects that are namespace-scoped.
   This includes `BuildStrategy`, `Builds`, and `BuildRuns`.
   Read access is granted to all `ClusterBuildStrategy` objects.
-  This role is aggregated to the [Kubernetes "edit" and "admin" roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings).
+  This role is aggregated to the [Kubernetes "edit" and "admin" roles].
 
 Only cluster administrators are granted write access to `ClusterBuildStrategy` objects.
-This can be changed by creating a separate [Kubernetes `ClusterRole`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) with these permissions and binding the role to appropriate users.
+This can be changed by creating a separate [Kubernetes `ClusterRole`] with these permissions and binding the role to appropriate users.
+
+[Container]:https://pkg.go.dev/k8s.io/api/core/v1#Container
+[controller-runtime controller Options]:https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options
+[Config.Burst]:https://pkg.go.dev/k8s.io/client-go/rest#Config.Burst
+[Config.QPS]:https://pkg.go.dev/k8s.io/client-go/rest#Config.QPS
+[Kubernetes "view" role]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+[Kubernetes "edit" and "admin" roles]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+[Kubernetes `ClusterRole`]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,28 +144,49 @@ type KubeAPIOptions struct {
 // NewDefaultConfig returns a new Config, with context timeout and default Kaniko image.
 func NewDefaultConfig() *Config {
 	return &Config{
-		CtxTimeOut: contextTimeout,
+		CtxTimeOut:                    contextTimeout,
+		RemoteArtifactsContainerImage: remoteArtifactsDefaultImage,
+		TerminationLogPath:            terminationLogPathDefault,
+		GitRewriteRule:                false,
+
 		GitContainerTemplate: pipeline.Step{
 			Image: gitDefaultImage,
 			Command: []string{
 				"/ko-app/git",
 			},
+			// We explicitly define HOME=/tekton/home because this was always set in the
+			// default configuration of Tekton until v0.24.0, see https://github.com/tektoncd/pipeline/pull/3878
+			Env: []corev1.EnvVar{
+				{
+					Name:  "HOME",
+					Value: "/tekton/home",
+				},
+			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  nonRoot,
 				RunAsGroup: nonRoot,
 			},
 		},
+
 		BundleContainerTemplate: pipeline.Step{
 			Image: bundleDefaultImage,
 			Command: []string{
 				"/ko-app/bundle",
 			},
+			// We explicitly define HOME=/tekton/home because this was always set in the
+			// default configuration of Tekton until v0.24.0, see https://github.com/tektoncd/pipeline/pull/3878
+			Env: []corev1.EnvVar{
+				{
+					Name:  "HOME",
+					Value: "/tekton/home",
+				},
+			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  nonRoot,
 				RunAsGroup: nonRoot,
 			},
 		},
-		RemoteArtifactsContainerImage: remoteArtifactsDefaultImage,
+
 		MutateImageContainerTemplate: pipeline.Step{
 			Image: mutateImageDefaultImage,
 			Command: []string{
@@ -193,6 +214,7 @@ func NewDefaultConfig() *Config {
 				},
 			},
 		},
+
 		WaiterContainerTemplate: pipeline.Step{
 			Image: waiterDefaultImage,
 			Command: []string{
@@ -201,19 +223,30 @@ func NewDefaultConfig() *Config {
 			Args: []string{
 				"start",
 			},
+			// We explicitly define HOME=/tekton/home because this was always set in the
+			// default configuration of Tekton until v0.24.0, see https://github.com/tektoncd/pipeline/pull/3878
+			Env: []corev1.EnvVar{
+				{
+					Name:  "HOME",
+					Value: "/tekton/home",
+				},
+			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  nonRoot,
 				RunAsGroup: nonRoot,
 			},
 		},
+
 		Prometheus: PrometheusConfig{
 			BuildRunCompletionDurationBuckets: metricBuildRunCompletionDurationBuckets,
 			BuildRunEstablishDurationBuckets:  metricBuildRunEstablishDurationBuckets,
 			BuildRunRampUpDurationBuckets:     metricBuildRunRampUpDurationBuckets,
 		},
+
 		ManagerOptions: ManagerOptions{
 			LeaderElectionNamespace: leaderElectionNamespaceDefault,
 		},
+
 		Controllers: Controllers{
 			Build: ControllerOptions{
 				MaxConcurrentReconciles: 0,
@@ -228,12 +261,11 @@ func NewDefaultConfig() *Config {
 				MaxConcurrentReconciles: 0,
 			},
 		},
+
 		KubeAPIOptions: KubeAPIOptions{
 			QPS:   0,
 			Burst: 0,
 		},
-		TerminationLogPath: terminationLogPathDefault,
-		GitRewriteRule:     false,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -132,6 +132,7 @@ var _ = Describe("Config", func() {
 					Command: []string{
 						"/ko-app/git",
 					},
+					Env: []corev1.EnvVar{{Name: "HOME", Value: "/tekton/home"}},
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser:  nonRoot,
 						RunAsGroup: nonRoot,
@@ -226,6 +227,7 @@ var _ = Describe("Config", func() {
 					Image:   "myregistry/custom/image",
 					Command: []string{"/ko-app/waiter"},
 					Args:    []string{"start"},
+					Env:     []corev1.EnvVar{{Name: "HOME", Value: "/tekton/home"}},
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser:  nonRoot,
 						RunAsGroup: nonRoot,


### PR DESCRIPTION
# Changes

Use same `HOME` variable stanza in all steps defined in the configuration:
- GitContainerTemplate
- BundleContainerTemplate
- MutateImageContainerTemplate (already defined)
- MutateImageContainerTemplate

Reorder fields to have simple settings at the beginning.

Add empty lines between sections for readability.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
