### PR TITLE
Improve PR body in auto-update tools version workflow

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -27,21 +27,33 @@ jobs:
           IMAGE: ${{ matrix.image }}
           LATEST_RELEASE_URL: ${{ matrix.latest-release-url }}
         run: |
-          for directory in samples test; do hack/check-latest-images.sh ${IMAGE} ${LATEST_RELEASE_URL} ${directory}; done
+          for directory in docs samples test; do hack/check-latest-images.sh ${IMAGE} ${LATEST_RELEASE_URL} ${directory}; done
       - name: Check image change
         run: |
-          echo "FROM=$(git diff --unified=0 | grep '^[-].*image: .*/.*/.*:' | cut --delimiter=':' --fields='3')" >> $GITHUB_OUTPUT
-          echo "TO=$(git diff --unified=0 | grep '^[+].*image: .*/.*/.*:' | cut --delimiter=':' --fields='3')" >> $GITHUB_OUTPUT
+          echo "FROM=$(git diff --unified=0 | grep '^[-].*image: .*/.*/.*:' | head --lines=1 | cut --delimiter=':' --fields='3' | sed 's/[^[[:digit:].]//g')" >> $GITHUB_OUTPUT
+          echo "TO=$(git diff --unified=0 | grep '^[+].*image: .*/.*/.*:' | head --lines=1 | cut --delimiter=':' --fields='3' | sed 's/[^[[:digit:].]//g')" >> $GITHUB_OUTPUT
         id: image-diff
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: Bump ${{ matrix.image }}
+          commit-message: Bump ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}
           title: Bump ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}
           body: |
+            # Changes
             Bumps ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}.
 
             You can trigger a rebase manually by commenting `/rebase` and resolve any conflicts with this PR.
+
+            # Submitter Checklist
+            - [ ] Includes tests if functionality changed/was added
+            - [ ] Includes docs if changes are user-facing
+            - [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
+            - [x] Release notes block has been filled in, or marked NONE
+
+            # Release Notes
+            ```release-note
+            NONE
+            ```
           labels: kind/dependency-change
           branch: ${{ matrix.image }}
           delete-branch: true

--- a/hack/check-latest-images.sh
+++ b/hack/check-latest-images.sh
@@ -34,7 +34,7 @@ function validate() {
 
 function update() {
         # Search the image URL recursively and parse the current image tag
-        CURRENT_TAG=$(grep --no-filename --recursive --max-count=1 "image: ${IMAGE}:"  | cut --delimiter=':' --fields='3')
+        CURRENT_TAG=$(grep --no-filename --recursive "image: ${IMAGE}:" | head --lines=1  | cut --delimiter=':' --fields='3')
 
         # Fetch the latest release tag name from release URL
         LATEST_TAG=$(curl --silent --retry 3 ${LATEST_RELEASE_URL} | jq --raw-output '.name')


### PR DESCRIPTION
# Changes
Improve PR body in auto update tools version [workflow]((https://github.com/shipwright-io/build/blob/main/.github/workflows/check-latest-images.yaml)) as per [this](https://github.com/shipwright-io/build/pull/1140#issuecomment-1294581457). Addition for [1039](https://github.com/shipwright-io/build/issues/1039).

# Submitter Checklist
- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes
```release-note
NONE
```