### PR TITLE
Add safe.directory to git commands / Tolerate old Heroku stack

### DIFF
--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -416,7 +416,12 @@ func clone(ctx context.Context) error {
 }
 
 func git(ctx context.Context, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	fullArgs := []string{
+		"-c",
+		fmt.Sprintf("safe.directory=%s", flagValues.target),
+	}
+	fullArgs = append(fullArgs, args...)
+	cmd := exec.CommandContext(ctx, "git", fullArgs...)
 
 	// Print the command to be executed, but replace the URL with a safe version
 	log.Print(strings.ReplaceAll(cmd.String(), flagValues.url, displayURL))

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -37,7 +37,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
-      env: 
+      env:
+        - name: ALLOW_INSECURE_HEROKU_18_BUILDER
+          value: "1"
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -37,7 +37,9 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
-      env: 
+      env:
+        - name: ALLOW_INSECURE_HEROKU_18_BUILDER
+          value: "1"
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT


### PR DESCRIPTION
# Changes

We are currently facing two issues that are causing all pull requests to be red which is why I am putting them together although they are unrelated:

(1) UBI update

The recent UBI changes seems to have bumped to a Git version that requires the use of `safe.directory` also for the Git step like we did in [Allow non-current user to own the directory which is built by ko #1219](https://github.com/shipwright-io/build/pull/1219) for the ko build strategy.

This fix is necessary to get back to green pull requests as it is failing like in [here](https://github.com/shipwright-io/build/actions/runs/4936301520/jobs/8823661767?pr=1291):

```
2023-05-10T11:17:10Z 1 Logs of container step-source-default: 2023/05/10 11:17:06 Info: ssh (/usr/bin/ssh): OpenSSH_8.7p1, OpenSSL 3.0.7 1 Nov 2022
2023/05/10 11:17:06 Info: git (/usr/bin/git): git version 2.39.1
2023/05/10 11:17:07 Info: git-lfs (/usr/bin/git-lfs): git-lfs/3.2.0 (GitHub; linux amd64; go 1.19.4)
2023/05/10 11:17:07 /usr/bin/git clone -h
2023/05/10 11:17:07 /usr/bin/git submodule -h
2023/05/10 11:17:07 /usr/bin/git clone --quiet --no-tags --single-branch --depth 1 -- https://github.com/shipwright-io/sample-nodejs /workspace/source
2023/05/10 11:17:07 /usr/bin/git -C /workspace/source submodule update --init --recursive --depth 1
2023/05/10 11:17:07 fatal: detected dubious ownership in repository at '/workspace/source'
  To add an exception for this directory, call:

  	git config --global --add safe.directory /workspace/source (exit code 128)
```

(2) Heroku 18

[The heroku-18 stack is deprecated and now end-of-life.](https://devcenter.heroku.com/changelog-items/2583) Builds that use it fail with this error:

```
  Error: This builder image (heroku/buildpacks:18) is based upon the Heroku-18
  stack, which has been end-of-life since April 30th, 2023:
  https://devcenter.heroku.com/changelog-items/2583

  The underlying Ubuntu 18.04 OS is no longer receiving security updates.
  Apps still using this OS could be vulnerable.

  Please switch to one of our newer 'heroku/builder:*' builder images:
  https://github.com/heroku/builder#heroku-builder-images

  If you are using the Pack CLI, you will need to adjust the '--builder' CLI
  argument, or else change the default builder configuration:
  https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/


  To ignore this error, set the env var ALLOW_INSECURE_HEROKU_18_BUILDER to 1.
```

I am adding the compatability environment variable. An update to heroku-22 should be done in a separate pull request before the next release. See #1295

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
