### PR TITLE
Pulls ginkgo version as per go.mod instead of latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ TEST_NAMESPACE ?= default
 TEKTON_VERSION ?= v0.44.0
 
 # E2E test flags
-TEST_E2E_FLAGS ?= --fail-fast -p --randomize-all -timeout=1h -progress -trace -v
+TEST_E2E_FLAGS ?= --fail-fast -p --randomize-all -timeout=1h -trace -vv
 
 # E2E test service account name to be used for the build runs, can be set to generated to use the generated service account feature
 TEST_E2E_SERVICEACCOUNT_NAME ?= pipeline
@@ -124,7 +124,7 @@ ifeq (, $(GINKGO))
   ifeq (, $(shell which ginkgo))
 	@{ \
 	set -e ;\
-	go install github.com/onsi/ginkgo/v2/ginkgo@latest ;\
+	go install github.com/onsi/ginkgo/v2/ginkgo ;\
 	}
   override GINKGO=$(GOBIN)/ginkgo
   else


### PR DESCRIPTION
# Changes
As per [Makefile#L127](https://github.com/shipwright-io/build/blob/main/Makefile#L127), `go install` installs the latest version of ginkgo. I was trying to perform `make install` when new ginkgo version (2.10.0) was released ~6 hours ago, and dependabot was yet to update the version in `go.mod`. Due to this a version mismatch is reported & led to failures.

--> Eliminating the `@latest`, so that `go install` installs the package version as that of specified in the `go.mod`.

Could also observe some warnings w.r.t deprecation of `--progress`. Hence removed the flag and added extra `v` for increased verbosity.

# Release Notes

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
