### PR TITLE
Fix remaining reference to `mutate-image`

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Config", func() {
 			})
 		})
 
-		It("should allow for an override of the Mutate-Image container template and image", func() {
+		It("should allow for an override of the image-processing container template and image", func() {
 			overrides := map[string]string{
 				"IMAGE_PROCESSING_CONTAINER_TEMPLATE": `{"image":"myregistry/custom/image-processing","resources":{"requests":{"cpu":"0.5","memory":"128Mi"}}}`,
 				"IMAGE_PROCESSING_CONTAINER_IMAGE":    "myregistry/custom/image-processing:override",

--- a/pkg/reconciler/buildrun/resources/image_processing.go
+++ b/pkg/reconciler/buildrun/resources/image_processing.go
@@ -27,17 +27,17 @@ func SetupImageProcessing(taskRun *pipeline.TaskRun, cfg *config.Config, buildOu
 	// Check if any build step references the output-directory system parameter. If that is the case,
 	// then we assume that Shipwright performs the image push operation.
 	volumeAdded := false
-	prefixedOuputDirectory := fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, paramOutputDirectory)
+	prefixedOutputDirectory := fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, paramOutputDirectory)
 	for i := range taskRun.Spec.TaskSpec.Steps {
 		step := taskRun.Spec.TaskSpec.Steps[i]
 
-		if isStepReferencingParameter(&step, prefixedOuputDirectory) {
+		if isStepReferencingParameter(&step, prefixedOutputDirectory) {
 			if !volumeAdded {
 				volumeAdded = true
 
 				// add an emptyDir volume for the output directory
 				taskRun.Spec.TaskSpec.Volumes = append(taskRun.Spec.TaskSpec.Volumes, core.Volume{
-					Name: prefixedOuputDirectory,
+					Name: prefixedOutputDirectory,
 					VolumeSource: core.VolumeSource{
 						EmptyDir: &core.EmptyDirVolumeSource{},
 					},
@@ -45,13 +45,13 @@ func SetupImageProcessing(taskRun *pipeline.TaskRun, cfg *config.Config, buildOu
 
 				// add the parameter definition
 				taskRun.Spec.TaskSpec.Params = append(taskRun.Spec.TaskSpec.Params, pipeline.ParamSpec{
-					Name: prefixedOuputDirectory,
+					Name: prefixedOutputDirectory,
 					Type: pipeline.ParamTypeString,
 				})
 
 				// add the parameter value
 				taskRun.Spec.Params = append(taskRun.Spec.Params, pipeline.Param{
-					Name: prefixedOuputDirectory,
+					Name: prefixedOutputDirectory,
 					Value: pipeline.ArrayOrString{
 						StringVal: outputDirectoryMountPath,
 						Type:      pipeline.ParamTypeString,
@@ -64,7 +64,7 @@ func SetupImageProcessing(taskRun *pipeline.TaskRun, cfg *config.Config, buildOu
 
 			// add a volumeMount to the step
 			taskRun.Spec.TaskSpec.Steps[i].VolumeMounts = append(taskRun.Spec.TaskSpec.Steps[i].VolumeMounts, core.VolumeMount{
-				Name:      prefixedOuputDirectory,
+				Name:      prefixedOutputDirectory,
 				MountPath: outputDirectoryMountPath,
 			})
 		}
@@ -103,7 +103,7 @@ func SetupImageProcessing(taskRun *pipeline.TaskRun, cfg *config.Config, buildOu
 
 		if volumeAdded {
 			imageProcessingStep.VolumeMounts = append(imageProcessingStep.VolumeMounts, core.VolumeMount{
-				Name:      prefixedOuputDirectory,
+				Name:      prefixedOutputDirectory,
 				MountPath: outputDirectoryMountPath,
 				ReadOnly:  true,
 			})
@@ -132,7 +132,7 @@ func SetupImageProcessing(taskRun *pipeline.TaskRun, cfg *config.Config, buildOu
 	}
 }
 
-// convertMutateArgs to convert the argument map to comma seprated values
+// convertMutateArgs to convert the argument map to comma separated values
 func convertMutateArgs(flag string, args map[string]string) []string {
 	var result []string
 

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -334,8 +334,8 @@ var _ = Describe("GenerateTaskrun", func() {
 					Expect(err).To(BeNil())
 				})
 
-				It("should contain a step to mutate the image with labels and annotations merged from build and buildrun", func() {
-					Expect(got.Steps[3].Name).To(Equal("mutate-image"))
+				It("should contain an image-processing step to mutate the image with labels and annotations merged from build and buildrun", func() {
+					Expect(got.Steps[3].Name).To(Equal("image-processing"))
 					Expect(got.Steps[3].Command[0]).To(Equal("/ko-app/image-processing"))
 					Expect(got.Steps[3].Args).To(Equal([]string{
 						"--image",
@@ -375,8 +375,8 @@ var _ = Describe("GenerateTaskrun", func() {
 					Expect(err).To(BeNil())
 				})
 
-				It("should contain a step to mutate the image with labels and annotations merged from build and buildrun", func() {
-					Expect(got.Steps[3].Name).To(Equal("mutate-image"))
+				It("should contain an image-processing step to mutate the image with labels and annotations merged from build and buildrun", func() {
+					Expect(got.Steps[3].Name).To(Equal("image-processing"))
 					Expect(got.Steps[3].Command[0]).To(Equal("/ko-app/image-processing"))
 					Expect(got.Steps[3].Args).To(Equal([]string{
 						"--image",

--- a/test/integration/build_to_taskruns_test.go
+++ b/test/integration/build_to_taskruns_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Integration tests Build and TaskRun", func() {
 		})
 
 		Context("when creating the taskrun", func() {
-			It("should contain a step to mutate the image", func() {
+			It("should contain an image-processing step to mutate the image", func() {
 				buildObject.Spec.Output.Annotations =
 					map[string]string{
 						"org.opencontainers.image.url": "https://my-company.com/images",


### PR DESCRIPTION
# Changes

Rename remaining mutate image reference to image processing.

Fix TYPO in variable name.

FIX TYPO in comment.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
