### PR TITLE
Remove unneeded find path

### DIFF
--- a/hack/generate-copyright.sh
+++ b/hack/generate-copyright.sh
@@ -28,8 +28,6 @@ function listDockerfiles() {
 function listBashFiles() {
   find . -name '*.sh' -not -path './vendor/*'
   local bashFiles=$?
-  find ./build/bin -type f
-  bashFiles="$bashFiles $?"
 }
 
 function listMarkdownFiles() {


### PR DESCRIPTION
# Changes

The build/ dir was removed via https://github.com/shipwright-io/build/pull/1171 but the generate-copyright.sh script was not updated accordingly. This fix it.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```

