### PR TITLE
Add base image for image processing command

### DIFF
--- a/.github/workflows/base-images.yaml
+++ b/.github/workflows/base-images.yaml
@@ -14,8 +14,9 @@ jobs:
       matrix:
         image:
           - git
+          - image-processing
           - waiter
-      max-parallel: 2
+      max-parallel: 3
 
     steps:
       - uses: actions/checkout@v3

--- a/images/image-processing/Dockerfile
+++ b/images/image-processing/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM registry.access.redhat.com/ubi9-minimal:latest AS bin-loader
+
+RUN \
+  microdnf --nodocs -y install gzip jq tar && \
+  TAG_NAME="$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | jq -r '.tag_name')" && \
+  curl -L -s "https://github.com/aquasecurity/trivy/releases/download/${TAG_NAME}/trivy_${TAG_NAME/v/}_$(uname -s)-$(uname -m | sed -e 's/aarch64/ARM64/' -e 's/ppc64le/PPC64LE/' -e 's/x86_64/64bit/').tar.gz" | tar -xzf - -C /usr/local/bin trivy
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+
+COPY --from=bin-loader /usr/local/bin/trivy /usr/local/bin/trivy
+
+RUN \
+  microdnf --nodocs -y update && \
+  microdnf clean all && \
+  rm -rf /var/cache/yum && \
+  echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
+  echo 'nonroot:x:1000:' > /etc/group
+
+USER 1000:1000


### PR DESCRIPTION
# Changes

Adding a base image that runs as user 1000 and contains the trivy command. This is needed for the image-processing command once we add vulnerability scanning.

This is part of the implementation of [Build Output Vulnerability Scanning](https://github.com/shipwright-io/community/blob/main/ships/0033-build-output-vulnerability-scanning.md).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```