### PR TITLE
Allow non-current user to own the directory which is built by ko

### DIFF
--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -71,6 +71,8 @@ spec:
           value: $(params.shp-output-image)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
+        - name: PARAM_SOURCE_ROOT
+          value: $(params.shp-source-root)
         - name: PARAM_TARGET_PLATFORM
           value: $(params.target-platform)
         - name: PARAM_PACKAGE_DIRECTORY
@@ -134,6 +136,11 @@ spec:
           # Print version information
           go version
           echo "ko version $(/tmp/ko version)"
+
+          # Allow directory to be owned by other user which is normal for a volume-mounted directory.
+          # This allows Go to run git commands to access repository metadata.
+          # Documentation: https://git-scm.com/docs/git-config/2.39.0#Documentation/git-config.txt-safedirectory
+          git config --global --add safe.directory "${PARAM_SOURCE_ROOT}"
 
           # Run ko
 


### PR DESCRIPTION
# Changes

Go is running some Git commands to determine version control information of the directory that it builds to attach them as metadata to the binary. This leads to BuildRun failures when the directory is not owned by the current user:

```txt
go version go1.19.6 linux/arm64
ko version 0.12.0
2023/02/25 11:42:10 Using base [registry.access.redhat.com/ubi9/ubi-minimal@sha256:085c5049f5bd0b3cb33c322306a528373f79dc6f1098ff8f5a5b28f2685c53f8](http://registry.access.redhat.com/ubi9/ubi-minimal@sha256:085c5049f5bd0b3cb33c322306a528373f79dc6f1098ff8f5a5b28f2685c53f8) for [github.com/shipwright-io/build/cmd/shipwright-build-controller](http://github.com/shipwright-io/build/cmd/shipwright-build-controller)
2023/02/25 11:42:10 Building [github.com/shipwright-io/build/cmd/shipwright-build-controller](http://github.com/shipwright-io/build/cmd/shipwright-build-controller) for linux/arm64
2023/02/25 11:42:11 Unexpected error running "go build": exit status 1
# cd /workspace/source; git status --porcelain
fatal: detected dubious ownership in repository at '/workspace/source'
To add an exception for this directory, call:

	git config --global --add [safe.directory](http://safe.directory/) /workspace/source
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

In Shipwright, it is more or less always the case that the user is not owning the directory. The reason is that `/workspace/source` is an emptyDir volume that root is owning.

The error already contains the solution that I am using = adding it as a safe directory.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The ko sample build strategy now make the source directory a Git safe directory so that Go builds can retrieve version control information
```