### PR TITLE
Use BuildKit's option to not tar the output image as OCI layout as we need it as a directory anyway

### DIFF
--- a/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -92,12 +92,11 @@ spec:
           echo "set -euo pipefail" >> /tmp/run.sh
           echo "buildctl-daemonless.sh \\" >> /tmp/run.sh
           echo "build \\" >> /tmp/run.sh
-          echo "--progress=plain \\" >> /tmp/run.sh
           echo "--frontend=dockerfile.v0 \\" >> /tmp/run.sh
           echo "--opt=filename=\"${DOCKERFILE_NAME}\" \\" >> /tmp/run.sh
           echo "--local=context=\"${PARAM_SOURCE_CONTEXT}\" \\" >> /tmp/run.sh
           echo "--local=dockerfile=\"${DOCKERFILE_DIR}\" \\" >> /tmp/run.sh
-          echo "--output=type=oci \\" >> /tmp/run.sh
+          echo "--output=type=oci,tar=false,dest=\"${PARAM_OUTPUT_DIRECTORY}\" \\" >> /tmp/run.sh
           if [ "${PARAM_CACHE}" == "registry" ]; then
             echo "--export-cache=type=inline \\" >> /tmp/run.sh
             echo "--import-cache=type=registry,ref=\"${PARAM_OUTPUT_IMAGE}\",registry.insecure=\"${PARAM_OUTPUT_INSECURE}\" \\" >> /tmp/run.sh
@@ -154,7 +153,7 @@ spec:
             echo "--opt=\"platform=${platforms}\" \\" >> /tmp/run.sh
           fi
 
-          echo "--metadata-file /tmp/image-metadata.json | tar -C \"${PARAM_OUTPUT_DIRECTORY}\" -xf -" >> /tmp/run.sh
+          echo "--progress=plain" >> /tmp/run.sh
 
           chmod +x /tmp/run.sh
           /tmp/run.sh


### PR DESCRIPTION
# Changes

This updates the BuildKit sample build strategy to use the recently introduced `tar=false` option on the output. This causes the files directly getting written to a directory that I pass in as `dest`. This saves us the extraction that we so far did.

I am also removing the metadata-file creation. We needed that before shipwright-managed push because we grabbed the digest from it. Now, Shipwright sets it now as part of the push.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The BuildKit sample build strategy now does not cause BuildKit to tar the image to then untar it
```