### PR TITLE
Replace `LayerFromReader` with `LayerFromOpener` in bundle package

### DIFF
--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -5,31 +5,88 @@
 package bundle_test
 
 import (
+	"fmt"
+	"log"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	. "github.com/shipwright-io/build/pkg/bundle"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 var _ = Describe("Bundle", func() {
+	withTempDir := func(f func(tempDir string)) {
+		tempDir, err := os.MkdirTemp("", "bundle")
+		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(tempDir)
+		f(tempDir)
+	}
+
+	withTempRegistry := func(f func(endpoint string)) {
+		logLogger := log.Logger{}
+		logLogger.SetOutput(GinkgoWriter)
+
+		s := httptest.NewServer(
+			registry.New(
+				registry.Logger(&logLogger),
+				registry.WithReferrersSupport(true),
+			),
+		)
+		defer s.Close()
+
+		u, err := url.Parse(s.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		f(u.Host)
+	}
+
 	Context("packing and unpacking", func() {
 		It("should pack and unpack a directory", func() {
-			r, err := Pack(filepath.Join("..", "..", "test", "bundle"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(r).ToNot(BeNil())
+			withTempDir(func(tempDir string) {
+				r, err := Pack(filepath.Join("..", "..", "test", "bundle"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(r).ToNot(BeNil())
 
-			tempDir, err := os.MkdirTemp("", "bundle")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(tempDir)
+				Expect(Unpack(r, tempDir)).To(Succeed())
+				Expect(filepath.Join(tempDir, "README.md")).To(BeAnExistingFile())
+				Expect(filepath.Join(tempDir, ".someToolDir", "config.json")).ToNot(BeAnExistingFile())
+				Expect(filepath.Join(tempDir, "somefile")).To(BeAnExistingFile())
+				Expect(filepath.Join(tempDir, "linktofile")).To(BeAnExistingFile())
+			})
+		})
+	})
 
-			Expect(Unpack(r, tempDir)).To(Succeed())
-			Expect(filepath.Join(tempDir, "README.md")).To(BeAnExistingFile())
-			Expect(filepath.Join(tempDir, ".someToolDir", "config.json")).ToNot(BeAnExistingFile())
-			Expect(filepath.Join(tempDir, "somefile")).To(BeAnExistingFile())
-			Expect(filepath.Join(tempDir, "linktofile")).To(BeAnExistingFile())
+	Context("packing/pushing and pulling/unpacking", func() {
+		It("should pull and unpack an image", func() {
+			withTempRegistry(func(endpoint string) {
+				ref, err := name.ParseReference(fmt.Sprintf("%s/namespace/unit-test-pkg-bundle-%s:latest", endpoint, rand.String(5)))
+				Expect(err).ToNot(HaveOccurred())
+
+				By("packing and pushing an image", func() {
+					_, err := PackAndPush(ref, filepath.Join("..", "..", "test", "bundle"))
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				By("pulling and unpacking the image", func() {
+					withTempDir(func(tempDir string) {
+						image, err := PullAndUnpack(ref, tempDir)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(image).ToNot(BeNil())
+
+						Expect(filepath.Join(tempDir, "README.md")).To(BeAnExistingFile())
+						Expect(filepath.Join(tempDir, ".someToolDir", "config.json")).ToNot(BeAnExistingFile())
+						Expect(filepath.Join(tempDir, "somefile")).To(BeAnExistingFile())
+						Expect(filepath.Join(tempDir, "linktofile")).To(BeAnExistingFile())
+					})
+				})
+			})
 		})
 	})
 })

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("Bundle", func() {
 	Context("packing and unpacking", func() {
 		It("should pack and unpack a directory", func() {
-			r, err := Pack("../../test/bundle")
+			r, err := Pack(filepath.Join("..", "..", "test", "bundle"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(r).ToNot(BeNil())
 
@@ -25,13 +25,9 @@ var _ = Describe("Bundle", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll(tempDir)
 
-			err = Unpack(r, tempDir)
-			Expect(err).ToNot((HaveOccurred()))
-
+			Expect(Unpack(r, tempDir)).To(Succeed())
 			Expect(filepath.Join(tempDir, "README.md")).To(BeAnExistingFile())
-
 			Expect(filepath.Join(tempDir, ".someToolDir", "config.json")).ToNot(BeAnExistingFile())
-
 			Expect(filepath.Join(tempDir, "somefile")).To(BeAnExistingFile())
 			Expect(filepath.Join(tempDir, "linktofile")).To(BeAnExistingFile())
 		})


### PR DESCRIPTION
# Changes

Add test case to test the push and pull flow in the package.

Change `Pack` signature to return `io.ReadCloser` to then use `os.Pipe` instead of bytes buffer to have the `ReadCloser` available. Use `LayerFromOpener` with a custom opener based on `Pack` to get rid of the deprecation warning.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
