### PR TITLE
Improve BuildAh query

### DIFF
--- a/hack/check-latest-images.sh
+++ b/hack/check-latest-images.sh
@@ -46,7 +46,7 @@ function update() {
         # Determine the latest tag
         QUERY=".tag_name"
         if [[ ${IMAGE} == *buildah* ]]; then
-                QUERY=".tags | .[0].name"
+                QUERY=".tags | sort_by(.name) | reverse | .[0].name"
         fi
         LATEST_TAG="$(curl --silent --retry 3 "${LATEST_RELEASE_URL}" | jq --raw-output "${QUERY}")"
 


### PR DESCRIPTION
# Changes

In response to https://github.com/shipwright-io/build/pull/1368

The BuildAh team seamingly rebuild all images in the last two days:

![grafik](https://github.com/shipwright-io/build/assets/48473177/84ab5562-cec6-4b42-8c22-5f031e390a75)

This lead to our automation to pickup "latest" yesterday, and v1.23.0 today.

I am changing the query to sort by name and take the last item. This should be what we want as long as BuildAh tags images the way it does today.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```