### PR TITLE
Include pkg directory

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -27,7 +27,7 @@ jobs:
           IMAGE: ${{ matrix.image }}
           LATEST_RELEASE_URL: ${{ matrix.latest-release-url }}
         run: |
-          for directory in docs samples test; do hack/check-latest-images.sh ${IMAGE} ${LATEST_RELEASE_URL} ${directory}; done
+          for directory in docs pkg samples test; do hack/check-latest-images.sh ${IMAGE} ${LATEST_RELEASE_URL} ${directory}; done
       - name: Check image change
         run: |
           echo "FROM=$(git diff --unified=0 | grep '^[-].*image: .*/.*/.*:' | head --lines=1 | cut --delimiter=':' --fields='3' | sed 's/[^[[:digit:].]//g')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Changes

There is a unit test case which is testing on the buildah image and currently fails in https://github.com/shipwright-io/build/pull/1145 with this error:

```
/home/runner/work/build/build/pkg/reconciler/buildrun/resources/taskrun_test.go:112

  [FAILED] Expected
      <string>: quay.io/containers/buildah:v1.28.0
  to equal
      <string>: quay.io/containers/buildah:v1.20.1
  In [It] at: /home/runner/work/build/build/pkg/reconciler/buildrun/resources/taskrun_test.go:113
```

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
