### PR TITLE
Add conversion code for buildrun deletion capability

### DIFF
--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -268,7 +268,7 @@ type BuildRetention struct {
 	// AtBuildDeletion defines if related BuildRuns should be deleted when deleting the Build.
 	//
 	// +optional
-	AtBuildDeletion bool `json:"atBuildDeletion,omitempty"`
+	AtBuildDeletion *bool `json:"atBuildDeletion,omitempty"`
 }
 
 func init() {

--- a/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
@@ -99,6 +99,11 @@ func (in *BuildRetention) DeepCopyInto(out *BuildRetention) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.AtBuildDeletion != nil {
+		in, out := &in.AtBuildDeletion, &out.AtBuildDeletion
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
# Changes

Adding conversion logic for the automatic "BuildRun deletion when Build is deleted" capability which is an annotation in alpha and a first class attribute in beta.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```