### PR TITLE
Update Buildpacks strategy

### DIFF
--- a/samples/build/build_buildpacks-v3-heroku_cr.yaml
+++ b/samples/build/build_buildpacks-v3-heroku_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   source:
     url: https://github.com/shipwright-io/sample-nodejs
-    contextDir: source-build
+    contextDir: source-build-heroku
   strategy:
     name: buildpacks-v3-heroku
     kind: ClusterBuildStrategy

--- a/samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/build/build_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   source:
     url: https://github.com/shipwright-io/sample-nodejs
-    contextDir: source-build
+    contextDir: source-build-heroku
   strategy:
     name: buildpacks-v3-heroku
     kind: BuildStrategy

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -10,13 +10,11 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.4"
+      default: "0.7"
   buildSteps:
     - name: build-and-push
-      image: heroku/buildpacks:18
+      image: heroku/builder:22
       env:
-        - name: ALLOW_INSECURE_HEROKU_18_BUILDER
-          value: "1"
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT
@@ -58,23 +56,23 @@ spec:
             fi
           done
 
-          LAYERS_DIR=/tmp/layers
-          CACHE_DIR=/tmp/cache
+          LAYERS_DIR=/tmp/.shp/layers
+          CACHE_DIR=/tmp/.shp/cache
 
-          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+          mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
             printf "===> %s\n" "$1" 
           }
 
+          announce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" "${PARAM_OUTPUT_IMAGE}"
+
           announce_phase "DETECTING"
           /cnb/lifecycle/detector -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
-          announce_phase "ANALYZING"
-          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "${PARAM_OUTPUT_IMAGE}"
-
           announce_phase "RESTORING"
-          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR" -layers="$LAYERS_DIR"
 
           announce_phase "BUILDING"
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
@@ -86,7 +84,7 @@ spec:
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
-          grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -10,13 +10,11 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.4"
+      default: "0.7"
   buildSteps:
     - name: build-and-push
-      image: heroku/buildpacks:18
+      image: heroku/builder:22
       env:
-        - name: ALLOW_INSECURE_HEROKU_18_BUILDER
-          value: "1"
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT
@@ -58,23 +56,23 @@ spec:
             fi
           done
 
-          LAYERS_DIR=/tmp/layers
-          CACHE_DIR=/tmp/cache
+          LAYERS_DIR=/tmp/.shp/layers
+          CACHE_DIR=/tmp/.shp/cache
 
-          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+          mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
             printf "===> %s\n" "$1" 
           }
 
+          announce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" "${PARAM_OUTPUT_IMAGE}"
+
           announce_phase "DETECTING"
           /cnb/lifecycle/detector -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
-          announce_phase "ANALYZING"
-          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "${PARAM_OUTPUT_IMAGE}"
-
           announce_phase "RESTORING"
-          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR" -layers="$LAYERS_DIR"
 
           announce_phase "BUILDING"
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
@@ -86,7 +84,7 @@ spec:
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
-          grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.4"
+      default: "0.7"
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
@@ -56,23 +56,23 @@ spec:
             fi
           done
 
-          LAYERS_DIR=/tmp/layers
-          CACHE_DIR=/tmp/cache
+          LAYERS_DIR=/tmp/.shp/layers
+          CACHE_DIR=/tmp/.shp/cache
 
-          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+          mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
             printf "===> %s\n" "$1" 
           }
 
+          announce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" "${PARAM_OUTPUT_IMAGE}"
+
           announce_phase "DETECTING"
           /cnb/lifecycle/detector -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
-          announce_phase "ANALYZING"
-          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "${PARAM_OUTPUT_IMAGE}"
-
           announce_phase "RESTORING"
-          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR" -layers="$LAYERS_DIR"
 
           announce_phase "BUILDING"
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
@@ -84,7 +84,7 @@ spec:
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
-          grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.4"
+      default: "0.7"
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
@@ -56,23 +56,23 @@ spec:
             fi
           done
 
-          LAYERS_DIR=/tmp/layers
-          CACHE_DIR=/tmp/cache
+          LAYERS_DIR=/tmp/.shp/layers
+          CACHE_DIR=/tmp/.shp/cache
 
-          mkdir "$CACHE_DIR" "$LAYERS_DIR"
+          mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
             printf "===> %s\n" "$1" 
           }
 
+          announce_phase "ANALYZING"
+          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" "${PARAM_OUTPUT_IMAGE}"
+
           announce_phase "DETECTING"
           /cnb/lifecycle/detector -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
-          announce_phase "ANALYZING"
-          /cnb/lifecycle/analyzer -layers="$LAYERS_DIR" -cache-dir="$CACHE_DIR" "${PARAM_OUTPUT_IMAGE}"
-
           announce_phase "RESTORING"
-          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR"
+          /cnb/lifecycle/restorer -cache-dir="$CACHE_DIR" -layers="$LAYERS_DIR"
 
           announce_phase "BUILDING"
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
@@ -84,7 +84,7 @@ spec:
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
-          grep digest /tmp/report.toml | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env


### PR DESCRIPTION
# Changes

This pull request updates several things in the Buildpacks strategy samples:

* Heroku is updated to Ubuntu Bionic (22). This required a change in the sample as Heroku does now require a Procfile to define the entrypoint. The e2e can therefore only succeed after https://github.com/shipwright-io/sample-nodejs/pull/7 is merged.
* The platform API is updated to 0.7. This includes the change to have [analyze before detect ](https://buildpacks.io/docs/reference/spec/migration/platform-api-0.6-0.7/#run-the-analyzer-before-the-detector)
* The layers and cache directories are changed to include a .shp directory in the path under /tmp. The reason is that /tmp/cache can be overlapping with a directory used by build tools.

Fixes #1280
Fixes #1295

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Buildpacks sample build strategies are updated to the latest Heroku version and a newer platform API version
```
