### PR TITLE
Fix job name duplication

### DIFF
--- a/.github/workflows/base-images.yaml
+++ b/.github/workflows/base-images.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:  # Manual trigger
 
 jobs:
-  build:
+  base-image-build:
     if: ${{ github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:  # Manual trigger
 
 jobs:
-  build:
+  mirror-images:
     if: ${{ github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release-notes-linter.yaml
+++ b/.github/workflows/release-notes-linter.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  build:
+  release-note-linter:
     name: Release Note Linter
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Changes

It doesn't hurt technically speaking, but it is better that the job names are unique across all GitHub Actions.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

