### PR TITLE
Fix `G402` reports with latest `gosec` version

### DIFF
--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -52,17 +52,15 @@ func GetOptions(ctx context.Context, imageName name.Reference, insecure bool, do
 	options = append(options, remote.WithContext(ctx))
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: false,
+	}
 
 	if insecure {
-		// #nosec:G402 explicitly requested by user to use insecure registry
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-	} else {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: false,
-			MinVersion:         tls.VersionTLS12,
-		}
+		// #nosec:G402 insecure is explicitly requested by user, make sure to skip verification and reset empty defaults
+		transport.TLSClientConfig.InsecureSkipVerify = insecure
+		transport.TLSClientConfig.MinVersion = 0
 	}
 
 	// find a Docker config.json

--- a/test/utils/v1alpha1/webhook.go
+++ b/test/utils/v1alpha1/webhook.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/shipwright-io/build/pkg/webhook/conversion"
+	"github.com/shipwright-io/build/test/utils"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -51,20 +52,8 @@ func StartBuildWebhook() *http.Server {
 		}
 	}()
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			IdleConnTimeout:       5 * time.Second,
-			ResponseHeaderTimeout: 5 * time.Second,
-			// #nosec:G402 test code
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-			TLSHandshakeTimeout: 5 * time.Second,
-		},
-	}
-
 	gomega.Eventually(func() int {
-		r, err := client.Get("https://localhost:30443/health")
+		r, err := utils.TestClient().Get("https://localhost:30443/health")
 		if err != nil {
 			return 0
 		}
@@ -81,20 +70,8 @@ func StopBuildWebhook(webhookServer *http.Server) {
 	err := webhookServer.Close()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			IdleConnTimeout:       5 * time.Second,
-			ResponseHeaderTimeout: 5 * time.Second,
-			// #nosec:G402 test code
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-			TLSHandshakeTimeout: 5 * time.Second,
-		},
-	}
-
 	gomega.Eventually(func() int {
-		r, err := client.Get("https://localhost:30443/health")
+		r, err := utils.TestClient().Get("https://localhost:30443/health")
 		if err != nil {
 			return 0
 		}

--- a/test/utils/v1beta1/webhook.go
+++ b/test/utils/v1beta1/webhook.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/shipwright-io/build/pkg/webhook/conversion"
+	"github.com/shipwright-io/build/test/utils"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -51,20 +52,8 @@ func StartBuildWebhook() *http.Server {
 		}
 	}()
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			IdleConnTimeout:       5 * time.Second,
-			ResponseHeaderTimeout: 5 * time.Second,
-			// #nosec:G402 test code
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-			TLSHandshakeTimeout: 5 * time.Second,
-		},
-	}
-
 	gomega.Eventually(func() int {
-		r, err := client.Get("https://localhost:30443/health")
+		r, err := utils.TestClient().Get("https://localhost:30443/health")
 		if err != nil {
 			return 0
 		}
@@ -81,20 +70,8 @@ func StopBuildWebhook(webhookServer *http.Server) {
 	err := webhookServer.Close()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			IdleConnTimeout:       5 * time.Second,
-			ResponseHeaderTimeout: 5 * time.Second,
-			// #nosec:G402 test code
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-			TLSHandshakeTimeout: 5 * time.Second,
-		},
-	}
-
 	gomega.Eventually(func() int {
-		r, err := client.Get("https://localhost:30443/health")
+		r, err := utils.TestClient().Get("https://localhost:30443/health")
 		if err != nil {
 			return 0
 		}


### PR DESCRIPTION
# Changes

Ref: https://github.com/securego/gosec/issues/1044#issuecomment-1764948001

Break up transport setup so that the `InsecureSkipVerify` is a single line, so that their latest changes can find the ignore statement at the exact statement level to be properly ignored.

Refactor test code to only have the test client setup once.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
