### PR TITLE
Update ko to v0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install Ko
         uses: ko-build/setup-ko@v0.6
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Install kubectl
         uses: azure/setup-kubectl@v3
         with:
@@ -173,7 +173,7 @@ jobs:
       - name: Install Ko
         uses: ko-build/setup-ko@v0.6
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Install Shipwright Build
         run: |
           make install-controller-kind

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -29,7 +29,7 @@ jobs:
     # Install tools
     - uses: ko-build/setup-ko@v0.6
       with:
-        version: v0.12.0
+        version: v0.13.0
     - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4
     - uses: sigstore/cosign-installer@v2.5.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
     # Install tools
     - uses: ko-build/setup-ko@v0.6
       with:
-        version: v0.12.0
+        version: v0.13.0
     - uses: sigstore/cosign-installer@v2.5.0
 
     - name: Build Release Changelog


### PR DESCRIPTION
# Changes

Updated solution for https://github.com/shipwright-io/build/pull/1230#issue-1615912566

Updating ko to v0.13 to pick up the fix [fix: handle docker's unknown/unknown platform in index manifests #975](https://github.com/ko-build/ko/pull/975) to resolve the problems in our nightly builds.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes
```release-note
NONE
```
