### PR TITLE
Explicitly specify platforms

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -17,13 +17,13 @@ KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" GOFLAGS="${GO_FLAGS}" ko resol
   --base-import-paths \
   --tags "${TAG}" \
   --image-label "io.shipwright.vcs-ref=${GITHUB_SHA}" \
-  --platform=all -R -f deploy/ > release.yaml
+  --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -R -f deploy/ > release.yaml
 
 KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve \
   --base-import-paths \
   --tags "${TAG}-debug" \
   --image-label "io.shipwright.vcs-ref=${GITHUB_SHA}" \
-  --platform=all -R -f deploy/ > release-debug.yaml
+  --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -R -f deploy/ > release-debug.yaml
 
 # Bundle the sample cluster build strategies, remove namespace strategies first
 find samples/buildstrategy -type f -print0 | xargs -0 grep -l "kind: BuildStrategy" | xargs rm -f


### PR DESCRIPTION
# Changes

The nightly build is still failing like in https://github.com/shipwright-io/build/actions/runs/4361360241/jobs/7625184623.

I tracked it down to the ko builds failing when using `--platform=all`. For example, this fails: `ko build --base-import-paths --platform all ./cmd/waiter --push=false`.

But, this works: `ko build --base-import-paths --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x ./cmd/waiter --push=false`

The reason is that the first command tries to build for an os/arch combination unknown/unknown. This is the case because ko takes the platforms (in case of all) from the manifest of the base image. The base images for git and waiter are built by us using docker buildx. I think since the last BuildKit update, this includes attestations. So if you run `crane manifest ghcr.io/shipwright-io/base-waiter:latest`, you will find the four images for our four platforms, plus four more entries with `"vnd.docker.reference.type": "attestation-manifest"` and they have os and architecture set to unknown.

I'll check seperately whether ko is already handling this in the latest code (there has not been a ko release since August).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```