### PR TITLE
Update to Golang 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.x'
+          go-version: '1.20.x'
           cache: true
           check-latest: true
       - name: Build
@@ -67,7 +67,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.x'
+          go-version: '1.20.x'
           cache: true
           check-latest: true
       - name: Install Ko
@@ -129,7 +129,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.x'
+          go-version: '1.20.x'
           cache: true
           check-latest: true
       - name: Install kubectl

--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -22,6 +22,7 @@ jobs:
             library/golang:1.17 \
             library/golang:1.18 \
             library/golang:1.19 \
+            library/golang:1.20 \
             library/maven:3-jdk-8-openj9 \
             library/node:12 \
             library/node:14 \

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
         cache: true
         check-latest: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0  # Fetch all history, needed for release note generation.
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
         cache: true
         check-latest: true
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
         cache: true
         check-latest: true
         cache-dependency-path: go/src/github.com/shipwright-io/build

--- a/HACK.md
+++ b/HACK.md
@@ -41,7 +41,7 @@ In the near future, the above would be setup by the controller.
 make clean && make build
 ```
 
-* This project uses Golang 1.19+ and controller-gen v0.10.0.
+* This project uses Golang 1.20 and controller-gen v0.10.0.
 * The controllers create/watch Tekton objects.
 
 # Testing

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -212,7 +212,7 @@ The build strategy provides the following parameters that you can set in a Build
 | Parameter | Description | Default |
 | -- | -- | -- |
 | `go-flags` | Value for the GOFLAGS environment variable. | Empty |
-| `go-version` | Version of Go, must match a tag from [the golang image](https://hub.docker.com/_/golang?tab=tags) | `1.19` |
+| `go-version` | Version of Go, must match a tag from [the golang image](https://hub.docker.com/_/golang?tab=tags) | `1.20` |
 | `ko-version` | Version of ko, must be either `latest` for the newest release, or a [ko release name](https://github.com/ko-build/ko/releases) | `latest` |
 | `package-directory` | The directory inside the context directory containing the main package. | `.` |
 | `target-platform` | Target platform to be built. For example: `linux/arm64`. Multiple platforms can be provided separated by comma, for example: `linux/arm64,linux/amd64`. The value `all` will build all platforms supported by the base image. The value `current` will build the platform on which the build runs. | `current` |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shipwright-io/build
 
-go 1.19
+go 1.20
 
 require (
 	github.com/docker/cli v24.0.5+incompatible

--- a/samples/build/build_ko_cr.yaml
+++ b/samples/build/build_ko_cr.yaml
@@ -10,7 +10,7 @@ spec:
     - name: go-flags
       value: "-v -mod=vendor -ldflags=-w"
     - name: go-version
-      value: "1.19"
+      value: "1.20"
     - name: package-directory
       value: ./cmd/shipwright-build-controller
   source:

--- a/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -10,7 +10,7 @@ spec:
       default: ""
     - name: go-version
       description: "Version of Go, must match a tag from https://hub.docker.com/_/golang?tab=tags"
-      default: "1.19"
+      default: "1.20"
     - name: ko-version
       description: "Version of ko, must be either 'latest', or a release name from https://github.com/ko-build/ko/releases"
       default: latest


### PR DESCRIPTION
# Changes

Golang 1.21 is expected to be released this month. Then, 1.19 is out of support. Therefore, it is time to move up to 1.20.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Golang 1.20 is used to compile
```