### PR TITLE
Replace deprecated set-output by GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%s')"
+      run: echo "{date}={$(date +'%Y-%m-%d-%s')}" >> $GITHUB_OUTPUT
 
     - name: Generate and upload release YAMLs
       env:


### PR DESCRIPTION
# Changes

We have this deprecation:

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Based on the instructions, I rewrote the set-output command.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```