### PR TITLE
Update setup-kubectl action from v1 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           version: v0.12.0
       - name: Install kubectl
-        uses: azure/setup-kubectl@v1
+        uses: azure/setup-kubectl@v3
         with:
           version: ${{ matrix.kubernetes }}
       - name: Create kind cluster
@@ -130,7 +130,7 @@ jobs:
           cache: true
           check-latest: true
       - name: Install kubectl
-        uses: azure/setup-kubectl@v1
+        uses: azure/setup-kubectl@v3
         with:
           version: ${{ matrix.kubernetes }}
       - name: Create kind cluster


### PR DESCRIPTION
# Changes

We are on a very old version of the azure/setup-kubectl action which is leading to this deprecation warning in our action run:

`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: azure/setup-kubectl@v1`

I am updating the action to v3.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
