### PR TITLE
Add custom error for basic auth with HTTP

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -488,10 +488,16 @@ func checkCredentials() (credentialType, error) {
 	// in which case there need to be the files username and password
 	hasUsername := hasFile(flagValues.secretPath, "username")
 	hasPassword := hasFile(flagValues.secretPath, "password")
-	isHTTPSURL := strings.HasPrefix(flagValues.url, "https")
 	switch {
-	case hasUsername && hasPassword && isHTTPSURL:
+	case hasUsername && hasPassword && strings.HasPrefix(flagValues.url, "https://"):
 		return typeUsernamePassword, nil
+
+	case hasUsername && hasPassword && strings.HasPrefix(flagValues.url, "http://"):
+		return typeUndef, &ExitError{
+			Code:    110,
+			Message: shpgit.AuthUnexpectedHTTP.ToMessage(),
+			Reason:  shpgit.AuthUnexpectedHTTP,
+		}
 
 	case hasUsername && !hasPassword || !hasUsername && hasPassword:
 		return typeUndef, &ExitError{

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -103,8 +103,8 @@ func main() {
 			exitcode = err.Code
 		}
 
-		if err := writeErrorResults(shpgit.NewErrorResultFromMessage(err.Error())); err != nil {
-			log.Printf("Could not write error results: %s", err.Error())
+		if writeErr := writeErrorResults(shpgit.NewErrorResultFromMessage(err.Error())); writeErr != nil {
+			log.Printf("Could not write error results: %s", writeErr.Error())
 		}
 
 		log.Print(err.Error())

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -30,6 +30,8 @@ const (
 var useNoTagsFlag = false
 var useDepthForSubmodule = false
 
+var displayURL string
+
 // ExitError is an error which has an exit code to be used in os.Exit() to
 // return both an exit code and an error message
 type ExitError struct {
@@ -127,13 +129,18 @@ func Execute(ctx context.Context) error {
 		return err
 	}
 
-	checkGitVersionSpecificSettings(ctx)
+	// Check if Git CLI supports --no-tags for clone
+	out, _ := git(ctx, "clone", "-h")
+	useNoTagsFlag = strings.Contains(out, "--no-tags")
 
-	if err := runGitClone(ctx); err != nil {
-		return err
-	}
+	// Check if Git CLI support --single-branch and therefore shallow clones using --depth
+	out, _ = git(ctx, "submodule", "-h")
+	useDepthForSubmodule = strings.Contains(out, "single-branch")
 
-	return nil
+	// Create clean version of the URL that should be safe to be displayed in logs
+	displayURL = cleanURL()
+
+	return runGitClone(ctx)
 }
 
 func runGitClone(ctx context.Context) error {
@@ -215,16 +222,6 @@ func checkEnvironment(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func checkGitVersionSpecificSettings(ctx context.Context) {
-	// Check if Git CLI supports --no-tags for clone
-	out, _ := git(ctx, "clone", "-h")
-	useNoTagsFlag = strings.Contains(out, "--no-tags")
-
-	// Check if Git CLI support --single-branch and therefore shallow clones using --depth
-	out, _ = git(ctx, "submodule", "-h")
-	useDepthForSubmodule = strings.Contains(out, "single-branch")
 }
 
 func clone(ctx context.Context) error {
@@ -410,7 +407,7 @@ func clone(ctx context.Context) error {
 	}
 
 	log.Printf("Successfully loaded %s (%s) into %s\n",
-		flagValues.url,
+		displayURL,
 		revision,
 		flagValues.target,
 	)
@@ -420,7 +417,9 @@ func clone(ctx context.Context) error {
 
 func git(ctx context.Context, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
-	log.Print(cmd.String())
+
+	// Print the command to be executed, but replace the URL with a safe version
+	log.Print(strings.ReplaceAll(cmd.String(), flagValues.url, displayURL))
 
 	// Make sure that the spawned process does not try to prompt for infos
 	os.Setenv("GIT_TERMINAL_PROMPT", "0")
@@ -535,4 +534,23 @@ func writeErrorResults(failure *shpgit.ErrorResult) (err error) {
 	}
 
 	return nil
+}
+
+func cleanURL() string {
+	// non HTTP/HTTPS URLs are returned as-is (i.e. Git+SSH URLs)
+	if !strings.HasPrefix(flagValues.url, "http") {
+		return flagValues.url
+	}
+
+	// return redacted version of the URL if it is a parsable URL
+	if repoURL, err := url.Parse(flagValues.url); err == nil {
+		if repoURL.User != nil {
+			log.Println("URL has inline credentials, which need to be redacted for log out. If possible, use an alternative approach.")
+		}
+
+		return repoURL.Redacted()
+	}
+
+	// in any case, as a fallback, return it as-is
+	return flagValues.url
 }

--- a/cmd/git/main_suite_test.go
+++ b/cmd/git/main_suite_test.go
@@ -5,13 +5,64 @@
 package main_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	. "github.com/shipwright-io/build/cmd/git"
+	shpgit "github.com/shipwright-io/build/pkg/git"
 )
 
 func TestGitCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Git Command Suite")
+}
+
+type errorClassMatcher struct{ expected shpgit.ErrorClass }
+
+func FailWith(expected shpgit.ErrorClass) types.GomegaMatcher {
+	return &errorClassMatcher{expected: expected}
+}
+
+func (m *errorClassMatcher) Match(actual interface{}) (success bool, err error) {
+	if actual == nil {
+		return false, nil
+	}
+
+	switch obj := actual.(type) {
+	case *ExitError:
+		return obj.Reason == m.expected, nil
+
+	case shpgit.ErrorClass:
+		return obj == m.expected, nil
+
+	default:
+		return false, fmt.Errorf("type mismatch: %T", actual)
+	}
+}
+
+func (m *errorClassMatcher) asStrings(actual interface{}) (string, string) {
+	switch obj := actual.(type) {
+	case *ExitError:
+		return obj.Reason.String(), m.expected.String()
+
+	case shpgit.ErrorClass:
+		return obj.String(), m.expected.String()
+
+	default:
+		return fmt.Sprintf("%v", obj), m.expected.String()
+	}
+}
+
+func (m *errorClassMatcher) FailureMessage(actual interface{}) string {
+	act, exp := m.asStrings(actual)
+	return fmt.Sprintf("\nExpected\n\t%s\nto equal\n\t%s", act, exp)
+}
+
+func (m *errorClassMatcher) NegatedFailureMessage(actual interface{}) string {
+	act, exp := m.asStrings(actual)
+	return fmt.Sprintf("\nExpected\n\t%s\nto not equal\n\t%s", act, exp)
 }

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -631,7 +631,6 @@ var _ = Describe("Git Resource", func() {
 						withTempDir(func(target string) {
 							withTempDir(func(secret string) {
 								// Mock the filesystem state of `kubernetes.io/ssh-auth` type secret volume mount
-								GinkgoWriter.Write([]byte(sshPrivateKey))
 								file(filepath.Join(secret, "ssh-privatekey"), 0400, []byte(sshPrivateKey))
 
 								err := run(withArgs(

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -344,6 +344,24 @@ var _ = Describe("Git Resource", func() {
 				})
 			})
 		})
+
+		It("should fail in case basic auth credentials are used in conjunction with HTTP URI", func() {
+			withTempDir(func(secret string) {
+				withUsernamePassword(func(username, password string) {
+					// Mock the filesystem state of `kubernetes.io/basic-auth` type secret volume mount
+					file(filepath.Join(secret, "username"), 0400, []byte(username))
+					file(filepath.Join(secret, "password"), 0400, []byte(password))
+
+					withTempDir(func(target string) {
+						Expect(run(
+							"--url", "http://github.com/shipwright-io/sample-nodejs-private",
+							"--secret-path", secret,
+							"--target", target,
+						)).To(FailWith(shpgit.AuthUnexpectedHTTP))
+					})
+				})
+			})
+		})
 	})
 
 	Context("cloning repositories with submodules", func() {

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,7 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -402,6 +403,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=

--- a/pkg/git/error_parser.go
+++ b/pkg/git/error_parser.go
@@ -37,6 +37,8 @@ const (
 	AuthUnexpectedSSH
 	// AuthBasicIncomplete expresses that either username or password is missing in basic auth credentials
 	AuthBasicIncomplete
+	// AuthUnexpectedHTTP expresses that basic auth username and password are used in combination with a HTTP endpoint
+	AuthUnexpectedHTTP
 	// AuthInvalidKey expresses that ssh authentication is not possible
 	AuthInvalidKey
 	// RevisionNotFound expresses that a remote branch does not exist.
@@ -96,6 +98,8 @@ func (class ErrorClass) String() string {
 		return "GitSSHAuthUnexpected"
 	case AuthExpectedSSH:
 		return "GitSSHAuthExpected"
+	case AuthUnexpectedHTTP:
+		return "AuthUnexpectedHTTP"
 	}
 
 	return "GitError"
@@ -120,6 +124,8 @@ func (class ErrorClass) ToMessage() string {
 		return "Credential/URL inconsistency: No SSH credentials provided, but URL is a SSH Git URL."
 	case AuthBasicIncomplete:
 		return "Basic Auth incomplete: Both username and password need to be configured."
+	case AuthUnexpectedHTTP:
+		return "Refusing to continue with basic authentication (username and password) over insecure HTTP connection"
 	}
 
 	return "Git encountered an unknown error."

--- a/pkg/git/error_parser.go
+++ b/pkg/git/error_parser.go
@@ -164,10 +164,10 @@ func parseLine(line string) (*errorToken, error) {
 		return nil, errWrongFormat
 	}
 
-	prefixToken := parsePrefix(prefixBuilder.String())
-	errorClassToken := parseErrorMessage(errorMessage)
-
-	return &errorToken{classToken: errorClassToken, prefixToken: prefixToken}, nil
+	return &errorToken{
+		classToken:  parseErrorMessage(errorMessage),
+		prefixToken: parsePrefix(prefixBuilder.String()),
+	}, nil
 }
 
 func parsePrefix(raw string) prefixToken {


### PR DESCRIPTION
# Changes

Fixes https://github.com/shipwright-io/build/issues/1131
Fixes https://github.com/shipwright-io/build/issues/1133

Ref: https://github.com/shipwright-io/build/issues/1116

Check that basic auth is not used in combination with a HTTP endpoint.

Redact log output in case basic auth is used with inline user fields, i.e. `https://user:pass@url.com`.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The Git source step of a build strategy now returns a more elaborate error in case basic authentication (username and password) are used in combination with a HTTP URI. Instead of a generic error, an error message with an explanation is presented to be more clear and helpful. Also, inline credentials used in the URL will be redacted in the log output.
```

