### PR TITLE
Add support to add labels and annotations to build pod

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -56,6 +56,12 @@ spec:
           spec:
             description: BuildRunSpec defines the desired state of BuildRun
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations contains annotations that should be passed
+                  to the build pod
+                type: object
               buildRef:
                 description: BuildRef refers to the Build
                 properties:
@@ -71,6 +77,12 @@ spec:
               buildSpec:
                 description: BuildSpec refers to an embedded build specification
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations contains annotations that should be passed
+                      to the build pod
+                    type: object
                   builder:
                     description: "Builder refers to the image containing the build
                       tools inside which the source code would be built. \n NOTICE:
@@ -223,6 +235,12 @@ spec:
                       - name
                       type: object
                     type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels contains labels that should be passed to the
+                      build pod
+                    type: object
                   output:
                     description: Output refers to the location where the built image
                       would be pushed.
@@ -2204,6 +2222,12 @@ spec:
                   - name
                   type: object
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels contains labels that should be passed to the build
+                  pod
+                type: object
               output:
                 description: Output refers to the location where the generated image
                   would be pushed to. It will overwrite the output image in build
@@ -3885,6 +3909,12 @@ spec:
               buildSpec:
                 description: BuildSpec is the Build Spec of this BuildRun.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations contains annotations that should be passed
+                      to the build pod
+                    type: object
                   builder:
                     description: "Builder refers to the image containing the build
                       tools inside which the source code would be built. \n NOTICE:
@@ -4037,6 +4067,12 @@ spec:
                       - name
                       type: object
                     type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels contains labels that should be passed to the
+                      build pod
+                    type: object
                   output:
                     description: Output refers to the location where the built image
                       would be pushed.

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -58,6 +58,12 @@ spec:
           spec:
             description: BuildSpec defines the desired state of Build
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations contains annotations that should be passed
+                  to the build pod
+                type: object
               builder:
                 description: "Builder refers to the image containing the build tools
                   inside which the source code would be built. \n NOTICE: Builder
@@ -205,6 +211,12 @@ spec:
                   - name
                   type: object
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels contains labels that should be passed to the build
+                  pod
+                type: object
               output:
                 description: Output refers to the location where the built image would
                   be pushed.

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -178,6 +178,14 @@ type BuildSpec struct {
 	// to be overridden. Must only contain volumes that exist in the corresponding BuildStrategy
 	// +optional
 	Volumes []BuildVolume `json:"volumes,omitempty"`
+
+	// Labels contains labels that should be passed to the build pod
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Annotations contains annotations that should be passed to the build pod
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // BuildVolume is a volume that will be mounted in build pod during build step

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -81,6 +81,14 @@ type BuildRunSpec struct {
 	// to be overridden. Must only contain volumes that exist in the corresponding BuildStrategy
 	// +optional
 	Volumes []BuildVolume `json:"volumes,omitempty"`
+
+	// Labels contains labels that should be passed to the build pod
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Annotations contains annotations that should be passed to the build pod
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // BuildRunRequestedState defines the buildrun state the user can provide to override whatever is the current state.

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -286,6 +286,20 @@ func (in *BuildRunSpec) DeepCopyInto(out *BuildRunSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -440,6 +454,20 @@ func (in *BuildSpec) DeepCopyInto(out *BuildSpec) {
 		*out = make([]BuildVolume, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	return


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This pr adds two fields `labels` and `annotations` to the `Build` and `BuildRun` CRD, the controller will add the labels and annotations to the `taskrun`, and eventually be added to the build pod.

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add support to add labels and annotations to build pod
```