### PR TITLE
Pass platform to ko build

### DIFF
--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -47,7 +47,7 @@ spec:
         requests:
           cpu: 100m
           memory: 128Mi
-    - name: build-and-push
+    - name: build
       image: golang:$(params.go-version)
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
@@ -126,7 +126,7 @@ spec:
           export GOROOT="$(go env GOROOT)"
 
           pushd "${PARAM_SOURCE_CONTEXT}" > /dev/null
-            /tmp/ko publish "${PARAM_PACKAGE_DIRECTORY}" --oci-layout-path="${PARAM_OUTPUT_DIRECTORY}" --push=false
+            /tmp/ko build "${PARAM_PACKAGE_DIRECTORY}" --oci-layout-path="${PARAM_OUTPUT_DIRECTORY}" --platform="${PLATFORM}" --push=false
           popd > /dev/null
       resources:
         limits:


### PR DESCRIPTION
# Changes

When I rewrote the `ko` commands to export an OCI image, I removed the `platform` argument. That was not correct. Adding it back. Also two more small changes:

1. I rename the step from `build-and-push` to just `build` as it does not push anymore.
2. I am calling `ko build` instead of `ko publish`. The commands do the same, but `ko --help` does not anymore document `publish`.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The platform support for the ko build strategy is functional again
```