### PR TITLE
Use -p flag with mkdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ test: test-unit
 .PHONY: test-unit
 test-unit:
 	@rm -rf build/coverage
-	@mkdir build/coverage
+	@mkdir -p build/coverage
 	go test \
 		./cmd/... \
 		./pkg/... \


### PR DESCRIPTION
# Changes
Use the `-p` flag with `mkdir` to fix the following error when running `make test`:
```

$ make test-unit
mkdir: cannot create directory ‘build/coverage’: No such file or directory
make: *** [Makefile:167: test-unit] Error 1
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes



```release-note
NONE
```

