### PR TITLE
Add `platform` to `install-controller-kind` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,11 @@ install-controller: install-apis
 
 .PHONY: install-controller-kind
 install-controller-kind: install-apis
-	KO_DOCKER_REPO=kind.local GOFLAGS="$(GO_FLAGS)" ko apply -f deploy/
+	KO_DOCKER_REPO=kind.local \
+	GOFLAGS="$(GO_FLAGS)" \
+	ko apply \
+	  --platform=$(GO_OS)/$(GO_ARCH) \
+	  --filename=deploy
 
 .PHONY: install-strategies
 install-strategies: install-apis


### PR DESCRIPTION
# Changes

On M1/M2 macOS machines, it can happen that the KinD setup uses `arm64` node images and `ko` wants to match the system OS and architecture. However, the base images Shipwright relies on do not support a platform like `darwin/arm64`.

Add `--platform=linux/$(GO_ARCH)` to enforce that `ko` build Linux images with the respective current system architecture.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
