### PR TITLE
Omit empty output object in BuildRun spec

### DIFF
--- a/pkg/apis/build/v1beta1/buildrun_conversion.go
+++ b/pkg/apis/build/v1beta1/buildrun_conversion.go
@@ -224,16 +224,17 @@ func (dest *BuildRunSpec) ConvertFrom(orig *v1alpha1.BuildRunSpec) error {
 		dest.ParamValues = append(dest.ParamValues, param)
 	}
 
-	// Handle BuildSpec Output
-	dest.Output = &Image{}
+	// Handle BuildRunSpec Output
 	if orig.Output != nil {
-		dest.Output.Image = orig.Output.Image
-		dest.Output.Annotations = orig.Output.Annotations
-		dest.Output.Labels = orig.Output.Labels
-	}
+		dest.Output = &Image{
+			Image:       orig.Output.Image,
+			Annotations: orig.Output.Annotations,
+			Labels:      orig.Output.Labels,
+		}
 
-	if orig.Output != nil && orig.Output.Credentials != nil {
-		dest.Output.PushSecret = &orig.Output.Credentials.Name
+		if orig.Output.Credentials != nil {
+			dest.Output.PushSecret = &orig.Output.Credentials.Name
+		}
 	}
 
 	// BuildRunSpec State

--- a/pkg/webhook/conversion/converter_test.go
+++ b/pkg/webhook/conversion/converter_test.go
@@ -1089,7 +1089,6 @@ request:
 							},
 						},
 					},
-					Output: &v1beta1.Image{},
 				},
 			}
 

--- a/test/utils/v1beta1/image.go
+++ b/test/utils/v1beta1/image.go
@@ -22,7 +22,7 @@ import (
 
 func getImageURL(buildRun *buildv1beta1.BuildRun) string {
 	image := ""
-	if buildRun.Spec.Output.Image != "" {
+	if buildRun.Spec.Output != nil && buildRun.Spec.Output.Image != "" {
 		image = buildRun.Spec.Output.Image
 	} else {
 		image = buildRun.Status.BuildSpec.Output.Image


### PR DESCRIPTION
# Changes

When a BuildRun without an output is converted to Beta, then this looks like this:

```yaml
apiVersion: shipwright.io/v1beta1
kind: BuildRun
spec:
  build:
    name: build-name
  output:
    image: ""
  serviceAccount: sa-name
```

The empty output section is not desired, especially as it has a mandatory image field which is then rendered as an empty string.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
