### PR TITLE
Setup security context of controller deployment, enforce restricted PodSecurity in namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - v1.24.7
-          - v1.25.3
+          - v1.24.15
+          - v1.25.11
       max-parallel: 2
     runs-on: ubuntu-latest
     steps:
@@ -81,7 +81,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.17.0
+          version: v0.20.0
           node_image: kindest/node:${{ matrix.kubernetes }}
           cluster_name: kind
           wait: 120s
@@ -119,8 +119,8 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - v1.24.7
-          - v1.25.3
+          - v1.24.15
+          - v1.25.11
       max-parallel: 2
     runs-on: ubuntu-latest
     steps:
@@ -139,7 +139,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.17.0
+          version: v0.20.0
           node_image: kindest/node:${{ matrix.kubernetes }}
           cluster_name: kind
           config: test/kind/config.yaml
@@ -182,7 +182,8 @@ jobs:
           kubectl -n shipwright-build rollout status deployment shipwright-build-controller --timeout=1m || true
       - name: Test
         run: |
-          export TEST_NAMESPACE=shipwright-build
+          kubectl create namespace shp-e2e
+          export TEST_NAMESPACE=shp-e2e
           export TEST_IMAGE_REPO=registry.registry.svc.cluster.local:32222/shipwright-io/build-e2e
           export TEST_IMAGE_REPO_INSECURE=true
           export TEST_E2E_TIMEOUT_MULTIPLIER=2

--- a/deploy/100-namespace.yaml
+++ b/deploy/100-namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: shipwright-build
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/deploy/500-controller.yaml
+++ b/deploy/500-controller.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         name: shipwright-build
     spec:
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: shipwright-build-controller
       containers:
         - name: shipwright-build
@@ -58,3 +60,13 @@ spec:
               port: metrics-port
             initialDelaySeconds: 5
             periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault

--- a/docs/build.md
+++ b/docs/build.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
   - [Defining Retention Parameters](#defining-retention-parameters)
   - [Defining Volumes](#defining-volumes)
   - [Defining Triggers](#defining-triggers)
-- [BuildRun deletion](#BuildRun-deletion)
+- [BuildRun deletion](#buildrun-deletion)
 
 ## Overview
 
@@ -64,7 +64,7 @@ To prevent users from triggering `BuildRuns` (_execution of a Build_) that will 
 | SpecOutputSecretRefNotFound | The secret used to authenticate to the container registry doesn't exist. |
 | SpecBuilderSecretRefNotFound | The secret used to authenticate the container registry doesn't exist.|
 | MultipleSecretRefNotFound | More than one secret is missing. At the moment, only three paths on a Build can specify a secret. |
-| RestrictedParametersInUse | One or many defined `params` are colliding with Shipwright reserved parameters. See [Defining Params](#defining-params) for more information. |
+| RestrictedParametersInUse | One or many defined `params` are colliding with Shipwright reserved parameters. See [Defining Params](#defining-paramvalues) for more information. |
 | UndefinedParameter | One or many defined `params` are not defined in the referenced strategy. Please ensure that the strategy defines them under its `spec.parameters` list. |
 | RemoteRepositoryUnreachable | The defined `spec.source.url` was not found. This validation only takes place for HTTP/HTTPS protocols. |
 | BuildNameInvalid | The defined `Build` name (`metadata.name`) is invalid. The `Build` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
@@ -78,7 +78,7 @@ The `Build` definition supports the following fields:
 - Required:
   - [`apiVersion`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the API version, for example `shipwright.io/v1alpha1`.
   - [`kind`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the Kind type, for example `Build`.
-  - [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Metadata that identify the CRD instance, for example the name of the `Build`.
+  - [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Metadata that identify the custom resource instance, especially the name of the `Build`, and in which [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) you place it. **Note**: You should use your own namespace, and not put your builds into the shipwright-build namespace where Shipwright's system components run.
   - `spec.source` - Refers to the location of the source code, for example a Git repository or source bundle image.
   - `spec.strategy` - Refers to the `BuildStrategy` to be used, see the [examples](../samples/buildstrategy)
   - `spec.builder.image` - Refers to the image containing the build tools to build the source code. (_Use this path for Dockerless strategies, this is just required for `source-to-image` buildStrategy_) **This field has been deprecated, and will be removed in a future release.**
@@ -88,7 +88,7 @@ The `Build` definition supports the following fields:
 - Optional:
   - `spec.paramValues` - Refers to a name-value(s) list to specify values for `parameters` defined in the `BuildStrategy`.
   - `spec.dockerfile` - Path to a Dockerfile to be used for building an image. (_Use this path for strategies that require a Dockerfile_). **This field has been deprecated, and will be removed in a future release.**
-  - `spec.sources` - [Sources](#Sources) describes a slice of artifacts that will be imported into the project context before the actual build process starts. **This field has been deprecated, and will be removed in a future release.**
+  - `spec.sources` - [Sources](#sources) describes a slice of artifacts that will be imported into the project context before the actual build process starts. **This field has been deprecated, and will be removed in a future release.**
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example, `5m`. The default is ten minutes. You can overwrite the value in the `BuildRun`.
   - `metadata.annotations[build.shipwright.io/build-run-deletion]` - Defines if delete all related BuildRuns when deleting the Build. The default is `false`.
   - `spec.output.annotations` - Refers to a list of `key/value` that could be used to [annotate](https://github.com/opencontainers/image-spec/blob/main/annotations.md) the output image.
@@ -156,7 +156,7 @@ spec:
     contextDir: renamed
 ```
 
-Example of a `Build` that specifies the tag `v.0.1.0` for the git repository:
+Example of a `Build` that specifies the tag `v0.1.0` for the git repository:
 
 ```yaml
 apiVersion: shipwright.io/v1alpha1

--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -13,7 +13,7 @@ set -eu
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 # kind version
-KIND_VERSION="${KIND_VERSION:-v0.17.0}"
+KIND_VERSION="${KIND_VERSION:-v0.20.0}"
 
 if ! hash kind > /dev/null 2>&1 ; then
     echo "# Installing KinD..."
@@ -27,7 +27,7 @@ kind --version
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 
 # kind cluster version
-KIND_CLUSTER_VERSION="${KIND_CLUSTER_VERSION:-v1.25.3}"
+KIND_CLUSTER_VERSION="${KIND_CLUSTER_VERSION:-v1.25.11}"
 
 echo "# Creating a new Kubernetes cluster..."
 kind delete cluster --name="${KIND_CLUSTER_NAME}"

--- a/test/kind/config.yaml
+++ b/test/kind/config.yaml
@@ -1,5 +1,13 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      enable-admission-plugins: PodSecurity
 nodes:
 - role: control-plane
   extraPortMappings:


### PR DESCRIPTION
# Changes

This pull request configures the security of the controller deployment to fulfill the restricted PodSecurity profile. The namespace is configured to enforce this. The KinD configuration is updated to enable PodSecurity admission. I also update the KinD version to be current. I had to change the e2e that we run here in GitHub to use its own namespace because build strategies like Kaniko require elevated permissions beyond privileged. And in general, we should have never used this namespace imo. I also updated the documentation in that regard.

Fixes #1331 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The shipwright-build namespace is now configured to enforce restricted PodSecurity. The shipwright-build-controller deployment was updated to fulfil all requirements.
```
