### PR TITLE
Use --snapshot-mode instead of --snapshotMode and --tar-path instead --tarPath in sample build strategies that use Kaniko

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -642,7 +642,7 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=$(params.shp-source-context)
         - --destination=$(params.shp-output-image)
-        - --snapshotMode=redo
+        - --snapshot-mode=redo
         - --push-retry=3
       resources:
         limits:
@@ -686,7 +686,7 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=$(params.shp-source-context)
         - --destination=$(params.shp-output-image)
-        - --snapshotMode=redo
+        - --snapshot-mode=redo
         - --push-retry=3
       resources:
         limits:

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko-trivy_cr.yaml
@@ -42,10 +42,10 @@ spec:
         - $(params.shp-source-context)
         - --destination
         - $(params.shp-output-image)
-        - --snapshotMode
+        - --snapshot-mode
         - redo
         - --no-push
-        - --tarPath
+        - --tar-path
         - $(params.shp-output-directory)/image.tar
         # https://github.com/GoogleContainerTools/kaniko/issues/2164
         - --ignore-path

--- a/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
+++ b/samples/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml
@@ -36,10 +36,10 @@ spec:
         - $(params.shp-source-context)
         - --destination
         - $(params.shp-output-image)
-        - --snapshotMode
+        - --snapshot-mode
         - redo
         - --no-push
-        - --tarPath
+        - --tar-path
         - $(params.shp-output-directory)/image.tar
         # https://github.com/GoogleContainerTools/kaniko/issues/2164
         - --ignore-path

--- a/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
+++ b/samples/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml
@@ -32,10 +32,10 @@ spec:
         - /gen-source
         - --destination
         - $(params.shp-output-image)
-        - --snapshotMode
+        - --snapshot-mode
         - redo
         - --no-push
-        - --tarPath
+        - --tar-path
         - $(params.shp-output-directory)/image.tar
         # https://github.com/GoogleContainerTools/kaniko/issues/2164
         - --ignore-path

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -158,7 +158,7 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=$(params.shp-source-context)
         - --destination=$(params.shp-output-image)
-        - --snapshotMode=redo
+        - --snapshot-mode=redo
         - --push-retry=3
       resources:
         limits:
@@ -207,7 +207,7 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=$(params.shp-source-context)
         - --destination=$(params.shp-output-image)
-        - --snapshotMode=redo
+        - --snapshot-mode=redo
         - --push-retry=3
       resources:
         limits:
@@ -325,7 +325,7 @@ spec:
         - --dockerfile=$(build.dockerfile)
         - --context=$(params.shp-source-root)
         - --destination=$(params.shp-output-image)
-        - --snapshotMode=redo
+        - --snapshot-mode=redo
         - --push-retry=3
       resources:
         limits:


### PR DESCRIPTION
# Changes

Already last year, [Kaniko cleaned up command line flags to make naming consistent](https://github.com/GoogleContainerTools/kaniko/pull/2084). The `snapshotMode` and `tarPath` are deprecated and cause a warning. Adopting our strategy example to use `snapshot-mode` and `tar-path`.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The Kaniko sample build strategy now uses the --snapshot-mode and --tar-path command line flags instead of the deprecated --snapshotMode and --tarPath
```