### PR TITLE
Allow a file or directory having a name with two subsequent dots while still preventing path traversal

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -240,7 +240,7 @@ func Unpack(in io.Reader, targetPath string) error {
 		}
 
 		var target = filepath.Join(targetPath, header.Name)
-		if strings.Contains(target, "..") {
+		if strings.Contains(target, "/../") {
 			return fmt.Errorf("targetPath validation failed, path contains unexpected special elements")
 		}
 


### PR DESCRIPTION
# Changes

When we prevent path traversal when extracting a source bundle, we were too strict. We only need to prevent `/../` because this means to go one directory up. We still must allow `..` because a directory or file can contain two subsequent dots in its name.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
You can now use files and directories with two subsequent dots in its name when using an OCI artifact as source
```
