### PR TITLE
fix: buildkit insecure registry image caching

### DIFF
--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -118,7 +118,7 @@ spec:
           echo "--output=type=image,name=\"${PARAM_OUTPUT_IMAGE}\",push=true,registry.insecure=\"${PARAM_INSECURE_REGISTRY}\" \\" >> /tmp/run.sh
           if [ "${PARAM_CACHE}" == "registry" ]; then
             echo "--export-cache=type=inline \\" >> /tmp/run.sh
-            echo "--import-cache=type=registry,ref=\"${PARAM_OUTPUT_IMAGE}\" \\" >> /tmp/run.sh
+            echo "--import-cache=type=registry,ref=\"${PARAM_OUTPUT_IMAGE}\",registry.insecure=\"${PARAM_INSECURE_REGISTRY}\" \\" >> /tmp/run.sh
           elif [ "${PARAM_CACHE}" == "disabled" ]; then
             echo "--no-cache \\" >> /tmp/run.sh
           else


### PR DESCRIPTION
https://github.com/moby/buildkit/commit/7bd72856ad4d403260a6f68c31977c72c2d1d8ce

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fix buildkit cluster build strategy's cache import from insecure registry.

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fix buildkit cluster build strategy's cache import from insecure registry.
```
