### PR TITLE
Adds `--server-side` to `ko apply` as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,11 +225,11 @@ test-e2e-kind-with-prereq-install: ginkgo install-controller-kind install-strate
 .PHONY: install
 install:
 	@echo "Building Shipwright Build controller for platform ${GO_OS}/${GO_ARCH}"
-	GOOS=$(GO_OS) GOARCH=$(GO_ARCH) KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE_NAMESPACE)" GOFLAGS="$(GO_FLAGS)" ko apply --base-import-paths -R -f deploy/
+	GOOS=$(GO_OS) GOARCH=$(GO_ARCH) KO_DOCKER_REPO="$(IMAGE_HOST)/$(IMAGE_NAMESPACE)" GOFLAGS="$(GO_FLAGS)" ko apply --base-import-paths -R -f deploy/ -- --server-side
 
 .PHONY: install-with-pprof
 install-with-pprof:
-	GOOS=$(GO_OS) GOARCH=$(GO_ARCH) GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko apply -R -f deploy/
+	GOOS=$(GO_OS) GOARCH=$(GO_ARCH) GOFLAGS="$(GO_FLAGS) -tags=pprof_enabled" ko apply -R -f deploy/ -- --server-side
 
 install-apis:
 	kubectl apply -f deploy/crds/ --server-side


### PR DESCRIPTION
# Changes

Fixes #1314 

--> As 'ko apply' feeds the yamls recursively to 'kubectl apply', adding `--server-side` flag to be sent directly to 'kubectl apply'.

# Release Notes

```release-note
NONE
```