### PR TITLE
Use Tekton V1 API when working with TaskRuns

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,7 +10,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
@@ -108,7 +107,7 @@ var _ = Describe("Config", func() {
 			}
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.GitContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.GitContainerTemplate).To(Equal(Step{
 					Image: "myregistry/custom/git-image",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -127,7 +126,7 @@ var _ = Describe("Config", func() {
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
 				nonRoot := pointer.Int64(1000)
-				Expect(config.GitContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.GitContainerTemplate).To(Equal(Step{
 					Image: "myregistry/custom/git-image",
 					Command: []string{
 						"/ko-app/git",
@@ -154,7 +153,7 @@ var _ = Describe("Config", func() {
 			}
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.GitContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.GitContainerTemplate).To(Equal(Step{
 					Image: "myregistry/custom/git-image:override",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -172,7 +171,7 @@ var _ = Describe("Config", func() {
 			}
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.ImageProcessingContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.ImageProcessingContainerTemplate).To(Equal(Step{
 					Image: "myregistry/custom/image-processing",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -190,7 +189,7 @@ var _ = Describe("Config", func() {
 			}
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.WaiterContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.WaiterContainerTemplate).To(Equal(Step{
 					Image: "myregistry/custom/image",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -209,7 +208,7 @@ var _ = Describe("Config", func() {
 			}
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.ImageProcessingContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.ImageProcessingContainerTemplate).To(Equal(Step{
 					Image: "myregistry/custom/image-processing:override",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -229,7 +228,7 @@ var _ = Describe("Config", func() {
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
 				nonRoot := pointer.Int64(1000)
-				Expect(config.WaiterContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.WaiterContainerTemplate).To(Equal(Step{
 					Image:   "myregistry/custom/image",
 					Command: []string{"/ko-app/waiter"},
 					Args:    []string{"start"},
@@ -255,7 +254,7 @@ var _ = Describe("Config", func() {
 			}
 
 			configWithEnvVariableOverrides(overrides, func(config *Config) {
-				Expect(config.WaiterContainerTemplate).To(Equal(pipeline.Step{
+				Expect(config.WaiterContainerTemplate).To(Equal(Step{
 					Image: "myregistry/custom/image:override",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,7 @@ package controller
 import (
 	"context"
 
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -39,7 +39,7 @@ func NewManager(ctx context.Context, config *config.Config, cfg *rest.Config, op
 
 	ctxlog.Info(ctx, "Registering Components.")
 
-	if err := pipelinev1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := pipelineapi.AddToScheme(mgr.GetScheme()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/reconciler/buildrun/controller.go
+++ b/pkg/reconciler/buildrun/controller.go
@@ -7,7 +7,7 @@ package buildrun
 import (
 	"context"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,8 +81,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler, maxConcurrentReconciles in
 
 	predTaskRun := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			o := e.ObjectOld.(*v1beta1.TaskRun)
-			n := e.ObjectNew.(*v1beta1.TaskRun)
+			o := e.ObjectOld.(*pipelineapi.TaskRun)
+			n := e.ObjectNew.(*pipelineapi.TaskRun)
 
 			// Process an update event when the old TR resource is not yet started and the new TR resource got a
 			// condition of the type Succeeded
@@ -99,7 +99,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, maxConcurrentReconciles in
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			o := e.Object.(*v1beta1.TaskRun)
+			o := e.Object.(*pipelineapi.TaskRun)
 
 			// If the TaskRun was deleted before completion, then we reconcile to update the BuildRun to a Failed status
 			return o.Status.CompletionTime == nil
@@ -113,8 +113,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler, maxConcurrentReconciles in
 
 	// enqueue Reconciles requests only for events where a TaskRun already exists and that is related
 	// to a BuildRun
-	return c.Watch(&source.Kind{Type: &v1beta1.TaskRun{}}, handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
-		taskRun := o.(*v1beta1.TaskRun)
+	return c.Watch(&source.Kind{Type: &pipelineapi.TaskRun{}}, handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+		taskRun := o.(*pipelineapi.TaskRun)
 
 		// check if TaskRun is related to BuildRun
 		if taskRun.GetLabels() == nil || taskRun.GetLabels()[buildv1alpha1.LabelBuildRun] == "" {

--- a/pkg/reconciler/buildrun/resources/conditions_test.go
+++ b/pkg/reconciler/buildrun/resources/conditions_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shipwright-io/build/pkg/controller/fakes"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
 	test "github.com/shipwright-io/build/test/v1alpha1_samples"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,7 +117,7 @@ var _ = Describe("Conditions", func() {
 			client *fakes.FakeClient
 			ctl    test.Catalog
 			br     *build.BuildRun
-			tr     *v1beta1.TaskRun
+			tr     *pipelineapi.TaskRun
 		)
 
 		tr = ctl.TaskRunWithStatus("foo", "bar")

--- a/pkg/reconciler/buildrun/resources/image_processing_test.go
+++ b/pkg/reconciler/buildrun/resources/image_processing_test.go
@@ -14,19 +14,19 @@ import (
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
 	utils "github.com/shipwright-io/build/test/utils/v1alpha1"
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 var _ = Describe("Image Processing overrides", func() {
 
 	config := config.NewDefaultConfig()
-	var processedTaskRun *pipeline.TaskRun
+	var processedTaskRun *pipelineapi.TaskRun
 
 	Context("for a TaskRun that does not reference the output directory", func() {
-		taskRun := &pipeline.TaskRun{
-			Spec: pipeline.TaskRunSpec{
-				TaskSpec: &pipeline.TaskSpec{
-					Steps: []pipeline.Step{
+		taskRun := &pipelineapi.TaskRun{
+			Spec: pipelineapi.TaskRunSpec{
+				TaskSpec: &pipelineapi.TaskSpec{
+					Steps: []pipelineapi.Step{
 						{
 							Name: "test-step",
 						},
@@ -83,10 +83,10 @@ var _ = Describe("Image Processing overrides", func() {
 
 	Context("for a TaskRun that references the output directory", func() {
 
-		taskRun := &pipeline.TaskRun{
-			Spec: pipeline.TaskRunSpec{
-				TaskSpec: &pipeline.TaskSpec{
-					Steps: []pipeline.Step{
+		taskRun := &pipelineapi.TaskRun{
+			Spec: pipelineapi.TaskRunSpec{
+				TaskSpec: &pipelineapi.TaskSpec{
+					Steps: []pipelineapi.Step{
 						{
 							Name: "test-step",
 							Args: []string{

--- a/pkg/reconciler/buildrun/resources/params_test.go
+++ b/pkg/reconciler/buildrun/resources/params_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 var _ = Describe("Params overrides", func() {
@@ -308,7 +308,7 @@ var _ = Describe("isStepReferencingParameter", func() {
 
 	Context("for a Step referencing parameters in different ways", func() {
 
-		step := &pipeline.Step{
+		step := &pipelineapi.Step{
 			Command: []string{
 				"some-command",
 				"$(params.first-param)",
@@ -347,13 +347,13 @@ var _ = Describe("isStepReferencingParameter", func() {
 
 var _ = Describe("HandleTaskRunParam", func() {
 
-	var taskRun *pipeline.TaskRun
+	var taskRun *pipelineapi.TaskRun
 
 	BeforeEach(func() {
-		taskRun = &pipeline.TaskRun{
-			Spec: pipeline.TaskRunSpec{
-				TaskSpec: &pipeline.TaskSpec{
-					Steps: []pipeline.Step{
+		taskRun = &pipelineapi.TaskRun{
+			Spec: pipelineapi.TaskRunSpec{
+				TaskSpec: &pipelineapi.TaskSpec{
+					Steps: []pipelineapi.Step{
 						{
 							Name: "first-container",
 							Args: []string{
@@ -388,11 +388,11 @@ var _ = Describe("HandleTaskRunParam", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipeline.Param{
+			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipelineapi.Param{
 				{
 					Name: "string-parameter",
-					Value: pipeline.ParamValue{
-						Type:      pipeline.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: "My value",
 					},
 				},
@@ -431,11 +431,11 @@ var _ = Describe("HandleTaskRunParam", func() {
 			Expect(len(taskRun.Spec.TaskSpec.Steps[1].Env)).To(Equal(0))
 
 			// Verify the parameters
-			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipeline.Param{
+			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipelineapi.Param{
 				{
 					Name: "string-parameter",
-					Value: pipeline.ParamValue{
-						Type:      pipeline.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: fmt.Sprintf("$(%s)", envVarName),
 					},
 				},
@@ -475,11 +475,11 @@ var _ = Describe("HandleTaskRunParam", func() {
 			Expect(len(taskRun.Spec.TaskSpec.Steps[1].Env)).To(Equal(0))
 
 			// Verify the parameters
-			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipeline.Param{
+			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipelineapi.Param{
 				{
 					Name: "string-parameter",
-					Value: pipeline.ParamValue{
-						Type:      pipeline.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: fmt.Sprintf("The value from the config map is '$(%s)'.", envVarName),
 					},
 				},
@@ -518,11 +518,11 @@ var _ = Describe("HandleTaskRunParam", func() {
 			Expect(len(taskRun.Spec.TaskSpec.Steps[1].Env)).To(Equal(0))
 
 			// Verify the parameters
-			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipeline.Param{
+			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipelineapi.Param{
 				{
 					Name: "string-parameter",
-					Value: pipeline.ParamValue{
-						Type:      pipeline.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: fmt.Sprintf("$(%s)", envVarName),
 					},
 				},
@@ -562,11 +562,11 @@ var _ = Describe("HandleTaskRunParam", func() {
 			Expect(len(taskRun.Spec.TaskSpec.Steps[1].Env)).To(Equal(0))
 
 			// Verify the parameters
-			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipeline.Param{
+			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipelineapi.Param{
 				{
 					Name: "string-parameter",
-					Value: pipeline.ParamValue{
-						Type:      pipeline.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: fmt.Sprintf("secret-value: $(%s)", envVarName),
 					},
 				},
@@ -601,11 +601,11 @@ var _ = Describe("HandleTaskRunParam", func() {
 			Expect(len(taskRun.Spec.TaskSpec.Steps[1].Env)).To(Equal(0))
 
 			// Verify the parameters
-			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipeline.Param{
+			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipelineapi.Param{
 				{
 					Name: "array-parameter",
-					Value: pipeline.ParamValue{
-						Type: pipeline.ParamTypeArray,
+					Value: pipelineapi.ParamValue{
+						Type: pipelineapi.ParamTypeArray,
 						ArrayVal: []string{
 							"first entry",
 							"",
@@ -660,11 +660,11 @@ var _ = Describe("HandleTaskRunParam", func() {
 			}))
 
 			// Verify the parameters
-			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipeline.Param{
+			Expect(taskRun.Spec.Params).To(BeEquivalentTo([]pipelineapi.Param{
 				{
 					Name: "array-parameter",
-					Value: pipeline.ParamValue{
-						Type: pipeline.ParamTypeArray,
+					Value: pipelineapi.ParamValue{
+						Type: pipelineapi.ParamTypeArray,
 						ArrayVal: []string{
 							"first entry",
 							fmt.Sprintf("$(%s)", envVarName),

--- a/pkg/reconciler/buildrun/resources/results.go
+++ b/pkg/reconciler/buildrun/resources/results.go
@@ -12,7 +12,7 @@ import (
 	build "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/ctxlog"
 
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -26,7 +26,7 @@ const (
 func UpdateBuildRunUsingTaskResults(
 	ctx context.Context,
 	buildRun *build.BuildRun,
-	taskRunResult []pipeline.TaskRunResult,
+	taskRunResult []pipelineapi.TaskRunResult,
 	request reconcile.Request,
 ) {
 	// Set source results
@@ -39,7 +39,7 @@ func UpdateBuildRunUsingTaskResults(
 	updateBuildRunStatusWithOutputResult(ctx, buildRun, taskRunResult, request)
 }
 
-func updateBuildRunStatusWithOutputResult(ctx context.Context, buildRun *build.BuildRun, taskRunResult []pipeline.TaskRunResult, request reconcile.Request) {
+func updateBuildRunStatusWithOutputResult(ctx context.Context, buildRun *build.BuildRun, taskRunResult []pipelineapi.TaskRunResult, request reconcile.Request) {
 	for _, result := range taskRunResult {
 		switch result.Name {
 		case generateOutputResultName(imageDigestResult):
@@ -59,8 +59,8 @@ func generateOutputResultName(resultName string) string {
 	return fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, resultName)
 }
 
-func getTaskSpecResults() []pipeline.TaskResult {
-	return []pipeline.TaskResult{
+func getTaskSpecResults() []pipelineapi.TaskResult {
+	return []pipelineapi.TaskResult{
 		{
 			Name:        fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, imageDigestResult),
 			Description: "The digest of the image",

--- a/pkg/reconciler/buildrun/resources/results_test.go
+++ b/pkg/reconciler/buildrun/resources/results_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
 	test "github.com/shipwright-io/build/test/v1alpha1_samples"
 
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -27,7 +27,7 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 		var (
 			taskRunRequest reconcile.Request
 			br             *build.BuildRun
-			tr             *pipelinev1beta1.TaskRun
+			tr             *pipelineapi.TaskRun
 		)
 
 		ctx := context.Background()
@@ -52,23 +52,23 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 			commitSha := "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
 			br.Status.BuildSpec.Source.URL = pointer.String("https://github.com/shipwright-io/sample-go")
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
-				pipelinev1beta1.TaskRunResult{
+			tr.Status.Results = append(tr.Status.Results,
+				pipelineapi.TaskRunResult{
 					Name: "shp-source-default-commit-sha",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: commitSha,
 					},
 				},
-				pipelinev1beta1.TaskRunResult{
+				pipelineapi.TaskRunResult{
 					Name: "shp-source-default-commit-author",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: "foo bar",
 					},
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.TaskRunResults, taskRunRequest)
+			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.Results, taskRunRequest)
 
 			Expect(len(br.Status.Sources)).To(Equal(1))
 			Expect(br.Status.Sources[0].Git.CommitSha).To(Equal(commitSha))
@@ -81,16 +81,16 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 				Image: "ghcr.io/shipwright-io/sample-go/source-bundle:latest",
 			}
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
-				pipelinev1beta1.TaskRunResult{
+			tr.Status.Results = append(tr.Status.Results,
+				pipelineapi.TaskRunResult{
 					Name: "shp-source-default-image-digest",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: bundleImageDigest,
 					},
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.TaskRunResults, taskRunRequest)
+			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.Results, taskRunRequest)
 
 			Expect(len(br.Status.Sources)).To(Equal(1))
 			Expect(br.Status.Sources[0].Bundle.Digest).To(Equal(bundleImageDigest))
@@ -99,23 +99,23 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 		It("should surface the TaskRun results emitting from output step", func() {
 			imageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
-				pipelinev1beta1.TaskRunResult{
+			tr.Status.Results = append(tr.Status.Results,
+				pipelineapi.TaskRunResult{
 					Name: "shp-image-digest",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: imageDigest,
 					},
 				},
-				pipelinev1beta1.TaskRunResult{
+				pipelineapi.TaskRunResult{
 					Name: "shp-image-size",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: "230",
 					},
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.TaskRunResults, taskRunRequest)
+			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.Results, taskRunRequest)
 
 			Expect(br.Status.Output.Digest).To(Equal(imageDigest))
 			Expect(br.Status.Output.Size).To(Equal(int64(230)))
@@ -126,37 +126,37 @@ var _ = Describe("TaskRun results to BuildRun", func() {
 			imageDigest := "sha256:fe1b73cd25ac3f11dec752755e2"
 			br.Status.BuildSpec.Source.URL = pointer.String("https://github.com/shipwright-io/sample-go")
 
-			tr.Status.TaskRunResults = append(tr.Status.TaskRunResults,
-				pipelinev1beta1.TaskRunResult{
+			tr.Status.Results = append(tr.Status.Results,
+				pipelineapi.TaskRunResult{
 					Name: "shp-source-default-commit-sha",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: commitSha,
 					},
 				},
-				pipelinev1beta1.TaskRunResult{
+				pipelineapi.TaskRunResult{
 					Name: "shp-source-default-commit-author",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: "foo bar",
 					},
 				},
-				pipelinev1beta1.TaskRunResult{
+				pipelineapi.TaskRunResult{
 					Name: "shp-image-digest",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: imageDigest,
 					},
 				},
-				pipelinev1beta1.TaskRunResult{
+				pipelineapi.TaskRunResult{
 					Name: "shp-image-size",
-					Value: pipelinev1beta1.ParamValue{
-						Type:      pipelinev1beta1.ParamTypeString,
+					Value: pipelineapi.ParamValue{
+						Type:      pipelineapi.ParamTypeString,
 						StringVal: "230",
 					},
 				})
 
-			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.TaskRunResults, taskRunRequest)
+			resources.UpdateBuildRunUsingTaskResults(ctx, br, tr.Status.Results, taskRunRequest)
 
 			Expect(len(br.Status.Sources)).To(Equal(1))
 			Expect(br.Status.Sources[0].Git.CommitSha).To(Equal(commitSha))

--- a/pkg/reconciler/buildrun/resources/sources.go
+++ b/pkg/reconciler/buildrun/resources/sources.go
@@ -9,7 +9,7 @@ import (
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/sources"
 
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 const defaultSourceName = "default"
@@ -37,7 +37,7 @@ func isLocalCopyBuildSource(
 // alternatively, configures the Task steps to use bundle and "git clone".
 func AmendTaskSpecWithSources(
 	cfg *config.Config,
-	taskSpec *pipeline.TaskSpec,
+	taskSpec *pipelineapi.TaskSpec,
 	build *buildv1alpha1.Build,
 	buildRun *buildv1alpha1.BuildRun,
 ) {
@@ -62,7 +62,7 @@ func AmendTaskSpecWithSources(
 	}
 }
 
-func updateBuildRunStatusWithSourceResult(buildrun *buildv1alpha1.BuildRun, results []pipeline.TaskRunResult) {
+func updateBuildRunStatusWithSourceResult(buildrun *buildv1alpha1.BuildRun, results []pipelineapi.TaskRunResult) {
 	buildSpec := buildrun.Status.BuildSpec
 
 	switch {

--- a/pkg/reconciler/buildrun/resources/sources/git_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/git_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/sources"
 
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 )
@@ -23,10 +23,10 @@ var _ = Describe("Git", func() {
 
 	Context("when adding a public Git source", func() {
 
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{}
+			taskSpec = &pipelineapi.TaskSpec{}
 		})
 
 		JustBeforeEach(func() {
@@ -67,10 +67,10 @@ var _ = Describe("Git", func() {
 
 	Context("when adding a private Git source", func() {
 
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{}
+			taskSpec = &pipelineapi.TaskSpec{}
 		})
 
 		JustBeforeEach(func() {

--- a/pkg/reconciler/buildrun/resources/sources/http.go
+++ b/pkg/reconciler/buildrun/resources/sources/http.go
@@ -9,7 +9,7 @@ import (
 
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/config"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 // RemoteArtifactsContainerName name for the container dealing with remote artifacts download.
@@ -18,7 +18,7 @@ const RemoteArtifactsContainerName = "sources-http"
 // AppendHTTPStep appends the step for a HTTP source to the TaskSpec
 func AppendHTTPStep(
 	cfg *config.Config,
-	taskSpec *tektonv1beta1.TaskSpec,
+	taskSpec *pipelineapi.TaskSpec,
 	source buildv1alpha1.BuildSource,
 ) {
 	// HTTP is done currently all in a single step, see if there is already one
@@ -26,7 +26,7 @@ func AppendHTTPStep(
 	if httpStep != nil {
 		httpStep.Args[3] = fmt.Sprintf("%s ; wget %q", httpStep.Args[3], source.URL)
 	} else {
-		httpStep := tektonv1beta1.Step{
+		httpStep := pipelineapi.Step{
 			Name:       RemoteArtifactsContainerName,
 			Image:      cfg.RemoteArtifactsContainerImage,
 			WorkingDir: fmt.Sprintf("$(params.%s-%s)", prefixParamsResultsVolumes, paramSourceRoot),
@@ -46,7 +46,7 @@ func AppendHTTPStep(
 	}
 }
 
-func findExistingHTTPSourcesStep(taskSpec *tektonv1beta1.TaskSpec) *tektonv1beta1.Step {
+func findExistingHTTPSourcesStep(taskSpec *pipelineapi.TaskSpec) *pipelineapi.Step {
 	for _, candidateStep := range taskSpec.Steps {
 		if candidateStep.Name == RemoteArtifactsContainerName {
 			return &candidateStep

--- a/pkg/reconciler/buildrun/resources/sources/http_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/http_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/sources"
 
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 var _ = Describe("HTTP", func() {
@@ -20,10 +20,10 @@ var _ = Describe("HTTP", func() {
 	cfg := config.NewDefaultConfig()
 
 	Context("when a TaskSpec does not contain an step", func() {
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{}
+			taskSpec = &pipelineapi.TaskSpec{}
 		})
 
 		It("adds the first step", func() {
@@ -41,11 +41,11 @@ var _ = Describe("HTTP", func() {
 	})
 
 	Context("when a TaskSpec already contains the http step", func() {
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{
-				Steps: []tektonv1beta1.Step{
+			taskSpec = &pipelineapi.TaskSpec{
+				Steps: []pipelineapi.Step{
 					{
 						Name:       sources.RemoteArtifactsContainerName,
 						Image:      cfg.RemoteArtifactsContainerImage,
@@ -79,11 +79,11 @@ var _ = Describe("HTTP", func() {
 	})
 
 	Context("when a TaskSpec already another source step step", func() {
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{
-				Steps: []tektonv1beta1.Step{
+			taskSpec = &pipelineapi.TaskSpec{
+				Steps: []pipelineapi.Step{
 					{
 						Name: "source-something",
 					},

--- a/pkg/reconciler/buildrun/resources/sources/local_copy.go
+++ b/pkg/reconciler/buildrun/resources/sources/local_copy.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/shipwright-io/build/pkg/config"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
 // WaiterContainerName name given to the container watier container.
@@ -17,11 +17,20 @@ const WaiterContainerName = "source-local"
 
 // AppendLocalCopyStep defines and append a new task based on the waiter container template, passed
 // by the configuration instance.
-func AppendLocalCopyStep(cfg *config.Config, taskSpec *tektonv1beta1.TaskSpec, timeout *metav1.Duration) {
-	step := *cfg.WaiterContainerTemplate.DeepCopy()
-	// the data upload mechanism targets a specific POD, and in this POD it aims for a specific
-	// container name, and having a static name, makes this process straight forward.
-	step.Name = WaiterContainerName
+func AppendLocalCopyStep(cfg *config.Config, taskSpec *pipelineapi.TaskSpec, timeout *metav1.Duration) {
+	step := pipelineapi.Step{
+		// the data upload mechanism targets a specific POD, and in this POD it aims for a specific
+		// container name, and having a static name, makes this process straight forward.
+		Name:             WaiterContainerName,
+		Image:            cfg.WaiterContainerTemplate.Image,
+		ImagePullPolicy:  cfg.WaiterContainerTemplate.ImagePullPolicy,
+		Command:          cfg.WaiterContainerTemplate.Command,
+		Args:             cfg.WaiterContainerTemplate.Args,
+		Env:              cfg.WaiterContainerTemplate.Env,
+		ComputeResources: cfg.WaiterContainerTemplate.Resources,
+		SecurityContext:  cfg.WaiterContainerTemplate.SecurityContext,
+		WorkingDir:       cfg.WaiterContainerTemplate.WorkingDir,
+	}
 
 	if timeout != nil {
 		step.Args = append(step.Args, fmt.Sprintf("--timeout=%s", timeout.Duration.String()))

--- a/pkg/reconciler/buildrun/resources/sources/local_copy_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/local_copy_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/sources"
@@ -20,10 +20,10 @@ var _ = Describe("LocalCopy", func() {
 	cfg := config.NewDefaultConfig()
 
 	Context("when LocalCopy source type is informed", func() {
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{}
+			taskSpec = &pipelineapi.TaskSpec{}
 			sources.AppendLocalCopyStep(cfg, taskSpec, &metav1.Duration{Duration: time.Minute})
 		})
 

--- a/pkg/reconciler/buildrun/resources/sources/utils.go
+++ b/pkg/reconciler/buildrun/resources/sources/utils.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 )
@@ -29,7 +29,7 @@ var (
 
 // AppendSecretVolume checks if a volume for a secret already exists, if not it appends it to the TaskSpec
 func AppendSecretVolume(
-	taskSpec *tektonv1beta1.TaskSpec,
+	taskSpec *pipelineapi.TaskSpec,
 	secretName string,
 ) {
 	volumeName := SanitizeVolumeNameForSecretName(secretName)
@@ -69,7 +69,7 @@ func SanitizeVolumeNameForSecretName(secretName string) string {
 	return sanitizedName
 }
 
-func findResultValue(results []tektonv1beta1.TaskRunResult, name string) string {
+func findResultValue(results []pipelineapi.TaskRunResult, name string) string {
 	for _, result := range results {
 		if result.Name == name {
 			return result.Value.StringVal

--- a/pkg/reconciler/buildrun/resources/sources/utils_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/utils_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/sources"
 
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -34,10 +34,10 @@ var _ = Describe("Utils", func() {
 	})
 
 	Context("when a TaskSpec does not contain any volume", func() {
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{}
+			taskSpec = &pipelineapi.TaskSpec{}
 		})
 
 		It("adds the first volume", func() {
@@ -51,10 +51,10 @@ var _ = Describe("Utils", func() {
 	})
 
 	Context("when a TaskSpec already contains a volume secret", func() {
-		var taskSpec *tektonv1beta1.TaskSpec
+		var taskSpec *pipelineapi.TaskSpec
 
 		BeforeEach(func() {
-			taskSpec = &tektonv1beta1.TaskSpec{
+			taskSpec = &pipelineapi.TaskSpec{
 				Volumes: []corev1.Volume{
 					{
 						Name: "shp-a-secret",

--- a/pkg/reconciler/buildrun/resources/steps/security_context.go
+++ b/pkg/reconciler/buildrun/resources/steps/security_context.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
-	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	"k8s.io/utils/strings/slices"
@@ -28,7 +28,7 @@ const (
 // UpdateSecurityContext updates the security context of a step based on the build strategy steps. If all build strategy steps run as the same user and group,
 // then the step is configured to also run as this user and group. This ensures that the supporting steps run as the same user as the build strategy and file
 // permissions created by source steps match the user that runs the build strategy steps.
-func UpdateSecurityContext(taskSpec *tektonapi.TaskSpec, taskRunAnnotations map[string]string, buildStrategySteps []buildapi.BuildStep, buildStrategySecurityContext *buildapi.BuildStrategySecurityContext) {
+func UpdateSecurityContext(taskSpec *pipelineapi.TaskSpec, taskRunAnnotations map[string]string, buildStrategySteps []buildapi.BuildStep, buildStrategySecurityContext *buildapi.BuildStrategySecurityContext) {
 	if buildStrategySecurityContext == nil {
 		return
 	}

--- a/pkg/reconciler/buildrun/resources/steps/security_context_test.go
+++ b/pkg/reconciler/buildrun/resources/steps/security_context_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/steps"
 
 	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
-	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
@@ -22,7 +22,7 @@ var _ = Describe("UpdateSecurityContext", func() {
 
 	var buildStrategySecurityContext *buildapi.BuildStrategySecurityContext
 	var buildStrategySteps []buildapi.BuildStep
-	var taskRunSpec *tektonapi.TaskSpec
+	var taskRunSpec *pipelineapi.TaskSpec
 	var taskRunAnnotations map[string]string
 
 	BeforeEach(func() {
@@ -47,8 +47,8 @@ var _ = Describe("UpdateSecurityContext", func() {
 			},
 		}}
 
-		taskRunSpec = &tektonapi.TaskSpec{
-			Steps: []tektonapi.Step{{
+		taskRunSpec = &pipelineapi.TaskSpec{
+			Steps: []pipelineapi.Step{{
 				Name: "shp-source-default",
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:  pointer.Int64(1000),

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -12,7 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -48,7 +48,7 @@ var _ = Describe("GenerateTaskrun", func() {
 	Describe("Generate the TaskSpec", func() {
 		var (
 			expectedCommandOrArg []string
-			got                  *v1beta1.TaskSpec
+			got                  *pipelineapi.TaskSpec
 			err                  error
 		)
 		BeforeEach(func() {
@@ -123,11 +123,11 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			It("should ensure resource replacements happen for the first step", func() {
-				Expect(got.Steps[1].Resources).To(Equal(ctl.LoadCustomResources("500m", "1Gi")))
+				Expect(got.Steps[1].ComputeResources).To(Equal(ctl.LoadCustomResources("500m", "1Gi")))
 			})
 
 			It("should ensure resource replacements happen for the second step", func() {
-				Expect(got.Steps[2].Resources).To(Equal(ctl.LoadCustomResources("100m", "65Mi")))
+				Expect(got.Steps[2].ComputeResources).To(Equal(ctl.LoadCustomResources("100m", "65Mi")))
 			})
 
 			It("should ensure arg replacements happen when needed", func() {
@@ -403,7 +403,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			k8sDuration30s                                                            *metav1.Duration
 			k8sDuration1m                                                             *metav1.Duration
 			namespace, contextDir, outputPath, outputPathBuildRun, serviceAccountName string
-			got                                                                       *v1beta1.TaskRun
+			got                                                                       *pipelineapi.TaskRun
 			err                                                                       error
 		)
 		BeforeEach(func() {
@@ -462,11 +462,6 @@ var _ = Describe("GenerateTaskrun", func() {
 				Expect(got.Annotations["kubernetes.io/ingress-bandwidth"]).To(Equal("1M"))
 			})
 
-			It("should ensure generated TaskRun has no resources", func() {
-				//lint:ignore SA1019 we want to verify that we do not set something that is not used
-				Expect(got.Spec.Resources).To(BeNil()) // nolint:staticcheck
-			})
-
 			It("should ensure resource replacements happen when needed", func() {
 				expectedResourceOrArg := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -478,7 +473,7 @@ var _ = Describe("GenerateTaskrun", func() {
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
 					},
 				}
-				Expect(got.Spec.TaskSpec.Steps[1].Resources).To(Equal(expectedResourceOrArg))
+				Expect(got.Spec.TaskSpec.Steps[1].ComputeResources).To(Equal(expectedResourceOrArg))
 			})
 
 			It("should have no timeout set", func() {
@@ -580,7 +575,7 @@ var _ = Describe("GenerateTaskrun", func() {
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
 					},
 				}
-				Expect(got.Spec.TaskSpec.Steps[1].Resources).To(Equal(expectedResourceOrArg))
+				Expect(got.Spec.TaskSpec.Steps[1].ComputeResources).To(Equal(expectedResourceOrArg))
 			})
 
 			It("should have the timeout set correctly", func() {

--- a/pkg/reconciler/buildrun/resources/volumes.go
+++ b/pkg/reconciler/buildrun/resources/volumes.go
@@ -7,7 +7,7 @@ package resources
 import (
 	"context"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +23,7 @@ func namespacedName(name, namespace string) types.NamespacedName {
 // CheckTaskRunVolumesExist tries to find some of the volumes referenced by the BuildRun with all the
 // overrides. If some secret or configmap does not exist in the namespace, function returns error
 // describing the missing resource
-func CheckTaskRunVolumesExist(ctx context.Context, client client.Client, taskRun *v1beta1.TaskRun) error {
+func CheckTaskRunVolumesExist(ctx context.Context, client client.Client, taskRun *pipelineapi.TaskRun) error {
 	for _, volume := range taskRun.Spec.TaskSpec.Volumes {
 		var (
 			err  error

--- a/test/e2e/v1alpha1/validators_test.go
+++ b/test/e2e/v1alpha1/validators_test.go
@@ -165,7 +165,7 @@ func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) 
 		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
 		Expect(err).ToNot(HaveOccurred())
 
-		for _, result := range tr.Status.TaskRunResults {
+		for _, result := range tr.Status.Results {
 			switch result.Name {
 			case "shp-source-default-commit-sha":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Sources[0].Git.CommitSha))
@@ -195,7 +195,7 @@ func validateBuildRunResultsFromBundleSource(testBuildRun *buildv1alpha1.BuildRu
 		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
 		Expect(err).ToNot(HaveOccurred())
 
-		for _, result := range tr.Status.TaskRunResults {
+		for _, result := range tr.Status.Results {
 			switch result.Name {
 			case "shp-source-default-image-digest":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Sources[0].Bundle.Digest))

--- a/test/e2e/v1beta1/validators_test.go
+++ b/test/e2e/v1beta1/validators_test.go
@@ -164,7 +164,7 @@ func validateBuildRunResultsFromGitSource(testBuildRun *buildv1beta1.BuildRun) {
 		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
 		Expect(err).ToNot(HaveOccurred())
 
-		for _, result := range tr.Status.TaskRunResults {
+		for _, result := range tr.Status.Results {
 			switch result.Name {
 			case "shp-source-default-commit-sha":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Source.Git.CommitSha))
@@ -194,7 +194,7 @@ func validateBuildRunResultsFromBundleSource(testBuildRun *buildv1beta1.BuildRun
 		tr, err := testBuild.GetTaskRunFromBuildRun(testBuildRun.Name)
 		Expect(err).ToNot(HaveOccurred())
 
-		for _, result := range tr.Status.TaskRunResults {
+		for _, result := range tr.Status.Results {
 			switch result.Name {
 			case "shp-source-default-image-digest":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Source.OciArtifact.Digest))

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -12,7 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
@@ -337,7 +337,7 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 
 			tr.Spec.Status = "TaskRunCancelled"
 
-			_, err = tb.UpdateTaskRun(tr.Name, func(tr *v1beta1.TaskRun) {
+			_, err = tb.UpdateTaskRun(tr.Name, func(tr *pipelineapi.TaskRun) {
 				tr.Spec.Status = "TaskRunCancelled"
 			})
 			Expect(err).To(BeNil())

--- a/test/integration/buildstrategy_to_taskruns_test.go
+++ b/test/integration/buildstrategy_to_taskruns_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	utils "github.com/shipwright-io/build/test/utils/v1alpha1"
 	test "github.com/shipwright-io/build/test/v1alpha1_samples"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -124,21 +124,21 @@ var _ = Describe("Integration tests BuildStrategies and TaskRuns", func() {
 			Expect(err).To(BeNil())
 		})
 
-		var constructStringParam = func(paramName string, val string) v1beta1.Param {
-			return v1beta1.Param{
+		var constructStringParam = func(paramName string, val string) pipelineapi.Param {
+			return pipelineapi.Param{
 				Name: paramName,
-				Value: v1beta1.ParamValue{
-					Type:      v1beta1.ParamTypeString,
+				Value: pipelineapi.ParamValue{
+					Type:      pipelineapi.ParamTypeString,
 					StringVal: val,
 				},
 			}
 		}
 
-		var constructArrayParam = func(paramName string, values ...string) v1beta1.Param {
-			return v1beta1.Param{
+		var constructArrayParam = func(paramName string, values ...string) pipelineapi.Param {
+			return pipelineapi.Param{
 				Name: paramName,
-				Value: v1beta1.ParamValue{
-					Type:     v1beta1.ParamTypeArray,
+				Value: pipelineapi.ParamValue{
+					Type:     pipelineapi.ParamTypeArray,
 					ArrayVal: values,
 				},
 			}
@@ -425,18 +425,18 @@ var _ = Describe("Integration tests BuildStrategies and TaskRuns", func() {
 			Expect(err).To(BeNil())
 
 			// Validate that the TaskSpec parameter have no default value
-			Expect(taskRun.Spec.TaskSpec.Params).To(ContainElement(v1beta1.ParamSpec{
+			Expect(taskRun.Spec.TaskSpec.Params).To(ContainElement(pipelineapi.ParamSpec{
 				Name:        "sleep-time",
-				Type:        v1beta1.ParamTypeString,
+				Type:        pipelineapi.ParamTypeString,
 				Description: "time in seconds for sleeping",
 				Default:     nil,
 			}))
 
 			// Validate that the TaskRun param have an empty string as the value
-			Expect(taskRun.Spec.Params).To(ContainElement(v1beta1.Param{
+			Expect(taskRun.Spec.Params).To(ContainElement(pipelineapi.Param{
 				Name: "sleep-time",
-				Value: v1beta1.ParamValue{
-					Type:      v1beta1.ParamTypeString,
+				Value: pipelineapi.ParamValue{
+					Type:      pipelineapi.ParamTypeString,
 					StringVal: "",
 				},
 			}))

--- a/test/utils/v1alpha1/lookup.go
+++ b/test/utils/v1alpha1/lookup.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,18 +61,18 @@ func (t *TestBuild) LookupBuildRun(entity types.NamespacedName) (*buildv1alpha1.
 	return result.(*buildv1alpha1.BuildRun), err
 }
 
-func (t *TestBuild) LookupTaskRun(entity types.NamespacedName) (*pipelinev1beta1.TaskRun, error) {
+func (t *TestBuild) LookupTaskRun(entity types.NamespacedName) (*pipelineapi.TaskRun, error) {
 	result, err := lookupRuntimeObject(func() (runtime.Object, error) {
 		return t.PipelineClientSet.
-			TektonV1beta1().
+			TektonV1().
 			TaskRuns(entity.Namespace).
 			Get(t.Context, entity.Name, metav1.GetOptions{})
 	})
 
-	return result.(*pipelinev1beta1.TaskRun), err
+	return result.(*pipelineapi.TaskRun), err
 }
 
-func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1alpha1.BuildRun) (*pipelinev1beta1.TaskRun, error) {
+func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1alpha1.BuildRun) (*pipelineapi.TaskRun, error) {
 	if buildRun == nil {
 		return nil, fmt.Errorf("no BuildRun specified to lookup TaskRun")
 	}
@@ -83,7 +83,7 @@ func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1alpha1.BuildRun)
 
 	tmp, err := lookupRuntimeObject(func() (runtime.Object, error) {
 		return t.PipelineClientSet.
-			TektonV1beta1().
+			TektonV1().
 			TaskRuns(buildRun.Namespace).
 			List(t.Context, metav1.ListOptions{
 				LabelSelector: labels.SelectorFromSet(
@@ -97,7 +97,7 @@ func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1alpha1.BuildRun)
 		return nil, err
 	}
 
-	var taskRunList = tmp.(*pipelinev1beta1.TaskRunList)
+	var taskRunList = tmp.(*pipelineapi.TaskRunList)
 	switch len(taskRunList.Items) {
 	case 0:
 		return nil, fmt.Errorf("no TaskRun found for BuildRun %s/%s", buildRun.Namespace, buildRun.Name)

--- a/test/utils/v1alpha1/taskruns.go
+++ b/test/utils/v1alpha1/taskruns.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,10 +21,10 @@ import (
 // This class is intended to host all CRUD calls for testing TaskRuns CRDs resources
 
 // GetTaskRunFromBuildRun retrieves an owned TaskRun based on the BuildRunName
-func (t *TestBuild) GetTaskRunFromBuildRun(buildRunName string) (*v1beta1.TaskRun, error) {
+func (t *TestBuild) GetTaskRunFromBuildRun(buildRunName string) (*pipelineapi.TaskRun, error) {
 	taskRunLabelSelector := fmt.Sprintf("buildrun.shipwright.io/name=%s", buildRunName)
 
-	trInterface := t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace)
+	trInterface := t.PipelineClientSet.TektonV1().TaskRuns(t.Namespace)
 
 	trList, err := trInterface.List(context.TODO(), metav1.ListOptions{
 		LabelSelector: taskRunLabelSelector,
@@ -41,8 +41,8 @@ func (t *TestBuild) GetTaskRunFromBuildRun(buildRunName string) (*v1beta1.TaskRu
 }
 
 // UpdateTaskRun applies changes to a TaskRun object
-func (t *TestBuild) UpdateTaskRun(name string, apply func(tr *v1beta1.TaskRun)) (*v1beta1.TaskRun, error) {
-	var tr *v1beta1.TaskRun
+func (t *TestBuild) UpdateTaskRun(name string, apply func(tr *pipelineapi.TaskRun)) (*pipelineapi.TaskRun, error) {
+	var tr *pipelineapi.TaskRun
 	var err error
 	for i := 0; i < 5; i++ {
 		tr, err = t.LookupTaskRun(types.NamespacedName{
@@ -55,7 +55,7 @@ func (t *TestBuild) UpdateTaskRun(name string, apply func(tr *v1beta1.TaskRun)) 
 
 		apply(tr)
 
-		tr, err = t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace).Update(context.TODO(), tr, metav1.UpdateOptions{})
+		tr, err = t.PipelineClientSet.TektonV1().TaskRuns(t.Namespace).Update(context.TODO(), tr, metav1.UpdateOptions{})
 		if err == nil {
 			return tr, nil
 		}
@@ -105,7 +105,7 @@ func (t *TestBuild) GetTRTillDesiredReason(buildRunName string, reason string) (
 
 // DeleteTR deletes a TaskRun from a desired namespace
 func (t *TestBuild) DeleteTR(name string) error {
-	trInterface := t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace)
+	trInterface := t.PipelineClientSet.TektonV1().TaskRuns(t.Namespace)
 
 	if err := trInterface.Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
 		return err

--- a/test/utils/v1beta1/lookup.go
+++ b/test/utils/v1beta1/lookup.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,18 +61,18 @@ func (t *TestBuild) LookupBuildRun(entity types.NamespacedName) (*buildv1beta1.B
 	return result.(*buildv1beta1.BuildRun), err
 }
 
-func (t *TestBuild) LookupTaskRun(entity types.NamespacedName) (*pipelinev1beta1.TaskRun, error) {
+func (t *TestBuild) LookupTaskRun(entity types.NamespacedName) (*pipelineapi.TaskRun, error) {
 	result, err := lookupRuntimeObject(func() (runtime.Object, error) {
 		return t.PipelineClientSet.
-			TektonV1beta1().
+			TektonV1().
 			TaskRuns(entity.Namespace).
 			Get(t.Context, entity.Name, metav1.GetOptions{})
 	})
 
-	return result.(*pipelinev1beta1.TaskRun), err
+	return result.(*pipelineapi.TaskRun), err
 }
 
-func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1beta1.BuildRun) (*pipelinev1beta1.TaskRun, error) {
+func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1beta1.BuildRun) (*pipelineapi.TaskRun, error) {
 	if buildRun == nil {
 		return nil, fmt.Errorf("no BuildRun specified to lookup TaskRun")
 	}
@@ -83,7 +83,7 @@ func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1beta1.BuildRun) 
 
 	tmp, err := lookupRuntimeObject(func() (runtime.Object, error) {
 		return t.PipelineClientSet.
-			TektonV1beta1().
+			TektonV1().
 			TaskRuns(buildRun.Namespace).
 			List(t.Context, metav1.ListOptions{
 				LabelSelector: labels.SelectorFromSet(
@@ -97,7 +97,7 @@ func (t *TestBuild) LookupTaskRunUsingBuildRun(buildRun *buildv1beta1.BuildRun) 
 		return nil, err
 	}
 
-	var taskRunList = tmp.(*pipelinev1beta1.TaskRunList)
+	var taskRunList = tmp.(*pipelineapi.TaskRunList)
 	switch len(taskRunList.Items) {
 	case 0:
 		return nil, fmt.Errorf("no TaskRun found for BuildRun %s/%s", buildRun.Namespace, buildRun.Name)

--- a/test/utils/v1beta1/taskruns.go
+++ b/test/utils/v1beta1/taskruns.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,10 +21,10 @@ import (
 // This class is intended to host all CRUD calls for testing TaskRuns CRDs resources
 
 // GetTaskRunFromBuildRun retrieves an owned TaskRun based on the BuildRunName
-func (t *TestBuild) GetTaskRunFromBuildRun(buildRunName string) (*v1beta1.TaskRun, error) {
+func (t *TestBuild) GetTaskRunFromBuildRun(buildRunName string) (*pipelineapi.TaskRun, error) {
 	taskRunLabelSelector := fmt.Sprintf("buildrun.shipwright.io/name=%s", buildRunName)
 
-	trInterface := t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace)
+	trInterface := t.PipelineClientSet.TektonV1().TaskRuns(t.Namespace)
 
 	trList, err := trInterface.List(context.TODO(), metav1.ListOptions{
 		LabelSelector: taskRunLabelSelector,
@@ -41,8 +41,8 @@ func (t *TestBuild) GetTaskRunFromBuildRun(buildRunName string) (*v1beta1.TaskRu
 }
 
 // UpdateTaskRun applies changes to a TaskRun object
-func (t *TestBuild) UpdateTaskRun(name string, apply func(tr *v1beta1.TaskRun)) (*v1beta1.TaskRun, error) {
-	var tr *v1beta1.TaskRun
+func (t *TestBuild) UpdateTaskRun(name string, apply func(tr *pipelineapi.TaskRun)) (*pipelineapi.TaskRun, error) {
+	var tr *pipelineapi.TaskRun
 	var err error
 	for i := 0; i < 5; i++ {
 		tr, err = t.LookupTaskRun(types.NamespacedName{
@@ -55,7 +55,7 @@ func (t *TestBuild) UpdateTaskRun(name string, apply func(tr *v1beta1.TaskRun)) 
 
 		apply(tr)
 
-		tr, err = t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace).Update(context.TODO(), tr, metav1.UpdateOptions{})
+		tr, err = t.PipelineClientSet.TektonV1().TaskRuns(t.Namespace).Update(context.TODO(), tr, metav1.UpdateOptions{})
 		if err == nil {
 			return tr, nil
 		}
@@ -105,7 +105,7 @@ func (t *TestBuild) GetTRTillDesiredReason(buildRunName string, reason string) (
 
 // DeleteTR deletes a TaskRun from a desired namespace
 func (t *TestBuild) DeleteTR(name string) error {
-	trInterface := t.PipelineClientSet.TektonV1beta1().TaskRuns(t.Namespace)
+	trInterface := t.PipelineClientSet.TektonV1().TaskRuns(t.Namespace)
 
 	if err := trInterface.Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
 		return err

--- a/test/v1alpha1_samples/catalog.go
+++ b/test/v1alpha1_samples/catalog.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
 	knativev1 "knative.dev/pkg/apis/duck/v1"
 
@@ -286,14 +286,14 @@ func (c *Catalog) StubBuildRun(
 // and a TaskRun when there is a client GET on this two objects
 func (c *Catalog) StubBuildRunAndTaskRun(
 	b *build.BuildRun,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 		switch object := object.(type) {
 		case *build.BuildRun:
 			b.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		}
@@ -305,14 +305,14 @@ func (c *Catalog) StubBuildRunAndTaskRun(
 // and a TaskRun when there is a client GET on this two objects
 func (c *Catalog) StubBuildAndTaskRun(
 	b *build.Build,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 		switch object := object.(type) {
 		case *build.Build:
 			b.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		}
@@ -390,7 +390,7 @@ func (c *Catalog) StubBuildRunGetWithoutSA(
 func (c *Catalog) StubBuildRunGetWithTaskRunAndSA(
 	b *build.Build,
 	br *build.BuildRun,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 	sa *corev1.ServiceAccount,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
@@ -401,7 +401,7 @@ func (c *Catalog) StubBuildRunGetWithTaskRunAndSA(
 		case *build.BuildRun:
 			br.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		case *corev1.ServiceAccount:
@@ -513,7 +513,7 @@ func (c *Catalog) StubBuildCRDsPodAndTaskRun(
 	sa *corev1.ServiceAccount,
 	cb *build.ClusterBuildStrategy,
 	bs *build.BuildStrategy,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 	pod *corev1.Pod,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
@@ -533,7 +533,7 @@ func (c *Catalog) StubBuildCRDsPodAndTaskRun(
 		case *build.BuildStrategy:
 			bs.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		case *corev1.Pod:
@@ -545,18 +545,18 @@ func (c *Catalog) StubBuildCRDsPodAndTaskRun(
 }
 
 // TaskRunWithStatus returns a minimal tekton TaskRun with an Status
-func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) TaskRunWithStatus(trName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 		},
-		Spec: v1beta1.TaskRunSpec{
+		Spec: pipelineapi.TaskRunSpec{
 			Timeout: &metav1.Duration{
 				Duration: time.Minute * 2,
 			},
 		},
-		Status: v1beta1.TaskRunStatus{
+		Status: pipelineapi.TaskRunStatus{
 			Status: knativev1.Status{
 				Conditions: knativev1.Conditions{
 					{
@@ -566,7 +566,7 @@ func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
 					},
 				},
 			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				PodName: "foobar-pod",
 				StartTime: &metav1.Time{
 					Time: time.Now(),
@@ -580,15 +580,15 @@ func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
 }
 
 // DefaultTaskRunWithStatus returns a minimal tekton TaskRun with an Status
-func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, ns string, status corev1.ConditionStatus, reason string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, ns string, status corev1.ConditionStatus, reason string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
-		Spec: v1beta1.TaskRunSpec{},
-		Status: v1beta1.TaskRunStatus{
+		Spec: pipelineapi.TaskRunSpec{},
+		Status: pipelineapi.TaskRunStatus{
 			Status: knativev1.Status{
 				Conditions: knativev1.Conditions{
 					{
@@ -598,7 +598,7 @@ func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, n
 					},
 				},
 			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				StartTime: &metav1.Time{
 					Time: time.Now(),
 				},
@@ -609,16 +609,16 @@ func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, n
 
 // TaskRunWithCompletionAndStartTime provides a TaskRun object with a
 // Completion and StartTime
-func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
-		Spec: v1beta1.TaskRunSpec{},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+		Spec: pipelineapi.TaskRunSpec{},
+		Status: pipelineapi.TaskRunStatus{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				CompletionTime: &metav1.Time{
 					Time: time.Now(),
 				},
@@ -642,15 +642,15 @@ func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName 
 }
 
 // DefaultTaskRunWithFalseStatus returns a minimal tektont TaskRun with a FALSE status
-func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
-		Spec: v1beta1.TaskRunSpec{},
-		Status: v1beta1.TaskRunStatus{
+		Spec: pipelineapi.TaskRunSpec{},
+		Status: pipelineapi.TaskRunStatus{
 			Status: knativev1.Status{
 				Conditions: knativev1.Conditions{
 					{
@@ -661,7 +661,7 @@ func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName stri
 					},
 				},
 			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				StartTime: &metav1.Time{
 					Time: time.Now(),
 				},
@@ -867,8 +867,8 @@ func (c *Catalog) BuildRunWithFakeNamespace(buildRunName string, buildName strin
 }
 
 // DefaultTaskRun returns a minimal TaskRun object
-func (c *Catalog) DefaultTaskRun(taskRunName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) DefaultTaskRun(taskRunName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      taskRunName,
 			Namespace: ns,

--- a/test/v1beta1_samples/catalog.go
+++ b/test/v1beta1_samples/catalog.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
 	knativev1 "knative.dev/pkg/apis/duck/v1"
 
@@ -293,14 +293,14 @@ func (c *Catalog) StubBuildRun(
 // and a TaskRun when there is a client GET on this two objects
 func (c *Catalog) StubBuildRunAndTaskRun(
 	b *build.BuildRun,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 		switch object := object.(type) {
 		case *build.BuildRun:
 			b.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		}
@@ -312,14 +312,14 @@ func (c *Catalog) StubBuildRunAndTaskRun(
 // and a TaskRun when there is a client GET on this two objects
 func (c *Catalog) StubBuildAndTaskRun(
 	b *build.Build,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 		switch object := object.(type) {
 		case *build.Build:
 			b.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		}
@@ -397,7 +397,7 @@ func (c *Catalog) StubBuildRunGetWithoutSA(
 func (c *Catalog) StubBuildRunGetWithTaskRunAndSA(
 	b *build.Build,
 	br *build.BuildRun,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 	sa *corev1.ServiceAccount,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
@@ -408,7 +408,7 @@ func (c *Catalog) StubBuildRunGetWithTaskRunAndSA(
 		case *build.BuildRun:
 			br.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		case *corev1.ServiceAccount:
@@ -520,7 +520,7 @@ func (c *Catalog) StubBuildCRDsPodAndTaskRun(
 	sa *corev1.ServiceAccount,
 	cb *build.ClusterBuildStrategy,
 	bs *build.BuildStrategy,
-	tr *v1beta1.TaskRun,
+	tr *pipelineapi.TaskRun,
 	pod *corev1.Pod,
 ) func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
 	return func(context context.Context, nn types.NamespacedName, object client.Object, getOptions ...client.GetOption) error {
@@ -540,7 +540,7 @@ func (c *Catalog) StubBuildCRDsPodAndTaskRun(
 		case *build.BuildStrategy:
 			bs.DeepCopyInto(object)
 			return nil
-		case *v1beta1.TaskRun:
+		case *pipelineapi.TaskRun:
 			tr.DeepCopyInto(object)
 			return nil
 		case *corev1.Pod:
@@ -552,18 +552,18 @@ func (c *Catalog) StubBuildCRDsPodAndTaskRun(
 }
 
 // TaskRunWithStatus returns a minimal tekton TaskRun with an Status
-func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) TaskRunWithStatus(trName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 		},
-		Spec: v1beta1.TaskRunSpec{
+		Spec: pipelineapi.TaskRunSpec{
 			Timeout: &metav1.Duration{
 				Duration: time.Minute * 2,
 			},
 		},
-		Status: v1beta1.TaskRunStatus{
+		Status: pipelineapi.TaskRunStatus{
 			Status: knativev1.Status{
 				Conditions: knativev1.Conditions{
 					{
@@ -573,7 +573,7 @@ func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
 					},
 				},
 			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				PodName: "foobar-pod",
 				StartTime: &metav1.Time{
 					Time: time.Now(),
@@ -587,15 +587,15 @@ func (c *Catalog) TaskRunWithStatus(trName string, ns string) *v1beta1.TaskRun {
 }
 
 // DefaultTaskRunWithStatus returns a minimal tekton TaskRun with an Status
-func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, ns string, status corev1.ConditionStatus, reason string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, ns string, status corev1.ConditionStatus, reason string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
-		Spec: v1beta1.TaskRunSpec{},
-		Status: v1beta1.TaskRunStatus{
+		Spec: pipelineapi.TaskRunSpec{},
+		Status: pipelineapi.TaskRunStatus{
 			Status: knativev1.Status{
 				Conditions: knativev1.Conditions{
 					{
@@ -605,7 +605,7 @@ func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, n
 					},
 				},
 			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				StartTime: &metav1.Time{
 					Time: time.Now(),
 				},
@@ -616,16 +616,16 @@ func (c *Catalog) DefaultTaskRunWithStatus(trName string, buildRunName string, n
 
 // TaskRunWithCompletionAndStartTime provides a TaskRun object with a
 // Completion and StartTime
-func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
-		Spec: v1beta1.TaskRunSpec{},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+		Spec: pipelineapi.TaskRunSpec{},
+		Status: pipelineapi.TaskRunStatus{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				CompletionTime: &metav1.Time{
 					Time: time.Now(),
 				},
@@ -649,15 +649,15 @@ func (c *Catalog) TaskRunWithCompletionAndStartTime(trName string, buildRunName 
 }
 
 // DefaultTaskRunWithFalseStatus returns a minimal tektont TaskRun with a FALSE status
-func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trName,
 			Namespace: ns,
 			Labels:    map[string]string{"buildrun.shipwright.io/name": buildRunName},
 		},
-		Spec: v1beta1.TaskRunSpec{},
-		Status: v1beta1.TaskRunStatus{
+		Spec: pipelineapi.TaskRunSpec{},
+		Status: pipelineapi.TaskRunStatus{
 			Status: knativev1.Status{
 				Conditions: knativev1.Conditions{
 					{
@@ -668,7 +668,7 @@ func (c *Catalog) DefaultTaskRunWithFalseStatus(trName string, buildRunName stri
 					},
 				},
 			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+			TaskRunStatusFields: pipelineapi.TaskRunStatusFields{
 				StartTime: &metav1.Time{
 					Time: time.Now(),
 				},
@@ -878,8 +878,8 @@ func (c *Catalog) BuildRunWithFakeNamespace(buildRunName string, buildName strin
 }
 
 // DefaultTaskRun returns a minimal TaskRun object
-func (c *Catalog) DefaultTaskRun(taskRunName string, ns string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
+func (c *Catalog) DefaultTaskRun(taskRunName string, ns string) *pipelineapi.TaskRun {
+	return &pipelineapi.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      taskRunName,
 			Namespace: ns,


### PR DESCRIPTION
# Changes

Fixes #1434

This pull request changes our controller code to use the V1 API of Tekton to work with TaskRuns. This was mostly straight-forward.

I had to adjust the config package. There, we also used Tekton's `Step` type. I changed it to our own type to maintain API compatibility to support `resources` while Tekton moved to `computeResources` in V1.

I also used the chance to use the same import everywhere, `pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"`.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Controllers now use Tekton's V1 API to create and access the TaskRun that backs a BuildRun
```