### PR TITLE
SHIP-0036: Part 1: Update base images to allow an arbitrary user to run it

### DIFF
--- a/.github/workflows/base-images.yaml
+++ b/.github/workflows/base-images.yaml
@@ -7,16 +7,18 @@ on:
 
 jobs:
   base-image-build:
-    if: ${{ github.repository == 'shipwright-io/build' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         image:
+          - base
           - git
           - image-processing
           - waiter
-      max-parallel: 3
+      # We cannot run in parallel because the base image must be built first
+      max-parallel: 1
 
     steps:
       - uses: actions/checkout@v3
@@ -36,4 +38,4 @@ jobs:
         working-directory: images/${{ matrix.image }}
         run: |
           NAMESPACE=$(tr '[:upper:]' '[:lower:]' <<<${{ github.repository_owner }})
-          IMAGE=ghcr.io/${NAMESPACE}/base-${{ matrix.image }} docker buildx bake --push -f ../docker-bake.hcl
+          IMAGE=ghcr.io/${NAMESPACE}/base-${{ matrix.image }} NAMESPACE="${NAMESPACE}" docker buildx bake --push -f ../docker-bake.hcl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         image:
-        - git
-        - image-processing
-        - waiter
+          - base
+          - git
+          - image-processing
+          - waiter
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -48,7 +49,8 @@ jobs:
       - name: Build Image
         working-directory: images/${{ matrix.image }}
         run: |
-          IMAGE=test-build/base-${{ matrix.image }} docker buildx bake --file ../docker-bake.hcl
+          NAMESPACE=$(tr '[:upper:]' '[:lower:]' <<<${{ github.repository_owner }})
+          IMAGE=test-build/base-${{ matrix.image }} NAMESPACE="${NAMESPACE}" docker buildx bake --file ../docker-bake.hcl
 
   integration:
     strategy:

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+FROM registry.access.redhat.com/ubi9-minimal:latest
+
+RUN \
+  microdnf --refresh --assumeyes --best --nodocs --noplugins --setopt=install_weak_deps=0 upgrade && \
+  microdnf clean all && \
+  rm -rf /var/cache/yum && \
+  # The following setup is necessary so that this image can run as any user
+  mkdir -p /shared-home/.docker /shared-home/.ssh && chmod -R 0777 /shared-home && \
+  # This is the default user that will be used when strategy steps use different runAs configuration.
+  # This must be in synchronization with our default configuration.
+  echo "shp:x:1000:1000:shp:/shared-home:/sbin/nologin" >/etc/passwd && \
+  echo "shp:x:1000" >/etc/group
+
+ENV HOME /shared-home

--- a/images/docker-bake.hcl
+++ b/images/docker-bake.hcl
@@ -1,11 +1,19 @@
 variable "IMAGE" {
 }
 
+variable "NAMESPACE" {
+}
+
 group "default" {
 	targets = ["all"]
 }
 
 target "all" {
+	args = {
+		BASE = "ghcr.io/${NAMESPACE}/base-base"
+	}
 	tags = ["${IMAGE}:latest"]
 	platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 }
+
+

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -1,16 +1,14 @@
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi9-minimal:latest
+
+ARG BASE
+
+FROM ${BASE}
 
 RUN \
-  microdnf --refresh --assumeyes --best --nodocs --noplugins --setopt=install_weak_deps=0 upgrade && \
   microdnf --assumeyes --nodocs install git git-lfs && \
   microdnf clean all && \
-  rm -rf /var/cache/yum && \
-  echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
-  echo 'nonroot:x:1000:' > /etc/group && \
-  mkdir /.docker && chown 1000:1000 /.docker && \
-  mkdir /.ssh && chown 1000:1000 /.ssh
+  rm -rf /var/cache/yum
 
 USER 1000:1000

--- a/images/image-processing/Dockerfile
+++ b/images/image-processing/Dockerfile
@@ -1,6 +1,8 @@
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+ARG BASE
+
 FROM registry.access.redhat.com/ubi9-minimal:latest AS bin-loader
 RUN \
   microdnf --assumeyes --nodocs install gzip jq tar && \
@@ -8,13 +10,8 @@ RUN \
   curl -L -s "https://github.com/aquasecurity/trivy/releases/download/${TAG_NAME}/trivy_${TAG_NAME/v/}_$(uname -s)-$(uname -m | sed -e 's/aarch64/ARM64/' -e 's/ppc64le/PPC64LE/' -e 's/x86_64/64bit/').tar.gz" | tar -xzf - -C /usr/local/bin trivy
 
 
-FROM registry.access.redhat.com/ubi9-minimal:latest
+FROM ${BASE}
+
 COPY --from=bin-loader /usr/local/bin/trivy /usr/local/bin/trivy
-RUN \
-  microdnf --refresh --assumeyes --best --nodocs --noplugins --setopt=install_weak_deps=0 upgrade && \
-  microdnf clean all && \
-  rm -rf /var/cache/yum && \
-  echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
-  echo 'nonroot:x:1000:' > /etc/group
 
 USER 1000:1000

--- a/images/waiter/Dockerfile
+++ b/images/waiter/Dockerfile
@@ -1,16 +1,14 @@
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi9-minimal:latest
+
+ARG BASE
+
+FROM ${BASE}
 
 RUN \
-  microdnf --refresh --assumeyes --best --nodocs --noplugins --setopt=install_weak_deps=0 upgrade && \
   microdnf --assumeyes --nodocs install tar && \
   microdnf clean all && \
-  rm -rf /var/cache/yum && \
-  echo 'nonroot:x:1000:1000:nonroot:/:/sbin/nologin' > /etc/passwd && \
-  echo 'nonroot:x:1000:' > /etc/group && \
-  mkdir /.docker && \
-  chown 1000:1000 /.docker
+  rm -rf /var/cache/yum
 
 USER 1000:1000


### PR DESCRIPTION
# Changes

This is part one of the implementation of [SHIP-0036: RunAs user and group for supporting steps](https://github.com/shipwright-io/community/pull/131).

This pull request changes the base images for the supporting steps:

* A common base image is introduced which ensures that the base packages are all up-to-date, which contains a world-writable `/shared-home` directory and an `/etc/passwd` and `/etc/group` file that is setup for user/group 1000/1000 to match our default configuration for supporting steps.
* git, image-processing, and waiter are adjusted to consume the common base image

The tests for this pull request cannot succeed. The reason is that we build here the images, but the Dockerfiles now require a common base image that will only be pushed AFTER this PR is merged. We will have to merge red. A successful run of the new Dockerfiles can be seen here: https://github.com/SaschaSchwarze0/build/actions/runs/4700899916. The images built by this run are used temporarily in the part 2 pull request.

I am marking this as HOLD because the ship is not yet merged a rollout must be coordinated with the PR [SHIP-0036: Part 2: Introduce securityContext for build strategy spec #1266](https://github.com/shipwright-io/build/pull/1266). Once both are approved, then

* The HOLD will be removed here so that it gets merged.
* A manual run of the [base images build](https://github.com/shipwright-io/build/actions/workflows/base-images.yaml) will be triggered.
* The temporary commit in the other PR will be removed so that it uses the new base images.
* The HOLD label on the other PR will be removed.
* After the tests finished, the other PR will be merged.
* All existing pull requests will need to be rebased when changes are made because the old code cannot run with the new base images.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Introduce a common base image for all supporting steps
```
