### PR TITLE
Refactor `image-processing` unit tests

### DIFF
--- a/cmd/image-processing/main_test.go
+++ b/cmd/image-processing/main_test.go
@@ -7,77 +7,74 @@ package main_test
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
 
-	"github.com/google/go-containerregistry/pkg/authn"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/shipwright-io/build/cmd/image-processing"
+
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	containerreg "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
-
-	. "github.com/shipwright-io/build/cmd/image-processing"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 var _ = Describe("Image Processing Resource", func() {
 	run := func(args ...string) error {
-		log.SetOutput(io.Discard)
+		log.SetOutput(GinkgoWriter)
 
 		// `pflag.Parse()` parses the command-line flags from os.Args[1:]
 		// appending `tool`(can be anything) at beginning of args array
 		// to avoid trimming the args we pass
 		os.Args = append([]string{"tool"}, args...)
 
+		// Simulate 2>/dev/null redirect as of now, there is no test case
+		// that checks the Stderr output of the command-line tool
+		tmp := os.Stderr
+		defer func() { os.Stderr = tmp }()
+		os.Stderr = nil
+
 		return Execute(context.Background())
 	}
 
-	const (
-		regUser   = "REGISTRY_USERNAME"
-		regPass   = "REGISTRY_PASSWORD"
-		imageHost = "IMAGE_HOST"
-		image     = "IMAGE"
-	)
-
-	BeforeEach(func() {
-		for _, env := range []string{regUser, regPass, imageHost, image} {
-			if _, ok := os.LookupEnv(env); !ok {
-				Skip(fmt.Sprintf("Skipping test case, because environment variable %s is not set", env))
-			}
-		}
-	})
-
-	resetFlags := func() {
+	AfterEach(func() {
 		// Reset flag variables
 		pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
-	}
-
-	AfterEach(func() {
-		resetFlags()
 	})
 
-	imageURL := fmt.Sprintf("%s/%s", os.Getenv(imageHost), os.Getenv(image))
+	withTempRegistry := func(f func(endpoint string)) {
+		logLogger := log.Logger{}
+		logLogger.SetOutput(GinkgoWriter)
 
-	pushImage := func(version string) name.Tag {
-		auth := authn.FromConfig(authn.AuthConfig{
-			Username: os.Getenv(regUser),
-			Password: os.Getenv(regPass),
-		})
+		s := httptest.NewServer(
+			registry.New(
+				registry.Logger(&logLogger),
+				registry.WithReferrersSupport(true),
+			),
+		)
+		defer s.Close()
 
-		tag, err := name.NewTag(fmt.Sprintf("%s:%s", imageURL, version))
+		u, err := url.Parse(s.URL)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(remote.Write(
-			tag,
-			empty.Image,
-			remote.WithAuth(auth),
-		)).ToNot(HaveOccurred())
+		f(u.Host)
+	}
 
-		return tag
+	withTestImage := func(f func(tag name.Tag)) {
+		withTempRegistry(func(endpoint string) {
+			tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", endpoint, "temp-image", rand.String(5)))
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(remote.Write(tag, empty.Image)).To(Succeed())
+			f(tag)
+		})
 	}
 
 	getCompressedImageSize := func(img containerreg.Image) int64 {
@@ -95,15 +92,10 @@ var _ = Describe("Image Processing Resource", func() {
 	}
 
 	getImageConfigLabel := func(image, label string) string {
-		auth := authn.FromConfig(authn.AuthConfig{
-			Username: os.Getenv(regUser),
-			Password: os.Getenv(regPass),
-		})
-
 		ref, err := name.ParseReference(image)
 		Expect(err).ToNot(HaveOccurred())
 
-		img, err := remote.Image(ref, remote.WithAuth(auth))
+		img, err := remote.Image(ref)
 		Expect(err).ToNot(HaveOccurred())
 
 		config, err := img.ConfigFile()
@@ -113,15 +105,10 @@ var _ = Describe("Image Processing Resource", func() {
 	}
 
 	getImageAnnotation := func(image, annotation string) string {
-		auth := authn.FromConfig(authn.AuthConfig{
-			Username: os.Getenv(regUser),
-			Password: os.Getenv(regPass),
-		})
-
 		ref, err := name.ParseReference(image)
 		Expect(err).ToNot(HaveOccurred())
 
-		img, err := remote.Image(ref, remote.WithAuth(auth))
+		img, err := remote.Image(ref)
 		Expect(err).ToNot(HaveOccurred())
 
 		manifest, err := img.Manifest()
@@ -138,15 +125,6 @@ var _ = Describe("Image Processing Resource", func() {
 		f(file.Name())
 	}
 
-	withDockerConfigJSON := func(f func(dockerConfigJSONPath string)) {
-		withTempFile("docker.config", func(tempFile string) {
-			err := os.WriteFile(tempFile, ([]byte(fmt.Sprintf("{\"auths\":{%q:{\"username\":%q,\"password\":%q}}}", os.Getenv(imageHost), os.Getenv(regUser), os.Getenv(regPass)))), 0644)
-			Expect(err).ToNot(HaveOccurred())
-
-			f(tempFile)
-		})
-	}
-
 	filecontent := func(path string) string {
 		data, err := os.ReadFile(path)
 		Expect(err).ToNot(HaveOccurred())
@@ -154,15 +132,10 @@ var _ = Describe("Image Processing Resource", func() {
 	}
 
 	getImage := func(tag name.Tag) containerreg.Image {
-		auth := authn.FromConfig(authn.AuthConfig{
-			Username: os.Getenv(regUser),
-			Password: os.Getenv(regPass),
-		})
-
 		ref, err := name.ParseReference(tag.String())
 		Expect(err).ToNot(HaveOccurred())
 
-		desc, err := remote.Get(ref, remote.WithAuth(auth))
+		desc, err := remote.Get(ref)
 		Expect(err).ToNot(HaveOccurred())
 
 		img, err := desc.Image()
@@ -193,177 +166,132 @@ var _ = Describe("Image Processing Resource", func() {
 
 		It("should fail in case --image does not exist", func() {
 			Expect(run(
-				"--image",
-				"docker.io/feqlQoDIHc/bcfHFHHXYF",
+				"--image", "docker.io/feqlQoDIHc/bcfHFHHXYF",
 			)).To(HaveOccurred())
 		})
 
 		It("should fail in case annotation is invalid", func() {
-			tag := pushImage("test1")
-
-			Expect(run(
-				"--image",
-				tag.String(),
-				"--annotation",
-				"org.opencontainers.image.url*https://my-company.com/images",
-			)).To(HaveOccurred())
+			withTestImage(func(tag name.Tag) {
+				Expect(run(
+					"--image", tag.String(),
+					"--annotation", "org.opencontainers.image.url*https://my-company.com/images",
+				)).To(HaveOccurred())
+			})
 		})
 
 		It("should fail in case label is invalid", func() {
-			tag := pushImage("test2")
-
-			Expect(run(
-				"--image",
-				tag.String(),
-				"--label",
-				" description*image description",
-			)).To(HaveOccurred())
+			withTestImage(func(tag name.Tag) {
+				Expect(run(
+					"--image", tag.String(),
+					"--label", " description*image description",
+				)).To(HaveOccurred())
+			})
 		})
 	})
 
 	Context("mutating the image", func() {
 		It("should mutate an image with single annotation", func() {
-			tag := pushImage("test3")
-
-			withDockerConfigJSON(func(dockerConfigJSONPath string) {
+			withTestImage(func(tag name.Tag) {
 				Expect(run(
-					"--image",
-					tag.String(),
-					"--annotation",
-					"org.opencontainers.image.url=https://my-company.com/images",
-					"--secret-path",
-					dockerConfigJSONPath,
+					"--insecure",
+					"--image", tag.String(),
+					"--annotation", "org.opencontainers.image.url=https://my-company.com/images",
 				)).ToNot(HaveOccurred())
-			})
 
-			Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.url")).
-				To(Equal("https://my-company.com/images"))
+				Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.url")).
+					To(Equal("https://my-company.com/images"))
+			})
 		})
 
 		It("should mutate an image with multiple annotations", func() {
-			tag := pushImage("test4")
-
-			withDockerConfigJSON(func(dockerConfigJSONPath string) {
+			withTestImage(func(tag name.Tag) {
 				Expect(run(
-					"--image",
-					tag.String(),
-					"--annotation",
-					"org.opencontainers.image.url=https://my-company.com/images",
-					"--annotation",
-					"org.opencontainers.image.source=https://github.com/org/repo",
-					"--secret-path",
-					dockerConfigJSONPath,
+					"--insecure",
+					"--image", tag.String(),
+					"--annotation", "org.opencontainers.image.url=https://my-company.com/images",
+					"--annotation", "org.opencontainers.image.source=https://github.com/org/repo",
 				)).ToNot(HaveOccurred())
+
+				Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.url")).
+					To(Equal("https://my-company.com/images"))
+
+				Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.source")).
+					To(Equal("https://github.com/org/repo"))
 			})
-
-			Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.url")).
-				To(Equal("https://my-company.com/images"))
-
-			Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.source")).
-				To(Equal("https://github.com/org/repo"))
 		})
 
 		It("should mutate an image with single label", func() {
-			tag := pushImage("test5")
-
-			withDockerConfigJSON(func(dockerConfigJSONPath string) {
+			withTestImage(func(tag name.Tag) {
 				Expect(run(
-					"--image",
-					tag.String(),
-					"--label",
-					"description=image description",
-					"--secret-path",
-					dockerConfigJSONPath,
+					"--insecure",
+					"--image", tag.String(),
+					"--label", "description=image description",
 				)).ToNot(HaveOccurred())
-			})
 
-			Expect(getImageConfigLabel(tag.String(), "description")).
-				To(Equal("image description"))
+				Expect(getImageConfigLabel(tag.String(), "description")).
+					To(Equal("image description"))
+			})
 		})
 
 		It("should mutate an image with multiple labels", func() {
-			tag := pushImage("test6")
-
-			withDockerConfigJSON(func(dockerConfigJSONPath string) {
+			withTestImage(func(tag name.Tag) {
 				Expect(run(
-					"--image",
-					tag.String(),
-					"--label",
-					"description=image description",
-					"--label",
-					"maintainer=team@my-company.com",
-					"--secret-path",
-					dockerConfigJSONPath,
+					"--insecure",
+					"--image", tag.String(),
+					"--label", "description=image description",
+					"--label", "maintainer=team@my-company.com",
 				)).ToNot(HaveOccurred())
+
+				Expect(getImageConfigLabel(tag.String(), "description")).
+					To(Equal("image description"))
+
+				Expect(getImageConfigLabel(tag.String(), "maintainer")).
+					To(Equal("team@my-company.com"))
 			})
-
-			Expect(getImageConfigLabel(tag.String(), "description")).
-				To(Equal("image description"))
-
-			Expect(getImageConfigLabel(tag.String(), "maintainer")).
-				To(Equal("team@my-company.com"))
 		})
 
 		It("should mutate an image with both annotation and label", func() {
-			tag := pushImage("test7")
-
-			withDockerConfigJSON(func(dockerConfigJSONPath string) {
+			withTestImage(func(tag name.Tag) {
 				Expect(run(
-					"--image",
-					tag.String(),
-					"--label",
-					"description=image description",
-					"--annotation",
-					"org.opencontainers.image.url=https://my-company.com/images",
-					"--secret-path",
-					dockerConfigJSONPath,
+					"--insecure",
+					"--image", tag.String(),
+					"--label", "description=image description",
+					"--annotation", "org.opencontainers.image.url=https://my-company.com/images",
 				)).ToNot(HaveOccurred())
+
+				Expect(getImageConfigLabel(tag.String(), "description")).
+					To(Equal("image description"))
+
+				Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.url")).
+					To(Equal("https://my-company.com/images"))
 			})
-
-			Expect(getImageConfigLabel(tag.String(), "description")).
-				To(Equal("image description"))
-
-			Expect(getImageAnnotation(tag.String(), "org.opencontainers.image.url")).
-				To(Equal("https://my-company.com/images"))
 		})
 	})
 
 	Context("store result after image mutation", func() {
 		It("should store image digest into file specified in --result-file-image-digest flags", func() {
-			tag := pushImage("test8")
-
-			withTempFile("image-digest", func(filename string) {
-				withDockerConfigJSON(func(dockerConfigJSONPath string) {
+			withTestImage(func(tag name.Tag) {
+				withTempFile("image-digest", func(filename string) {
 					Expect(run(
-						"--image",
-						tag.String(),
-						"--annotation",
-						"org.opencontainers.image.url=https://my-company.com/images",
-						"--result-file-image-digest",
-						filename,
-						"--secret-path",
-						dockerConfigJSONPath,
+						"--insecure",
+						"--image", tag.String(),
+						"--annotation", "org.opencontainers.image.url=https://my-company.com/images",
+						"--result-file-image-digest", filename,
 					)).ToNot(HaveOccurred())
-				})
 
-				Expect(filecontent(filename)).To(Equal(getImageDigest(tag).String()))
+					Expect(filecontent(filename)).To(Equal(getImageDigest(tag).String()))
+				})
 			})
 		})
 
 		It("should store image size into file specified in result-file-image-size flags", func() {
-			tag := pushImage("test9")
-
-			withTempFile("image-size", func(filename string) {
-				withDockerConfigJSON(func(dockerConfigJSONPath string) {
+			withTestImage(func(tag name.Tag) {
+				withTempFile("image-size", func(filename string) {
 					Expect(run(
-						"--image",
-						tag.String(),
-						"--annotation",
-						"org.opencontainers.image.url=https://my-company.com/images",
-						"--result-file-image-size",
-						filename,
-						"--secret-path",
-						dockerConfigJSONPath,
+						"--insecure",
+						"--image", tag.String(),
+						"--annotation", "org.opencontainers.image.url=https://my-company.com/images",
+						"--result-file-image-size", filename,
 					)).ToNot(HaveOccurred())
 
 					size := getCompressedImageSize(getImage(tag))


### PR DESCRIPTION
# Changes

So far, the unit tests required container registry credentials to run and therefore were skipped in the GitHub Action based tests:
- Rework test cases that do not rely on image pushes or pulls to not be skipped.
- Rework test cases that rely on image processing to work against an in-memory temporary registry.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

