### PR TITLE
SHIP-0036: Option 1: Part 1: Update Git base image to allow an arbitrary user to run it

### DIFF
--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -8,9 +8,12 @@ RUN \
   microdnf --assumeyes --nodocs install git git-lfs && \
   microdnf clean all && \
   rm -rf /var/cache/yum && \
-  echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
-  echo 'nonroot:x:1000:' > /etc/group && \
-  mkdir /.docker && chown 1000:1000 /.docker && \
-  mkdir /.ssh && chown 1000:1000 /.ssh
+  # The following setup is necessary so that this image can run as any user
+  mkdir -p /shared-home/.docker /shared-home/.ssh && chmod -R 0777 /shared-home && \
+  # ssh, which is required for Git clone using SSH, will require an entry in /etc/passwd,
+  # as we do not know the user/group combination, we allow the user to register itself.
+  # The runtime privileges of the container will prevent a switch to root.
+  echo -n > /etc/passwd && chmod 0666 /etc/passwd && \
+  echo -n > /etc/groups && chmod 0666 /etc/groups
 
-USER 1000:1000
+ENV HOME /shared-home


### PR DESCRIPTION
# Changes

/hold

This is part of the implementation of [SHIP-0036: RunAs user and group for supporting steps](https://github.com/shipwright-io/community/pull/131).

This pull request changes the base image for the Git step based on https://github.com/SaschaSchwarze0/community/blob/sascha-0036-runas-user/ships/0036-runAs-for-supporting-steps.md#base-image-changes.

I am marking this as HOLD because a rollout must be coordinated with the PR [SHIP-0036: Part 2: Update runtime logic to use a common runAsUser and runAsGroup in the steps when possible #1264](https://github.com/shipwright-io/build/pull/1264). Once both are approved, then

* The HOLD will be removed here so that it gets merged.
* A manual run of the [base images build](https://github.com/shipwright-io/build/actions/workflows/base-images.yaml) will be triggered.
* The temporary commit in the other PR will be removed so that it uses the new Git base image.
* The HOLD label on the other PR will be removed.
* After the tests finished, the other PR will be merged.
* All existing pull requests will need to be rebased when changes are made because the old code cannot run with the new Git base image.

I am omiting a release note here in favor of providing one on the other PR.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```