### PR TITLE
Use tag name instead of release name

### DIFF
--- a/hack/check-latest-images.sh
+++ b/hack/check-latest-images.sh
@@ -44,7 +44,7 @@ function update() {
         echo "[INFO] Determined current tag ${CURRENT_TAG}"
 
         # Determine the latest tag
-        QUERY=".name"
+        QUERY=".tag_name"
         if [[ ${IMAGE} == *buildah* ]]; then
                 QUERY=".tags | .[0].name"
         fi


### PR DESCRIPTION
# Changes

Kaniko has changed their release name to include ` Release` as suffix. This breaks our update pipeline: https://github.com/shipwright-io/build/pull/1319/files

Changing our script to use the tag name instead of the release name.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
