### PR TITLE
Run buildah steps without privileged containers

### DIFF
--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -250,7 +250,7 @@ var _ = Describe("GenerateTaskrun", func() {
 				Expect(err).To(BeNil())
 
 				expectedCommandOrArg = []string{
-					"bud", "--tag=$(params.shp-output-image)", fmt.Sprintf("--file=$(inputs.params.%s)", "DOCKERFILE"), "$(params.shp-source-context)",
+					"--storage-driver=$(params.storage-driver)", "bud", "--tag=$(params.shp-output-image)", fmt.Sprintf("--file=$(inputs.params.%s)", "DOCKERFILE"), "$(params.shp-source-context)",
 				}
 			})
 

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
@@ -138,7 +138,8 @@ spec:
 
           # Building the image
           echo "[INFO] Building image ${image}"
-          buildah bud "${buildArgs[@]}" \
+          buildah --storage-driver=$(params.storage-driver) \
+            bud "${buildArgs[@]}" \
             --registries-conf=/tmp/registries.conf \
             --tag="${image}" \
             --file="${dockerfile}" \
@@ -146,7 +147,7 @@ spec:
 
           # Write the image
           echo "[INFO] Writing image ${image}"
-          buildah push \
+          buildah --storage-driver=$(params.storage-driver) push \
             "${image}" \
             "oci:${target}"
         # That's the separator between the shell script and its args
@@ -193,6 +194,11 @@ spec:
       defaults:
         - docker.io
         - quay.io
+    - name: storage-driver
+      description: "The storage driver to use, such as 'overlay' or 'vfs'."
+      type: string
+      default: "vfs"
+      # For details see the "--storage-driver" section of https://github.com/containers/buildah/blob/main/docs/buildah.1.md#options
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/samples/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
+++ b/samples/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
@@ -9,7 +9,9 @@ spec:
       image: quay.io/containers/buildah:v1.31.0
       workingDir: $(params.shp-source-root)
       securityContext:
-        privileged: true
+        capabilities:
+          add:
+          - "SETFCAP"
       command:
         - /bin/bash
       args:
@@ -136,7 +138,8 @@ spec:
 
           # Building the image
           echo "[INFO] Building image ${image}"
-          buildah bud "${buildArgs[@]}" \
+          buildah --storage-driver=$(params.storage-driver) \
+            bud "${buildArgs[@]}" \
             --registries-conf=/tmp/registries.conf \
             --tag="${image}" \
             --file="${dockerfile}" \
@@ -144,7 +147,7 @@ spec:
 
           # Push the image
           echo "[INFO] Pushing image ${image}"
-          buildah push \
+          buildah --storage-driver=$(params.storage-driver) push \
             --digestfile='$(results.shp-image-digest.path)' \
             --tls-verify="${tlsVerify}" \
             "${image}" \
@@ -191,6 +194,11 @@ spec:
       defaults:
         - docker.io
         - quay.io
+    - name: storage-driver
+      description: "The storage driver to use, such as 'overlay' or 'vfs'"
+      type: string
+      default: "vfs"
+      # For details see the "--storage-driver" section of https://github.com/containers/buildah/blob/main/docs/buildah.1.md#options
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/test/buildstrategy_samples.go
+++ b/test/buildstrategy_samples.go
@@ -21,7 +21,8 @@ spec:
       image: quay.io/containers/buildah:v1.31.0
       workingDir: $(params.shp-source-root)
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
@@ -42,7 +43,8 @@ spec:
     - name: buildah-push
       image: quay.io/containers/buildah:v1.31.0
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
@@ -74,15 +76,22 @@ spec:
   volumes:
     - name: buildah-images
       emptyDir: {}
+  parameters:
+    - name: storage-driver
+      description: "The storage driver to use, such as 'overlay' or 'vfs'"
+      type: string
+      default: "vfs"
   buildSteps:
     - name: buildah-bud
       image: quay.io/containers/buildah:v1.31.0
       workingDir: $(params.shp-source-root)
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
+        - --storage-driver=$(params.storage-driver)
         - bud
         - --tag=$(params.shp-output-image)
         - --file=$(build.dockerfile)
@@ -107,10 +116,12 @@ spec:
     - name: buildah-push
       image: quay.io/containers/buildah:v1.31.0
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
+        - --storage-driver=$(params.storage-driver)
         - push
         - --tls-verify=false
         - docker://$(params.shp-output-image)
@@ -143,12 +154,18 @@ spec:
   volumes:
     - name: varlibcontainers
       emptyDir: {}
+  parameters:
+    - name: storage-driver
+      description: "The storage driver to use, such as 'overlay' or 'vfs'"
+      type: string
+      default: "vfs"
   buildSteps:
     - name: build
       image: "$(build.builder.image)"
       workingDir: $(params.shp-source-root)
       command:
         - buildah
+        - --storage-driver=$(params.storage-driver)
         - bud
         - --tls-verify=false
         - --layers

--- a/test/clusterbuildstrategy_samples.go
+++ b/test/clusterbuildstrategy_samples.go
@@ -17,15 +17,22 @@ spec:
     - name: buildah-images
       volumeSource:
         emptyDir: {}
+  parameters:
+    - name: storage-driver
+      description: "The storage driver to use, such as 'overlay' or 'vfs'"
+      type: string
+      default: "vfs"
   buildSteps:
     - name: buildah-bud
       image: quay.io/containers/buildah:v1.31.0
       workingDir: $(params.shp-source-root)
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
+        - --storage-driver=$(params.storage-driver)
         - bud
         - --tag=$(params.shp-output-image)
         - --file=$(build.dockerfile)
@@ -43,10 +50,12 @@ spec:
     - name: buildah-push
       image: quay.io/containers/buildah:v1.31.0
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
+        - --storage-driver=$(params.storage-driver)
         - push
         - --tls-verify=false
         - docker://$(params.shp-output-image)
@@ -75,15 +84,22 @@ spec:
     - name: buildah-images
       volumeSource:
         emptyDir: {}
+  parameters:
+    - name: storage-driver
+      description: "The storage driver to use, such as 'overlay' or 'vfs'"
+      type: string
+      default: "vfs"
   buildSteps:
     - name: buildah-bud
       image: quay.io/containers/buildah:v1.31.0
       workingDir: $(params.shp-source-root)
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
+        - --storage-driver=$(params.storage-driver)
         - bud
         - --tag=$(params.shp-output-image)
         - --file=$(build.dockerfile)
@@ -101,10 +117,12 @@ spec:
     - name: buildah-push
       image: quay.io/containers/buildah:v1.31.0
       securityContext:
-        privileged: true
+        capabilities:
+          add: ["SETFCAP"]
       command:
         - /usr/bin/buildah
       args:
+        - --storage-driver=$(params.storage-driver)
         - push
         - --tls-verify=false
         - docker://$(params.shp-output-image)


### PR DESCRIPTION
# Changes

The current Shipwright strategy examples use privileged containers to run buildah.

With the current PR these have been updated to use more limited permissions/capabilities and align with Tekton task for OpenShift pipelines.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE


# Release Notes

```release-note
The BuildAh sample build strategies now do not anymore run privileged containers
```
