### PR TITLE
Handle dockerfile in build strategy conversion

### DIFF
--- a/hack/generate-cert.sh
+++ b/hack/generate-cert.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
+
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-
-#!/bin/bash
 
 set -euo pipefail
 

--- a/hack/patch-crds-with-conversion.sh
+++ b/hack/patch-crds-with-conversion.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
+
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-
-#!/bin/bash
 
 set -euo pipefail
 

--- a/pkg/apis/build/v1beta1/build_conversion.go
+++ b/pkg/apis/build/v1beta1/build_conversion.go
@@ -40,8 +40,10 @@ func (src *Build) ConvertTo(ctx context.Context, obj *unstructured.Unstructured)
 
 	// convert annotation-controlled features
 	if src.Spec.Retention != nil && src.Spec.Retention.AtBuildDeletion != nil {
-		if alphaBuild.ObjectMeta.Annotations == nil {
-			alphaBuild.ObjectMeta.Annotations = make(map[string]string, 1)
+		// We must create a new Map as otherwise the addition is not kept
+		alphaBuild.ObjectMeta.Annotations = map[string]string{}
+		for k, v := range src.Annotations {
+			alphaBuild.ObjectMeta.Annotations[k] = v
 		}
 		alphaBuild.ObjectMeta.Annotations[v1alpha1.AnnotationBuildRunDeletion] = strconv.FormatBool(*src.Spec.Retention.AtBuildDeletion)
 	}

--- a/pkg/apis/build/v1beta1/build_conversion.go
+++ b/pkg/apis/build/v1beta1/build_conversion.go
@@ -27,6 +27,8 @@ var _ webhook.Conversion = (*Build)(nil)
 
 // ConvertTo converts this Build object to v1alpha1 format.
 func (src *Build) ConvertTo(ctx context.Context, obj *unstructured.Unstructured) error {
+	ctxlog.Debug(ctx, "Converting Build from beta to alpha", "namespace", src.Namespace, "name", src.Name)
+
 	var alphaBuild v1alpha1.Build
 
 	alphaBuild.TypeMeta = src.TypeMeta
@@ -64,6 +66,9 @@ func (src *Build) ConvertFrom(ctx context.Context, obj *unstructured.Unstructure
 	if err != nil {
 		ctxlog.Error(ctx, err, "failed unstructuring the convertedObject")
 	}
+
+	ctxlog.Debug(ctx, "Converting Build from alpha to beta", "namespace", alphaBuild.Namespace, "name", alphaBuild.Name)
+
 	src.ObjectMeta = alphaBuild.ObjectMeta
 	src.TypeMeta = alphaBuild.TypeMeta
 	src.TypeMeta.APIVersion = betaGroupVersion
@@ -217,12 +222,14 @@ func (dest *BuildSpec) ConvertTo(bs *v1alpha1.BuildSpec) error {
 	// Handle BuildSpec ParamValues
 	bs.ParamValues = nil
 	for _, p := range dest.ParamValues {
+		if p.Name == "dockerfile" && p.SingleValue != nil {
+			bs.Dockerfile = p.SingleValue.Value
+			continue
+		}
+
 		param := v1alpha1.ParamValue{}
 		p.convertToAlpha(&param)
 		bs.ParamValues = append(bs.ParamValues, param)
-		if param.Name == "dockerfile" {
-			bs.Dockerfile = param.Value
-		}
 	}
 
 	// Handle BuildSpec Output

--- a/pkg/apis/build/v1beta1/buildrun_conversion.go
+++ b/pkg/apis/build/v1beta1/buildrun_conversion.go
@@ -20,6 +20,7 @@ var _ webhook.Conversion = (*BuildRun)(nil)
 
 // To Alpha
 func (src *BuildRun) ConvertTo(ctx context.Context, obj *unstructured.Unstructured) error {
+	ctxlog.Debug(ctx, "Converting BuildRun from beta to alpha", "namespace", src.Namespace, "name", src.Name)
 
 	var alphaBuildRun v1alpha1.BuildRun
 
@@ -109,6 +110,8 @@ func (src *BuildRun) ConvertFrom(ctx context.Context, obj *unstructured.Unstruct
 	if err != nil {
 		ctxlog.Error(ctx, err, "failed unstructuring the buildrun convertedObject")
 	}
+
+	ctxlog.Debug(ctx, "Converting BuildRun from alpha to beta", "namespace", alphaBuildRun.Namespace, "name", alphaBuildRun.Name)
 
 	src.ObjectMeta = alphaBuildRun.ObjectMeta
 	src.TypeMeta = alphaBuildRun.TypeMeta

--- a/pkg/apis/build/v1beta1/clusterbuildstrategy_conversion.go
+++ b/pkg/apis/build/v1beta1/clusterbuildstrategy_conversion.go
@@ -19,6 +19,8 @@ var _ webhook.Conversion = (*ClusterBuildStrategy)(nil)
 
 // ConvertTo converts this object to its v1alpha1 equivalent
 func (src *ClusterBuildStrategy) ConvertTo(ctx context.Context, obj *unstructured.Unstructured) error {
+	ctxlog.Debug(ctx, "Converting ClusterBuildStrategy from beta to alpha", "namespace", src.Namespace, "name", src.Name)
+
 	var bs v1alpha1.ClusterBuildStrategy
 	bs.TypeMeta = src.TypeMeta
 	bs.TypeMeta.APIVersion = alphaGroupVersion
@@ -37,19 +39,21 @@ func (src *ClusterBuildStrategy) ConvertTo(ctx context.Context, obj *unstructure
 
 // ConvertFrom converts v1alpha1.ClusterBuildStrategy into this object
 func (src *ClusterBuildStrategy) ConvertFrom(ctx context.Context, obj *unstructured.Unstructured) error {
-	var br v1alpha1.ClusterBuildStrategy
+	var cbs v1alpha1.ClusterBuildStrategy
 
 	unstructured := obj.UnstructuredContent()
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured, &br)
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured, &cbs)
 	if err != nil {
 		ctxlog.Error(ctx, err, "failed unstructuring the buildrun convertedObject")
 	}
 
-	src.ObjectMeta = br.ObjectMeta
-	src.TypeMeta = br.TypeMeta
+	ctxlog.Debug(ctx, "Converting ClusterBuildStrategy from alpha to beta", "namespace", cbs.Namespace, "name", cbs.Name)
+
+	src.ObjectMeta = cbs.ObjectMeta
+	src.TypeMeta = cbs.TypeMeta
 	src.TypeMeta.APIVersion = betaGroupVersion
 
-	src.Spec.ConvertFrom(br.Spec)
+	src.Spec.ConvertFrom(cbs.Spec)
 
 	return nil
 }

--- a/pkg/webhook/conversion/converter.go
+++ b/pkg/webhook/conversion/converter.go
@@ -80,7 +80,7 @@ func convertSHPCR(ctx context.Context, Object *unstructured.Unstructured, toVers
 				}
 				clusterBuildStrategy.ConvertTo(ctx, convertedObject)
 			} else {
-				return nil, statusErrorWithMessage("unsupporteddda skdksdjkjsd Kind")
+				return nil, statusErrorWithMessage("unsupported Kind")
 			}
 		default:
 			return nil, statusErrorWithMessage("unexpected conversion version to %q", toVersion)

--- a/pkg/webhook/conversion/converter_test.go
+++ b/pkg/webhook/conversion/converter_test.go
@@ -260,12 +260,6 @@ request:
 					},
 					ParamValues: []v1alpha1.ParamValue{
 						{
-							Name: "dockerfile",
-							SingleValue: &v1alpha1.SingleValue{
-								Value: &dockerfileVal,
-							},
-						},
-						{
 							Name: "foo1",
 							SingleValue: &v1alpha1.SingleValue{
 								Value: &valDisable,
@@ -978,6 +972,10 @@ request:
         steps:
         - name: step-foobar
           image: foobar
+          command:
+          - some-command
+          args:
+          - $(params.dockerfile)
           securityContext:
             privileged: false
         parameters:
@@ -987,6 +985,10 @@ request:
         - name: param_two
           description: foobar
           type: array
+        - name: dockerfile
+          description: The Dockerfile to build.
+          type: string
+          default: Dockerfile
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000
@@ -1024,8 +1026,10 @@ request:
 					BuildSteps: []v1alpha1.BuildStep{
 						{
 							Container: corev1.Container{
-								Name:  "step-foobar",
-								Image: "foobar",
+								Name:    "step-foobar",
+								Command: []string{"some-command"},
+								Args:    []string{"$(params.DOCKERFILE)"},
+								Image:   "foobar",
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: &privileged,
 								},
@@ -1079,6 +1083,10 @@ request:
       spec:
         buildSteps:
         - name: step-foobar
+          command:
+          - some-command
+          args:
+          - $(params.DOCKERFILE)
           image: foobar
           securityContext:
             privileged: false
@@ -1125,8 +1133,10 @@ request:
 				Spec: v1beta1.BuildStrategySpec{
 					Steps: []v1beta1.Step{
 						{
-							Name:  "step-foobar",
-							Image: "foobar",
+							Name:    "step-foobar",
+							Command: []string{"some-command"},
+							Args:    []string{"$(params.dockerfile)"},
+							Image:   "foobar",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &privileged,
 							},
@@ -1142,6 +1152,12 @@ request:
 							Name:        "param_two",
 							Description: "foobar",
 							Type:        v1beta1.ParameterTypeArray,
+						},
+						{
+							Name:        "dockerfile",
+							Description: "The Dockerfile to be built.",
+							Type:        v1beta1.ParameterTypeString,
+							Default:     pointer.String("Dockerfile"),
 						},
 					},
 					SecurityContext: &v1beta1.BuildStrategySecurityContext{


### PR DESCRIPTION
# Changes

This change completes the handling of Dockerfiles:

* When a Beta build contains a Dockerfile parameter, then this is converted to .spec.dockerfile in Alpha without adding the parameter
* An Alpha build strategy that uses `$(build.dockerfile)` or `$(params.DOCKERFILE)` gets their usage migrated to `$(params.dockerfile)` and the dockerfile parameter is declared
* A Beta build strategy that declares a dockerfile parameter as string with Dockerfile as default value gets this parameter removed and all referenced changed to `$(params.DOCKERFILE)
`
I am also adding a commit that fixes the conversion of the retention from alpha to beta. The old code worked find in unit tests but not in reality. We must create a copy of the Map so that the annotation addition works.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
