### PR TITLE
Fix `G601` findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ linters-settings:
       - G101 # Look for hard coded credentials
       - G305 # File traversal when extracting zip/tar archive
       - G306 # Poor file permissions used when writing to a new file
-      - G601 # Implicit memory aliasing of items from a range statement
 
 issues:
   exclude-rules:

--- a/pkg/reconciler/buildrun/resources/params.go
+++ b/pkg/reconciler/buildrun/resources/params.go
@@ -254,7 +254,9 @@ stepLookupLoop:
 	// In this second loop, we iterate all the steps and add the environment variable to all steps
 	// where the parameter is referenced.
 stepModifyLoop:
-	for i, step := range taskRun.Spec.TaskSpec.Steps {
+	for i := range taskRun.Spec.TaskSpec.Steps {
+		step := taskRun.Spec.TaskSpec.Steps[i]
+
 		if isStepReferencingParameter(&step, paramName) {
 			// make sure we don't add a duplicate environment variable to a step
 			for _, env := range step.Env {
@@ -314,7 +316,9 @@ stepLookupLoop:
 	// In this second loop, we iterate all the steps and add the environment variable to all steps
 	// where the parameter is referenced.
 stepModifyLoop:
-	for i, step := range taskRun.Spec.TaskSpec.Steps {
+	for i := range taskRun.Spec.TaskSpec.Steps {
+		step := taskRun.Spec.TaskSpec.Steps[i]
+
 		if isStepReferencingParameter(&step, paramName) {
 			// make sure we don't add a duplicate environment variable to a step
 			for _, env := range step.Env {

--- a/pkg/validate/ownerreferences.go
+++ b/pkg/validate/ownerreferences.go
@@ -30,7 +30,6 @@ type OwnerRef struct {
 // ValidatePath implements BuildPath interface and validates
 // setting the ownershipReference between a Build and a BuildRun
 func (o OwnerRef) ValidatePath(ctx context.Context) error {
-
 	buildRunList, err := o.retrieveBuildRunsfromBuild(ctx)
 	if err != nil {
 		return err
@@ -39,7 +38,9 @@ func (o OwnerRef) ValidatePath(ctx context.Context) error {
 	switch o.Build.GetAnnotations()[build.AnnotationBuildRunDeletion] {
 	case "true":
 		// if the buildRun does not have an ownerreference to the Build, lets add it.
-		for _, buildRun := range buildRunList.Items {
+		for i := range buildRunList.Items {
+			buildRun := buildRunList.Items[i]
+
 			if index := o.validateBuildOwnerReference(buildRun.OwnerReferences); index == -1 {
 				if err := controllerutil.SetControllerReference(o.Build, &buildRun, o.Scheme); err != nil {
 					o.Build.Status.Reason = build.BuildReasonPtr(build.SetOwnerReferenceFailed)
@@ -53,7 +54,9 @@ func (o OwnerRef) ValidatePath(ctx context.Context) error {
 		}
 	case "", "false":
 		// if the buildRun have an ownerreference to the Build, lets remove it
-		for _, buildRun := range buildRunList.Items {
+		for i := range buildRunList.Items {
+			buildRun := buildRunList.Items[i]
+
 			if index := o.validateBuildOwnerReference(buildRun.OwnerReferences); index != -1 {
 				buildRun.OwnerReferences = removeOwnerReferenceByIndex(buildRun.OwnerReferences, index)
 				if err := o.Client.Update(ctx, &buildRun); err != nil {

--- a/pkg/volumes/volumes.go
+++ b/pkg/volumes/volumes.go
@@ -34,7 +34,9 @@ func TaskSpecVolumes(
 		return nil, err
 	}
 
-	for _, v := range volumes {
+	for i := range volumes {
+		v := volumes[i]
+
 		if readOnly, ok := existingVolumeMounts[v.Name]; ok {
 			// In case volume mount is not read only and
 			// volume type is either secret or config map,


### PR DESCRIPTION
# Changes

Use explicit variable in for loops that can safely be used for references.

Remove `G601` ignore in global configuration.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

