### PR TITLE
Add `syft` to `image-process` `Dockerfile`

### DIFF
--- a/images/image-processing/Dockerfile
+++ b/images/image-processing/Dockerfile
@@ -2,14 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 FROM registry.access.redhat.com/ubi9-minimal:latest AS bin-loader
+RUN microdnf --assumeyes --nodocs install gzip jq tar
+
 RUN \
-  microdnf --assumeyes --nodocs install gzip jq tar && \
   TAG_NAME="$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | jq -r '.tag_name')" && \
   curl -L -s "https://github.com/aquasecurity/trivy/releases/download/${TAG_NAME}/trivy_${TAG_NAME/v/}_$(uname -s)-$(uname -m | sed -e 's/aarch64/ARM64/' -e 's/ppc64le/PPC64LE/' -e 's/x86_64/64bit/').tar.gz" | tar -xzf - -C /usr/local/bin trivy
 
+RUN \
+  curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+    | sh -s -- -b /usr/local/bin
 
 FROM registry.access.redhat.com/ubi9-minimal:latest
-COPY --from=bin-loader /usr/local/bin/trivy /usr/local/bin/trivy
+COPY --from=bin-loader /usr/local/bin /usr/local/bin
 RUN \
   microdnf --refresh --assumeyes --best --nodocs --noplugins --setopt=install_weak_deps=0 upgrade && \
   microdnf clean all && \


### PR DESCRIPTION
# Changes

Add `syft` tool for SBOM creation to the `image-process` `Dockerfile` in preparation for use cases that require this tool to be available.

Please note: This image is actually not in use at the moment. The current `image-process` build is still using the default base image. If this is intended to be changed, we can do this with this PR as well.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

