### PR TITLE
Update cosign action

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,7 +31,7 @@ jobs:
       with:
         version: v0.13.0
     - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4
-    - uses: sigstore/cosign-installer@v2.5.0
+    - uses: sigstore/cosign-installer@v3
 
     - name: Get current date
       id: date
@@ -64,12 +64,6 @@ jobs:
         done
 
     - name: Sign released images
-      env:
-        # This enables keyless mode
-        # (https://github.com/sigstore/cosign/blob/main/KEYLESS.md) which signs
-        # images using an ephemeral key tied to the GitHub Actions identity via
-        # OIDC.
-        COSIGN_EXPERIMENTAL: "true"
       run: |
         for f in \
           nightly-${{ steps.date.outputs.date }}.yaml \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
     - uses: ko-build/setup-ko@v0.6
       with:
         version: v0.13.0
-    - uses: sigstore/cosign-installer@v2.5.0
+    - uses: sigstore/cosign-installer@v3
 
     - name: Build Release Changelog
       env:
@@ -74,12 +74,6 @@ jobs:
         gh release upload ${TAG} sample-strategies.yaml
 
     - name: Sign released images
-      env:
-        # This enables keyless mode
-        # (https://github.com/sigstore/cosign/blob/main/KEYLESS.md) which signs
-        # images using an ephemeral key tied to the GitHub Actions identity via
-        # OIDC.
-        COSIGN_EXPERIMENTAL: "true"
       run: |
         grep -o "ghcr.io[^\"]*" release.yaml | xargs cosign sign \
             -a sha=${{ github.sha }} \


### PR DESCRIPTION
# Changes

The nightly build is still failing. https://github.com/shipwright-io/build/actions/runs/4508014260/jobs/7936340125

Not completely sure why. I am updating to the latest action that installs cosign, and ~I am changing the env var value from `true` to `1` based on the documentation~ I am removing the env var based on https://blog.sigstore.dev/cosign-2-0-released/.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
