### PR TITLE
Ensure transparency logs confirmation is not interactive

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -68,7 +68,7 @@ jobs:
         for f in \
           nightly-${{ steps.date.outputs.date }}.yaml \
           nightly-${{ steps.date.outputs.date }}-debug.yaml; do
-          grep -o "ghcr.io[^\"]*" $f | xargs cosign sign \
+          grep -o "ghcr.io[^\"]*" $f | xargs cosign sign --yes \
               -a sha=${{ github.sha }} \
               -a run_id=${{ github.run_id }} \
               -a run_attempt=${{ github.run_attempt }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Sign released images
       run: |
-        grep -o "ghcr.io[^\"]*" release.yaml | xargs cosign sign \
+        grep -o "ghcr.io[^\"]*" release.yaml | xargs cosign sign --yes \
             -a sha=${{ github.sha }} \
             -a run_id=${{ github.run_id }} \
             -a run_attempt=${{ github.run_attempt }}


### PR DESCRIPTION
# Changes

Ensure interactive prompt is disabled by adding the requires --yes flag. Fixes current issues with the nightly releases.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE


# Release Notes

```release-note
NONE
```
