### PR TITLE
Remove incorrect curly brackets

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "{date}={$(date +'%Y-%m-%d-%s')}" >> $GITHUB_OUTPUT
+      run: echo "date=$(date +'%Y-%m-%d-%s')" >> $GITHUB_OUTPUT
 
     - name: Generate and upload release YAMLs
       env:


### PR DESCRIPTION
# Changes

I think, I mis-interpreted the documentation of https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter.

The curly brackets there are not to be included as it can later be seen in the example.

I am removing them. This should help fixing the nightly release build issues that we have.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
