### PR TITLE
Update release process for webhook certificate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,12 @@ jobs:
           kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-webhook --timeout=1m
       - name: Test
         run: |
+          # host.docker.internal does not work in a GitHub action
+          docker exec kind-control-plane bash -c "echo '172.17.0.1 host.docker.internal' >>/etc/hosts"
+
+          # Build and load the Git image
           export GIT_CONTAINER_IMAGE="$(KO_DOCKER_REPO=kind.local ko publish ./cmd/git)"
+
           make test-integration
 
   e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install Ko
         uses: ko-build/setup-ko@v0.6
         with:
-          version: v0.13.0
+          version: v0.14.1
       - name: Install kubectl
         uses: azure/setup-kubectl@v3
         with:
@@ -175,10 +175,9 @@ jobs:
       - name: Install Ko
         uses: ko-build/setup-ko@v0.6
         with:
-          version: v0.13.0
+          version: v0.14.1
       - name: Install Shipwright Build
         run: |
-          make prepare-conversion
           make install-controller-kind
           kubectl -n shipwright-build rollout status deployment shipwright-build-controller --timeout=1m || true
           kubectl -n shipwright-build rollout status deployment shipwright-build-webhook --timeout=1m || true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -29,7 +29,7 @@ jobs:
     # Install tools
     - uses: ko-build/setup-ko@v0.6
       with:
-        version: v0.13.0
+        version: v0.14.1
     - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4
     - uses: sigstore/cosign-installer@v3
 
@@ -54,6 +54,9 @@ jobs:
 
         mv sample-strategies.yaml nightly-${{ steps.date.outputs.date }}-sample-strategies.yaml
         gh release upload nightly nightly-${{ steps.date.outputs.date }}-sample-strategies.yaml
+
+        echo ${{ steps.date.outputs.date }} > /tmp/latest.txt
+        gh release upload nightly /tmp/latest.txt --clobber
 
     - name: Update latest tag of supporting images
       working-directory: ./cmd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
     # Install tools
     - uses: ko-build/setup-ko@v0.6
       with:
-        version: v0.13.0
+        version: v0.14.1
     - uses: sigstore/cosign-installer@v3
 
     - name: Build Release Changelog

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -37,7 +37,10 @@ jobs:
     - name: Install Counterfeiter
       run: |
         make -C go/src/github.com/shipwright-io/build install-counterfeiter
+    - name: Install Spruce
+      run: |
+        make -C go/src/github.com/shipwright-io/build install-spruce
     - name: Run verify-generate
       run: |
         export GOPATH="${GITHUB_WORKSPACE}"/go
-        make -C $GOPATH/src/github.com/shipwright-io/build verify-generate
+        make -C go/src/github.com/shipwright-io/build verify-generate

--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,6 @@ generate:
 	hack/generate-copyright.sh
 	hack/install-controller-gen.sh
 	"$(CONTROLLER_GEN)" crd rbac:roleName=manager-role webhook paths="./..." output:crd:dir=deploy/crds
-
-.PHONY: prepare-conversion
-prepare-conversion:
-	hack/generate-cert.sh
-	hack/install-spruce.sh
 	hack/patch-crds-with-conversion.sh
 
 .PHONY: verify-generate
@@ -261,6 +256,7 @@ install-controller-kind: install-apis
 	ko apply \
 	  --platform=$(GO_OS)/$(GO_ARCH) \
 	  --filename=deploy
+	./hack/setup-webhook-cert.sh
 
 .PHONY: install-strategies
 install-strategies: install-apis

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
   ```bash
   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.44.0/release.yaml
   ```
+
   If you are using OpenShift cluster refer [Running on OpenShift](#running-on-openshift) for some more configurations.
 
 - Install the Shipwright deployment. To install the latest version, run:
@@ -51,10 +52,23 @@ Shipwright supports any tool that can build container images in Kubernetes clust
   kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.11.0/release.yaml
   ```
 
+  To install the latest nightly release, run:
+
+  ```bash
+  kubectl apply --filename "https://github.com/shipwright-io/build/releases/download/nightly/nightly-$(curl --silent https://github.com/shipwright-io/build/releases/download/nightly/latest.txt).yaml" --server-side
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/setup-webhook-cert.sh | bash
+  ```
+
 - Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
   kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.11.0/sample-strategies.yaml
+  ```
+
+  To install the latest nightly release, run:
+
+  ```bash
+  kubectl apply --filename "https://github.com/shipwright-io/build/releases/download/nightly/nightly-$(curl --silent https://github.com/shipwright-io/build/releases/download/nightly/latest.txt)-sample-strategies.yaml" --server-side
   ```
 
 - Generate a secret to access your container registry, such as one on [Docker Hub](https://hub.docker.com/) or [Quay.io](https://quay.io/):

--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7,6 +6,16 @@ metadata:
   creationTimestamp: null
   name: buildruns.shipwright.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: shp-build-webhook
+          namespace: shipwright-build
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: shipwright.io
   names:
     kind: BuildRun
@@ -12246,3 +12255,4 @@ spec:
     storage: false
     subresources:
       status: {}
+

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7,6 +6,16 @@ metadata:
   creationTimestamp: null
   name: builds.shipwright.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: shp-build-webhook
+          namespace: shipwright-build
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: shipwright.io
   names:
     kind: Build
@@ -4090,3 +4099,4 @@ spec:
     storage: false
     subresources:
       status: {}
+

--- a/deploy/crds/shipwright.io_buildstrategies.yaml
+++ b/deploy/crds/shipwright.io_buildstrategies.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7,6 +6,16 @@ metadata:
   creationTimestamp: null
   name: buildstrategies.shipwright.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: shp-build-webhook
+          namespace: shipwright-build
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: shipwright.io
   names:
     kind: BuildStrategy
@@ -4875,3 +4884,4 @@ spec:
     storage: false
     subresources:
       status: {}
+

--- a/deploy/crds/shipwright.io_clusterbuildstrategies.yaml
+++ b/deploy/crds/shipwright.io_clusterbuildstrategies.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7,6 +6,16 @@ metadata:
   creationTimestamp: null
   name: clusterbuildstrategies.shipwright.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: shp-build-webhook
+          namespace: shipwright-build
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: shipwright.io
   names:
     kind: ClusterBuildStrategy
@@ -4875,3 +4884,4 @@ spec:
     storage: false
     subresources:
       status: {}
+

--- a/hack/customization/conversion_webhook_block.yaml
+++ b/hack/customization/conversion_webhook_block.yaml
@@ -3,7 +3,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: CA_BUNDLE
         service:
           namespace: shipwright-build
           name: shp-build-webhook

--- a/hack/patch-crds-with-conversion.sh
+++ b/hack/patch-crds-with-conversion.sh
@@ -7,28 +7,27 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
-TARGET_DIR=/tmp/
 
 if ! hash spruce > /dev/null 2>&1 ; then
     echo "[ERROR] spruce binary is not installed, see the install-spruce target"
 fi
 
 echo "[INFO] Going to patch the Build CRD"
-spruce merge $DIR/hack/customization/conversion_webhook_block.yaml $DIR/deploy/crds/shipwright.io_builds.yaml > /tmp/shipwright.io_builds.yaml
-mv /tmp/shipwright.io_builds.yaml "${DIR}"/deploy/crds/shipwright.io_builds.yaml
+spruce merge "${DIR}/hack/customization/conversion_webhook_block.yaml" "${DIR}/deploy/crds/shipwright.io_builds.yaml" > /tmp/shipwright.io_builds.yaml
+mv /tmp/shipwright.io_builds.yaml "${DIR}/deploy/crds/shipwright.io_builds.yaml"
 echo "[INFO] Build CRD successfully patched"
 
 echo "[INFO] Going to patch the BuildRun CRD"
-spruce merge $DIR/hack/customization/conversion_webhook_block.yaml $DIR/deploy/crds/shipwright.io_buildruns.yaml > /tmp/shipwright.io_buildruns.yaml
-mv /tmp/shipwright.io_buildruns.yaml "${DIR}"/deploy/crds/shipwright.io_buildruns.yaml
+spruce merge "${DIR}/hack/customization/conversion_webhook_block.yaml" "${DIR}/deploy/crds/shipwright.io_buildruns.yaml" > /tmp/shipwright.io_buildruns.yaml
+mv /tmp/shipwright.io_buildruns.yaml "${DIR}/deploy/crds/shipwright.io_buildruns.yaml"
 echo "[INFO] BuildRun CRD successfully patched"
 
 echo "[INFO] Going to patch the BuildStrategy CRD"
-spruce merge $DIR/hack/customization/conversion_webhook_block.yaml $DIR/deploy/crds/shipwright.io_buildstrategies.yaml > /tmp/shipwright.io_buildstrategies.yaml
-mv /tmp/shipwright.io_buildstrategies.yaml "${DIR}"/deploy/crds/shipwright.io_buildstrategies.yaml
+spruce merge "${DIR}/hack/customization/conversion_webhook_block.yaml" "${DIR}/deploy/crds/shipwright.io_buildstrategies.yaml" > /tmp/shipwright.io_buildstrategies.yaml
+mv /tmp/shipwright.io_buildstrategies.yaml "${DIR}/deploy/crds/shipwright.io_buildstrategies.yaml"
 echo "[INFO] BuildStrategy CRD successfully patched"
 
 echo "[INFO] Going to patch the ClusterBuildStrategy CRD"
-spruce merge $DIR/hack/customization/conversion_webhook_block.yaml $DIR/deploy/crds/shipwright.io_clusterbuildstrategies.yaml > /tmp/shipwright.io_clusterbuildstrategies.yaml
-mv /tmp/shipwright.io_clusterbuildstrategies.yaml "${DIR}"/deploy/crds/shipwright.io_clusterbuildstrategies.yaml
+spruce merge "${DIR}/hack/customization/conversion_webhook_block.yaml" "${DIR}/deploy/crds/shipwright.io_clusterbuildstrategies.yaml" > /tmp/shipwright.io_clusterbuildstrategies.yaml
+mv /tmp/shipwright.io_clusterbuildstrategies.yaml "${DIR}/deploy/crds/shipwright.io_clusterbuildstrategies.yaml"
 echo "[INFO] ClusterBuildStrategy CRD successfully patched"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -13,19 +13,28 @@ echo "Building container image"
 
 echo "Adding io.shipwright.vcs-ref label with value: ${GITHUB_SHA}"
 
+PLATFORM="${PLATFORM:-all}"
+
+echo "[INFO] Building images and release.yaml"
 KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" GOFLAGS="${GO_FLAGS}" ko resolve \
   --base-import-paths \
+  --recursive \
   --tags "${TAG}" \
   --image-label "io.shipwright.vcs-ref=${GITHUB_SHA}" \
-  --platform=all -R -f deploy/ > release.yaml
+  --platform "${PLATFORM}" \
+  --filename deploy/ > release.yaml
 
+echo "[INFO] Building debug images and release-debug.yaml"
 KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" GOFLAGS="${GO_FLAGS} -tags=pprof_enabled" ko resolve \
   --base-import-paths \
+  --recursive \
   --tags "${TAG}-debug" \
   --image-label "io.shipwright.vcs-ref=${GITHUB_SHA}" \
-  --platform=all -R -f deploy/ > release-debug.yaml
+  --platform "${PLATFORM}" \
+  --filename deploy/ > release-debug.yaml
 
 # Bundle the sample cluster build strategies, remove namespace strategies first
+echo "[INFO] Bundling sample build strategies"
 find samples/buildstrategy -type f -print0 | xargs -0 grep -l "kind: BuildStrategy" | xargs rm -f
-ko resolve -R -f samples/buildstrategy/ > sample-strategies.yaml
+KO_DOCKER_REPO=dummy ko resolve --recursive --filename samples/buildstrategy/ > sample-strategies.yaml
 git restore samples/buildstrategy

--- a/hack/setup-webhook-cert-integration-test.sh
+++ b/hack/setup-webhook-cert-integration-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if ! hash jq >/dev/null 2>&1 ; then
+  echo "[ERROR] jq is not installed"
+  exit 1
+fi
+
+if ! hash openssl >/dev/null 2>&1 ; then
+  echo "[ERROR] openssl is not installed"
+  exit 1
+fi
+
+echo "[INFO] Generating key and signing request for Shipwright Build Webhook"
+
+cat <<EOF >/tmp/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = host.docker.internal
+EOF
+
+openssl genrsa -out /tmp/server-key.pem 2048
+openssl req -new -days 365 -key /tmp/server-key.pem -subj "/O=system:nodes/CN=system:node:host.docker.internal" -out /tmp/server.csr -config /tmp/csr.conf
+
+echo "[INFO] Deleting previous CertificateSigningRequest"
+kubectl delete csr shipwright-build-webhook-csr --ignore-not-found
+
+echo "[INFO] Create a CertificateSigningRequest"
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: shipwright-build-webhook-csr
+spec:
+  groups:
+  - system:authenticated
+  request: $(base64 </tmp/server.csr | tr -d '\n')
+  signerName: kubernetes.io/kubelet-serving
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+echo "[INFO] Approve the CertificateSigningRequest"
+kubectl certificate approve shipwright-build-webhook-csr
+
+certificate="$(kubectl get csr shipwright-build-webhook-csr -o json | jq -r '.status.certificate')"
+while [ "${certificate}" == "null" ]; do
+  echo "[INFO] Waiting for certificate to be ready"
+  sleep 1
+  certificate="$(kubectl get csr shipwright-build-webhook-csr -o json | jq -r '.status.certificate')"
+done
+
+openssl base64 -d -A -out /tmp/server-cert.pem <<<"${certificate}"
+
+echo "[INFO] Deleting the CertificateSigningRequest"
+kubectl delete csr shipwright-build-webhook-csr --ignore-not-found
+rm -rf /tmp/csr.conf
+
+echo "[INFO] Retrieving CABundle"
+CA="$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')"
+
+echo "[INFO] Patching caBundle into CustomResourceDefinitions"
+kubectl patch crd clusterbuildstrategies.shipwright.io --type=json -p "[{\"op\":\"replace\",\"path\":\"/spec/conversion/webhook/clientConfig\",\"value\":{\"caBundle\":\"${CA}\",\"url\":\"https://host.docker.internal:30443/convert\"}}]"
+kubectl patch crd buildstrategies.shipwright.io --type=json -p "[{\"op\":\"replace\",\"path\":\"/spec/conversion/webhook/clientConfig\",\"value\":{\"caBundle\":\"${CA}\",\"url\":\"https://host.docker.internal:30443/convert\"}}]"
+kubectl patch crd builds.shipwright.io --type=json -p "[{\"op\":\"replace\",\"path\":\"/spec/conversion/webhook/clientConfig\",\"value\":{\"caBundle\":\"${CA}\",\"url\":\"https://host.docker.internal:30443/convert\"}}]"
+kubectl patch crd buildruns.shipwright.io --type=json -p "[{\"op\":\"replace\",\"path\":\"/spec/conversion/webhook/clientConfig\",\"value\":{\"caBundle\":\"${CA}\",\"url\":\"https://host.docker.internal:30443/convert\"}}]"

--- a/hack/setup-webhook-cert.sh
+++ b/hack/setup-webhook-cert.sh
@@ -6,9 +6,17 @@
 
 set -euo pipefail
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+if ! hash jq >/dev/null 2>&1 ; then
+  echo "[ERROR] jq is not installed"
+  exit 1
+fi
 
-echo "[INFO] Generating key for Shipwright Build Webhook"
+if ! hash openssl >/dev/null 2>&1 ; then
+  echo "[ERROR] openssl is not installed"
+  exit 1
+fi
+
+echo "[INFO] Generating key and signing request for Shipwright Build Webhook"
 
 cat <<EOF >/tmp/csr.conf
 [req]
@@ -28,10 +36,10 @@ DNS.4 = shp-build-webhook.shipwright-build.svc.cluster.local
 EOF
 
 openssl genrsa -out /tmp/server-key.pem 2048
-openssl req -new -days 365  -key /tmp/server-key.pem -subj "/O=system:nodes/CN=system:node:shp-build-webhook.shipwright-build.svc.cluster.local" -out /tmp/server.csr -config /tmp/csr.conf
+openssl req -new -days 365 -key /tmp/server-key.pem -subj "/O=system:nodes/CN=system:node:shp-build-webhook.shipwright-build.svc.cluster.local" -out /tmp/server.csr -config /tmp/csr.conf
+
 echo "[INFO] Deleting previous CertificateSigningRequest"
 kubectl delete csr shipwright-build-webhook-csr --ignore-not-found
-
 
 echo "[INFO] Create a CertificateSigningRequest"
 cat <<EOF | kubectl create -f -
@@ -42,7 +50,7 @@ metadata:
 spec:
   groups:
   - system:authenticated
-  request: $(cat /tmp/server.csr | base64 | tr -d '\n')
+  request: $(base64 </tmp/server.csr | tr -d '\n')
   signerName: kubernetes.io/kubelet-serving
   usages:
   - digital signature
@@ -52,7 +60,6 @@ EOF
 
 echo "[INFO] Approve the CertificateSigningRequest"
 kubectl certificate approve shipwright-build-webhook-csr
-
 
 certificate=$(kubectl get csr shipwright-build-webhook-csr -o json | jq -r '.status.certificate')
 while [ "${certificate}" == "null" ]; do
@@ -66,17 +73,20 @@ openssl base64 -d -A -out /tmp/server-cert.pem <<<"${certificate}"
 echo "[INFO] Deleting the CertificateSigningRequest"
 kubectl delete csr shipwright-build-webhook-csr --ignore-not-found
 
-
-echo "[INFO] Creating shipwright-build namespace"
-kubectl apply -f $DIR/deploy/100-namespace.yaml
-
-echo "[INFO] Creating Opaque Secret with generated certificates"
-kubectl create secret tls shipwright-build-webhook-cert -n shipwright-build --cert /tmp/server-cert.pem --key /tmp/server-key.pem
-
+echo "[INFO] Creating TLS secret shipwright-build-webhook-cert"
+kubectl -n shipwright-build delete secret shipwright-build-webhook-cert --ignore-not-found
+kubectl -n shipwright-build create secret tls shipwright-build-webhook-cert --cert /tmp/server-cert.pem --key /tmp/server-key.pem
 rm -rf /tmp/csr.conf /tmp/server-cert.pem /tmp/server-key.pem
 
 echo "[INFO] Retrieving CABundle"
-CA=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
+CA="$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')"
 
-echo "[INFO] Applying CABundle into customization/conversion_webhook_block.yaml"
-sed -i "s/CA_BUNDLE/${CA}/g" $DIR/hack/customization/conversion_webhook_block.yaml
+echo "[INFO] Patching caBundle into CustomResourceDefinitions"
+kubectl patch crd clusterbuildstrategies.shipwright.io -p "{\"spec\":{\"conversion\":{\"webhook\":{\"clientConfig\":{\"caBundle\":\"${CA}\"}}}}}"
+kubectl patch crd buildstrategies.shipwright.io -p "{\"spec\":{\"conversion\":{\"webhook\":{\"clientConfig\":{\"caBundle\":\"${CA}\"}}}}}"
+kubectl patch crd builds.shipwright.io -p "{\"spec\":{\"conversion\":{\"webhook\":{\"clientConfig\":{\"caBundle\":\"${CA}\"}}}}}"
+kubectl patch crd buildruns.shipwright.io -p "{\"spec\":{\"conversion\":{\"webhook\":{\"clientConfig\":{\"caBundle\":\"${CA}\"}}}}}"
+
+echo "[INFO] Restarting shipwright-build-webhook"
+kubectl -n shipwright-build rollout restart deployment shipwright-build-webhook
+kubectl -n shipwright-build rollout status deployment shipwright-build-webhook

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -6,6 +6,7 @@ package integration_test
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,9 +29,20 @@ func TestIntegration(t *testing.T) {
 // TODO: clean resources in cluster, e.g. mainly cluster-scope ones
 // TODO: clean each resource created per spec
 var (
-	tb  *utils.TestBuild
-	err error
+	tb            *utils.TestBuild
+	err           error
+	webhookServer *http.Server
 )
+
+var _ = BeforeSuite(func() {
+	webhookServer = utils.StartBuildWebhook()
+})
+
+var _ = AfterSuite(func() {
+	if webhookServer != nil {
+		utils.StopBuildWebhook(webhookServer)
+	}
+})
 
 var _ = BeforeEach(func() {
 	tb, err = utils.NewTestBuild()

--- a/test/utils/environment.go
+++ b/test/utils/environment.go
@@ -25,7 +25,6 @@ import (
 	buildClient "github.com/shipwright-io/build/pkg/client/clientset/versioned"
 	"github.com/shipwright-io/build/pkg/ctxlog"
 	"github.com/shipwright-io/build/test"
-	// from https://github.com/kubernetes/client-go/issues/345
 )
 
 var (
@@ -42,11 +41,11 @@ type TestBuild struct {
 	Interval                 time.Duration
 	TimeOut                  time.Duration
 	KubeConfig               *rest.Config
-	Clientset                *kubernetes.Clientset
+	Clientset                kubernetes.Interface
 	Namespace                string
 	StopBuildControllers     context.CancelFunc
-	BuildClientSet           *buildClient.Clientset
-	PipelineClientSet        *tektonClient.Clientset
+	BuildClientSet           buildClient.Interface
+	PipelineClientSet        tektonClient.Interface
 	ControllerRuntimeClient  client.Client
 	Catalog                  test.Catalog
 	Context                  context.Context

--- a/test/utils/namespaces.go
+++ b/test/utils/namespaces.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -68,5 +69,5 @@ func (t *TestBuild) DeleteNamespace() error {
 		return false, nil
 	}
 
-	return wait.PollImmediate(t.Interval, t.TimeOut, pollNamespace)
+	return wait.PollImmediate(t.Interval, 5*time.Second, pollNamespace)
 }

--- a/test/utils/webhook.go
+++ b/test/utils/webhook.go
@@ -1,0 +1,110 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/shipwright-io/build/pkg/webhook/conversion"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func StartBuildWebhook() *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/convert", conversion.CRDConvertHandler(context.Background()))
+	mux.HandleFunc("/health", health)
+
+	webhookServer := &http.Server{
+		Addr:              ":30443",
+		Handler:           mux,
+		ReadHeaderTimeout: 32 * time.Second,
+		IdleTimeout:       time.Second,
+		TLSConfig: &tls.Config{
+			MinVersion:       tls.VersionTLS12,
+			CurvePreferences: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.X25519},
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			},
+		},
+	}
+
+	// start server
+	go func() {
+		defer ginkgo.GinkgoRecover()
+
+		if err := webhookServer.ListenAndServeTLS("/tmp/server-cert.pem", "/tmp/server-key.pem"); err != nil {
+			if err != http.ErrServerClosed {
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		}
+	}()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			IdleConnTimeout:       5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			// #nosec:G402 test code
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			TLSHandshakeTimeout: 5 * time.Second,
+		},
+	}
+
+	gomega.Eventually(func() int {
+		r, err := client.Get("https://localhost:30443/health")
+		if err != nil {
+			return 0
+		}
+		if r != nil {
+			return r.StatusCode
+		}
+		return 0
+	}).WithTimeout(10 * time.Second).Should(gomega.Equal(http.StatusNoContent))
+
+	return webhookServer
+}
+
+func StopBuildWebhook(webhookServer *http.Server) {
+	err := webhookServer.Close()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			IdleConnTimeout:       5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			// #nosec:G402 test code
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			TLSHandshakeTimeout: 5 * time.Second,
+		},
+	}
+
+	gomega.Eventually(func() int {
+		r, err := client.Get("https://localhost:30443/health")
+		if err != nil {
+			return 0
+		}
+		if r != nil {
+			return r.StatusCode
+		}
+		return 0
+	}).WithTimeout(10 * time.Second).Should(gomega.Equal(0))
+}
+
+func health(resp http.ResponseWriter, _ *http.Request) {
+	resp.WriteHeader(http.StatusNoContent)
+}


### PR DESCRIPTION
# Changes

Part of https://github.com/shipwright-io/build/issues/1344

I am changing `make generate` to also run the hack/patch-crds-with-conversion.sh script so that the conversion block is now part of the CRDs that are committed.

With that, we are producing an incomplete release yaml where two things are missing: the shipwright-build-webhook-cert secret and the caBundle in the CRDs.

I am introducing hack/setup-webhook-cert.sh which can run against a cluster to create or update the webhook cert and configure the caBundle.

I am changing `make install-controller-kind` to call this script so that it can be used again as single make target to setup Shipwright Build. That is also required for the setup GitHub action which calls this make target and nothing else. The prepare-conversion target is therefore obsolete.

I am changing the nightly build to publish a latest.txt containing the timestamp. I am using this in the README to provide an easy command to install the latest which includes invoking the setup-webhook-cert.sh script.

I tested as much as I could locally, but will need to retest this after the nightly build ran for the first time with this.

Users who will install v0.12 will need to apply the release YAML and then run the setup script from the v0.12 tag. We will mention this in the release notes and will need to update the README again once we release.

The changes to release.sh are non-functional. I only added an env var to override the platform from the outside (which makes testing much faster if you call that script and just build for one platform instead of all), and adjusted the `ko` commands to be consistent by always using the long parameter name.  And I needed to add a dummy KO_DOCKER_REPO to the sample build strategy command - it does not actually build any binary, but for me it always failed with exit code 123 (or 132 ?) until I specified it.

Finally, I had to fix the integration tests. Basically, whenever Kubernetes performs an operation on Shipwright artifacts, it will perform it on the Beta object. This applies to deletion propagation mainly: when a Build owns all BuildRuns and the Build is deleted, or when a namespace is deleted that contains Shipwright artifacts. Because of this, I changed the integration test to setup the CRDs with a URL with host.docker.internal, and start the webhook in the `BeforeSuite` of the integration tests. This works locally, but not in the GitHub action. The tests are still green because I reduced the wait time for the namespace deletion and when it is not deleted, it only prints a warning, and this warning (`failed to delete namespace: test-build-291, with error: timed out waiting for the condition`) happens for every test run. We should eventually address this.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Installing a nightly release now requires you to run a post-script that sets up the TLS certificate of the coversion webhook
```
