### PR TITLE
Fixes cancelation of buildruns without a build reference

### DIFF
--- a/pkg/reconciler/buildrun/controller.go
+++ b/pkg/reconciler/buildrun/controller.go
@@ -71,7 +71,7 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler, maxCo
 			// - when a BuildRun already have a referenced TaskRun, but the latest version is not canceled
 			// - when a BuildRun have a completionTime set
 			switch {
-			case o.GetLabels()[buildv1alpha1.LabelBuild] == "":
+			case o.Spec.BuildRef != nil && o.GetLabels()[buildv1alpha1.LabelBuild] == "":
 				return false
 			case o.Status.LatestTaskRunRef != nil && !n.IsCanceled():
 				return false

--- a/pkg/reconciler/buildrun/controller.go
+++ b/pkg/reconciler/buildrun/controller.go
@@ -66,20 +66,14 @@ func add(ctx context.Context, mgr manager.Manager, r reconcile.Reconciler, maxCo
 			o := e.ObjectOld.(*buildv1alpha1.BuildRun)
 			n := e.ObjectNew.(*buildv1alpha1.BuildRun)
 
-			// Avoid reconciling when for updates on the BuildRun the following takes place
-			// - the build.shipwright.io/name label is set
-			// - when a BuildRun already have a referenced TaskRun, but the latest version is not canceled
-			// - when a BuildRun have a completionTime set
+			// Only reconcile a BuildRun update when
+			// - it is set to canceled
 			switch {
-			case o.Spec.BuildRef != nil && o.GetLabels()[buildv1alpha1.LabelBuild] == "":
-				return false
-			case o.Status.LatestTaskRunRef != nil && !n.IsCanceled():
-				return false
-			case o.Status.CompletionTime != nil:
-				return false
+			case !o.IsCanceled() && n.IsCanceled():
+				return true
 			}
 
-			return o.GetGeneration() != n.GetGeneration()
+			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Never reconcile on deletion, there is nothing we have to do

--- a/test/buildrun_samples.go
+++ b/test/buildrun_samples.go
@@ -131,6 +131,21 @@ spec:
     name: foobar
 `
 
+const MinimalOneOffBuildRun = `
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+metadata:
+  name: standalone-buildrun
+spec:
+  buildSpec:
+    source:
+      url: "https://github.com/shipwright-io/sample-go"
+    strategy:
+      kind: ClusterBuildStrategy
+      name: buildah
+    dockerfile: Dockerfile
+`
+
 // MinimalBuildRunWithParams defines a param override
 const MinimalBuildRunWithParams = `
 apiVersion: shipwright.io/v1alpha1

--- a/test/buildrun_samples.go
+++ b/test/buildrun_samples.go
@@ -140,10 +140,12 @@ spec:
   buildSpec:
     source:
       url: "https://github.com/shipwright-io/sample-go"
+      contextDir: docker-build
     strategy:
       kind: ClusterBuildStrategy
       name: buildah
-    dockerfile: Dockerfile
+    output:
+      image: image-registry.openshift-image-registry.svc:5000/example/buildpacks-app
 `
 
 // MinimalBuildRunWithParams defines a param override

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -1039,6 +1039,16 @@ func (c *Catalog) LoadBRWithNameAndRef(name string, buildName string, d []byte) 
 	return b, nil
 }
 
+func (c *Catalog) LoadStandAloneBuildRunWithName(name string, d []byte) (*build.BuildRun, error) {
+	b := &build.BuildRun{}
+	err := yaml.Unmarshal(d, b)
+	if err != nil {
+		return nil, err
+	}
+	b.Name = name
+	return b, nil
+}
+
 // LoadBuildStrategyFromBytes returns a populated BuildStrategy
 func (c *Catalog) LoadBuildStrategyFromBytes(d []byte) (*build.BuildStrategy, error) {
 	b := &build.BuildStrategy{}

--- a/test/catalog.go
+++ b/test/catalog.go
@@ -1039,13 +1039,15 @@ func (c *Catalog) LoadBRWithNameAndRef(name string, buildName string, d []byte) 
 	return b, nil
 }
 
-func (c *Catalog) LoadStandAloneBuildRunWithName(name string, d []byte) (*build.BuildRun, error) {
+func (c *Catalog) LoadStandAloneBuildRunWithNameAndStrategy(name string, strategy *build.ClusterBuildStrategy, d []byte) (*build.BuildRun, error) {
 	b := &build.BuildRun{}
 	err := yaml.Unmarshal(d, b)
 	if err != nil {
 		return nil, err
 	}
 	b.Name = name
+	b.Spec.BuildSpec.Strategy = build.Strategy{Kind: (*build.BuildStrategyKind)(&strategy.Kind), Name: strategy.Name}
+
 	return b, nil
 }
 


### PR DESCRIPTION
# Changes

The bug is that updates to an one-off build are not considered for reconcilation because they do not reference a build in their labels. Therefore, the label validation should only be considered for brs that have a build reference.

Fixes #1155.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixes cancelation of buildruns without a build reference.
```

/kind bug