### PR TITLE
Removing Strategy.APIversion

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -6732,9 +6732,6 @@ spec:
                         description: Strategy references the BuildStrategy to use
                           to build the container image.
                         properties:
-                          apiVersion:
-                            description: API version of the referent
-                            type: string
                           kind:
                             description: BuildStrategyKind indicates the kind of the
                               buildstrategy, namespaced or cluster scoped.
@@ -10694,9 +10691,6 @@ spec:
                     description: Strategy references the BuildStrategy to use to build
                       the container image.
                     properties:
-                      apiVersion:
-                        description: API version of the referent
-                        type: string
                       kind:
                         description: BuildStrategyKind indicates the kind of the buildstrategy,
                           namespaced or cluster scoped.

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -2508,9 +2508,6 @@ spec:
                 description: Strategy references the BuildStrategy to use to build
                   the container image.
                 properties:
-                  apiVersion:
-                    description: API version of the referent
-                    type: string
                   kind:
                     description: BuildStrategyKind indicates the kind of the buildstrategy,
                       namespaced or cluster scoped.

--- a/pkg/apis/build/v1beta1/build_conversion.go
+++ b/pkg/apis/build/v1beta1/build_conversion.go
@@ -133,9 +133,8 @@ func (dest *BuildSpec) ConvertFrom(orig *v1alpha1.BuildSpec) error {
 
 	// Handle BuildSpec Strategy
 	dest.Strategy = Strategy{
-		Name:       orig.StrategyName(),
-		Kind:       (*BuildStrategyKind)(orig.Strategy.Kind),
-		APIVersion: orig.Strategy.APIVersion,
+		Name: orig.StrategyName(),
+		Kind: (*BuildStrategyKind)(orig.Strategy.Kind),
 	}
 
 	// Handle BuildSpec ParamValues
@@ -213,9 +212,8 @@ func (dest *BuildSpec) ConvertTo(bs *v1alpha1.BuildSpec) error {
 
 	// Handle BuildSpec Strategy
 	bs.Strategy = v1alpha1.Strategy{
-		Name:       dest.StrategyName(),
-		Kind:       (*v1alpha1.BuildStrategyKind)(dest.Strategy.Kind),
-		APIVersion: dest.Strategy.APIVersion,
+		Name: dest.StrategyName(),
+		Kind: (*v1alpha1.BuildStrategyKind)(dest.Strategy.Kind),
 	}
 
 	// Handle BuildSpec Builder, TODO

--- a/pkg/apis/build/v1beta1/buildstrategy.go
+++ b/pkg/apis/build/v1beta1/buildstrategy.go
@@ -187,10 +187,6 @@ type Strategy struct {
 
 	// BuildStrategyKind indicates the kind of the buildstrategy, namespaced or cluster scoped.
 	Kind *BuildStrategyKind `json:"kind,omitempty"`
-
-	// API version of the referent
-	// +optional
-	APIVersion *string `json:"apiVersion,omitempty"`
 }
 
 // BuilderStrategy defines the common elements of build strategies

--- a/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
@@ -1139,11 +1139,6 @@ func (in *Strategy) DeepCopyInto(out *Strategy) {
 		*out = new(BuildStrategyKind)
 		**out = **in
 	}
-	if in.APIVersion != nil {
-		in, out := &in.APIVersion, &out.APIVersion
-		*out = new(string)
-		**out = **in
-	}
 	return
 }
 


### PR DESCRIPTION
# Changes

Fixes #1363 

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The Strategy struct does not have an APIVersion field anymore.
```
