### PR TITLE
Ensure assets deletion use a sleep time

### DIFF
--- a/.github/workflows/cleanup-nightly-assets.yaml
+++ b/.github/workflows/cleanup-nightly-assets.yaml
@@ -36,8 +36,13 @@ jobs:
           exit 0
         fi
 
+        echo "[INFO] Going to delete ${ASSETS_TO_REMOVE} assets"
+
         find $WORK_DIR -type f -iname "*.yaml" -printf "%f\n" | grep  -v "${{ steps.currentmonth.outputs.date }}\|${{ steps.previousmonth.outputs.date }}" |
           while IFS= read FILE; do
+            # sleep 2 sec, as recommended by https://docs.github.com/en/rest/guides/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#dealing-with-secondary-rate-limits
+            sleep 2
+            echo "[INFO] Going to delete ${FILE} asset"
             gh release delete-asset nightly $FILE -y
           done
 


### PR DESCRIPTION
# Changes

Introduce a sleep time when deleting assets from nightly release, recommended by github when hitting the secondary rate limits.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```
