### PR TITLE
Add source timestamp field for source result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Unit, Integration, and E2E Tests
-on: 
+on:
   pull_request:
     branches:
     - main
@@ -7,7 +7,7 @@ on:
     paths-ignore:
     - 'README.md'
     - 'docs/**'
-    branches: 
+    branches:
     - main
 
 jobs:
@@ -114,8 +114,9 @@ jobs:
           # host.docker.internal does not work in a GitHub action
           docker exec kind-control-plane bash -c "echo '172.17.0.1 host.docker.internal' >>/etc/hosts"
 
-          # Build and load the Git image
+          # Build and load the Git and Bundle image
           export GIT_CONTAINER_IMAGE="$(KO_DOCKER_REPO=kind.local ko publish ./cmd/git)"
+          export BUNDLE_CONTAINER_IMAGE="$(KO_DOCKER_REPO=kind.local ko publish ./cmd/bundle)"
 
           make test-integration
 

--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -188,14 +188,16 @@ var _ = Describe("Bundle Loader", func() {
 		})
 
 		AfterEach(func() {
-			ref, err := name.ParseReference(testImage)
-			Expect(err).ToNot(HaveOccurred())
+			if testImage != "" {
+				ref, err := name.ParseReference(testImage)
+				Expect(err).ToNot(HaveOccurred())
 
-			options, auth, err := image.GetOptions(context.TODO(), ref, true, dockerConfigFile, "test-agent")
-			Expect(err).ToNot(HaveOccurred())
+				options, auth, err := image.GetOptions(context.TODO(), ref, true, dockerConfigFile, "test-agent")
+				Expect(err).ToNot(HaveOccurred())
 
-			// Delete test image (best effort)
-			_ = image.Delete(ref, options, *auth)
+				// Delete test image (best effort)
+				_ = image.Delete(ref, options, *auth)
+			}
 		})
 
 		It("should pull and unpack an image from a private registry", func() {

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -46,20 +46,21 @@ func (e ExitError) Error() string {
 }
 
 type settings struct {
-	help                   bool
-	url                    string
-	revision               string
-	depth                  uint
-	target                 string
-	resultFileCommitSha    string
-	resultFileCommitAuthor string
-	resultFileBranchName   string
-	secretPath             string
-	skipValidation         bool
-	gitURLRewrite          bool
-	resultFileErrorMessage string
-	resultFileErrorReason  string
-	verbose                bool
+	help                      bool
+	url                       string
+	revision                  string
+	depth                     uint
+	target                    string
+	resultFileCommitSha       string
+	resultFileCommitAuthor    string
+	resultFileBranchName      string
+	resultFileSourceTimestamp string
+	secretPath                string
+	skipValidation            bool
+	gitURLRewrite             bool
+	resultFileErrorMessage    string
+	resultFileErrorReason     string
+	verbose                   bool
 }
 
 var flagValues settings
@@ -81,6 +82,7 @@ func init() {
 	pflag.StringVar(&flagValues.target, "target", "", "The target directory of the clone operation")
 	pflag.StringVar(&flagValues.resultFileCommitSha, "result-file-commit-sha", "", "A file to write the commit sha to.")
 	pflag.StringVar(&flagValues.resultFileCommitAuthor, "result-file-commit-author", "", "A file to write the commit author to.")
+	pflag.StringVar(&flagValues.resultFileSourceTimestamp, "result-file-source-timestamp", "", "A file to write the source timestamp to.")
 	pflag.StringVar(&flagValues.resultFileBranchName, "result-file-branch-name", "", "A file to write the branch name to.")
 	pflag.StringVar(&flagValues.secretPath, "secret-path", "", "A directory that contains a secret. Either username and password for basic authentication. Or a SSH private key and optionally a known hosts file. Optional.")
 
@@ -176,6 +178,17 @@ func runGitClone(ctx context.Context) error {
 		}
 
 		if err = os.WriteFile(flagValues.resultFileCommitAuthor, []byte(output), 0644); err != nil {
+			return err
+		}
+	}
+
+	if flagValues.resultFileSourceTimestamp != "" {
+		output, err := git(ctx, "-C", flagValues.target, "show", "--no-patch", "--format=%ct")
+		if err != nil {
+			return err
+		}
+
+		if err = os.WriteFile(flagValues.resultFileSourceTimestamp, []byte(output), 0644); err != nil {
 			return err
 		}
 	}

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -471,6 +471,21 @@ var _ = Describe("Git Resource", func() {
 				})
 			})
 		})
+
+		It("should store source-timestamp into file specified in --result-file-source-timestamp flag", func() {
+			withTempFile("source-timestamp", func(filename string) {
+				withTempDir(func(target string) {
+					Expect(run(withArgs(
+						"--url", exampleRepo,
+						"--target", target,
+						"--revision", "v0.1.0",
+						"--result-file-source-timestamp", filename,
+					))).ToNot(HaveOccurred())
+
+					Expect(filecontent(filename)).To(Equal("1619426578"))
+				})
+			})
+		})
 	})
 
 	Context("Some tests mutate or depend on git configurations. They must run sequentially to avoid race-conditions.", Ordered, func() {

--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -6334,6 +6334,13 @@ spec:
                     name:
                       description: Name is the name of source
                       type: string
+                    timestamp:
+                      description: Timestamp holds the timestamp of the source, which
+                        depends on the actual source type and could range from being
+                        the commit timestamp or the fileystem timestamp of the most
+                        recent source file in the working directory
+                      format: date-time
+                      type: string
                   required:
                   - name
                   type: object
@@ -12552,6 +12559,13 @@ spec:
                         description: Digest hold the image digest result
                         type: string
                     type: object
+                  timestamp:
+                    description: Timestamp holds the timestamp of the source, which
+                      depends on the actual source type and could range from being
+                      the commit timestamp or the fileystem timestamp of the most
+                      recent source file in the working directory
+                    format: date-time
+                    type: string
                 type: object
               startTime:
                 description: StartTime is the time the build is actually started.

--- a/pkg/apis/build/v1alpha1/buildrun_types.go
+++ b/pkg/apis/build/v1alpha1/buildrun_types.go
@@ -117,6 +117,14 @@ type SourceResult struct {
 	//
 	// +optional
 	Bundle *BundleSourceResult `json:"bundle,omitempty"`
+
+	// Timestamp holds the timestamp of the source, which
+	// depends on the actual source type and could range from
+	// being the commit timestamp or the fileystem timestamp
+	// of the most recent source file in the working directory
+	//
+	// +optional
+	Timestamp *metav1.Time `json:"timestamp,omitempty"`
 }
 
 // BundleSourceResult holds the results emitted from the bundle source

--- a/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1alpha1/zz_generated.deepcopy.go
@@ -1123,6 +1123,10 @@ func (in *SourceResult) DeepCopyInto(out *SourceResult) {
 		*out = new(BundleSourceResult)
 		**out = **in
 	}
+	if in.Timestamp != nil {
+		in, out := &in.Timestamp, &out.Timestamp
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/build/v1beta1/buildrun_conversion.go
+++ b/pkg/apis/build/v1beta1/buildrun_conversion.go
@@ -142,6 +142,7 @@ func (src *BuildRun) ConvertFrom(ctx context.Context, obj *unstructured.Unstruct
 		sourceStatus = &SourceResult{
 			Git:         (*GitSourceResult)(s.Git),
 			OciArtifact: (*OciArtifactSourceResult)(s.Bundle),
+			Timestamp:   s.Timestamp,
 		}
 	}
 

--- a/pkg/apis/build/v1beta1/buildrun_types.go
+++ b/pkg/apis/build/v1beta1/buildrun_types.go
@@ -122,6 +122,14 @@ type SourceResult struct {
 	//
 	// +optional
 	OciArtifact *OciArtifactSourceResult `json:"ociArtifact,omitempty"`
+
+	// Timestamp holds the timestamp of the source, which
+	// depends on the actual source type and could range from
+	// being the commit timestamp or the fileystem timestamp
+	// of the most recent source file in the working directory
+	//
+	// +optional
+	Timestamp *metav1.Time `json:"timestamp,omitempty"`
 }
 
 // OciArtifactSourceResult holds the results emitted from the bundle source

--- a/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
@@ -1097,6 +1097,10 @@ func (in *SourceResult) DeepCopyInto(out *SourceResult) {
 		*out = new(OciArtifactSourceResult)
 		**out = **in
 	}
+	if in.Timestamp != nil {
+		in, out := &in.Timestamp, &out.Timestamp
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -54,7 +54,10 @@ var _ = Describe("Bundle", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(r).ToNot(BeNil())
 
-				Expect(Unpack(r, tempDir)).To(Succeed())
+				details, err := Unpack(r, tempDir)
+				Expect(details).ToNot(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+
 				Expect(filepath.Join(tempDir, "README.md")).To(BeAnExistingFile())
 				Expect(filepath.Join(tempDir, ".someToolDir", "config.json")).ToNot(BeAnExistingFile())
 				Expect(filepath.Join(tempDir, "somefile")).To(BeAnExistingFile())

--- a/pkg/reconciler/buildrun/resources/sources.go
+++ b/pkg/reconciler/buildrun/resources/sources.go
@@ -5,6 +5,12 @@
 package resources
 
 import (
+	"strconv"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/sources"
@@ -13,6 +19,8 @@ import (
 )
 
 const defaultSourceName = "default"
+
+const sourceTimestampName = "source-timestamp"
 
 // isLocalCopyBuildSource appends all "Sources" in a single slice, and if any entry is typed
 // "LocalCopy" it returns first LocalCopy typed BuildSource found, or nil.
@@ -33,6 +41,15 @@ func isLocalCopyBuildSource(
 	return nil
 }
 
+func appendSourceTimestampResult(taskSpec *pipelineapi.TaskSpec) {
+	taskSpec.Results = append(taskSpec.Results,
+		pipelineapi.TaskResult{
+			Name:        sources.TaskResultName(defaultSourceName, sourceTimestampName),
+			Description: "The timestamp of the source.",
+		},
+	)
+}
+
 // AmendTaskSpecWithSources adds the necessary steps to either wait for user upload ("LocalCopy"), or
 // alternatively, configures the Task steps to use bundle and "git clone".
 func AmendTaskSpecWithSources(
@@ -47,8 +64,10 @@ func AmendTaskSpecWithSources(
 		// create the step for spec.source, either Git or Bundle
 		switch {
 		case build.Spec.Source.BundleContainer != nil:
+			appendSourceTimestampResult(taskSpec)
 			sources.AppendBundleStep(cfg, taskSpec, build.Spec.Source, defaultSourceName)
 		case build.Spec.Source.URL != nil:
+			appendSourceTimestampResult(taskSpec)
 			sources.AppendGitStep(cfg, taskSpec, build.Spec.Source, defaultSourceName)
 		}
 	}
@@ -65,6 +84,7 @@ func AmendTaskSpecWithSources(
 func updateBuildRunStatusWithSourceResult(buildrun *buildv1alpha1.BuildRun, results []pipelineapi.TaskRunResult) {
 	buildSpec := buildrun.Status.BuildSpec
 
+	// no results for HTTP sources yet
 	switch {
 	case buildSpec.Source.BundleContainer != nil:
 		sources.AppendBundleResult(buildrun, defaultSourceName, results)
@@ -73,5 +93,13 @@ func updateBuildRunStatusWithSourceResult(buildrun *buildv1alpha1.BuildRun, resu
 		sources.AppendGitResult(buildrun, defaultSourceName, results)
 	}
 
-	// no results for HTTP sources yet
+	if sourceTimestamp := sources.FindResultValue(results, defaultSourceName, sourceTimestampName); strings.TrimSpace(sourceTimestamp) != "" {
+		if sec, err := strconv.ParseInt(sourceTimestamp, 10, 64); err == nil {
+			for i := range buildrun.Status.Sources {
+				if buildrun.Status.Sources[i].Name == defaultSourceName {
+					buildrun.Status.Sources[i].Timestamp = &metav1.Time{Time: time.Unix(sec, 0)}
+				}
+			}
+		}
+	}
 }

--- a/pkg/reconciler/buildrun/resources/sources/git_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/git_test.go
@@ -47,20 +47,14 @@ var _ = Describe("Git", func() {
 			Expect(taskSpec.Steps[0].Name).To(Equal("source-default"))
 			Expect(taskSpec.Steps[0].Image).To(Equal(cfg.GitContainerTemplate.Image))
 			Expect(taskSpec.Steps[0].Args).To(Equal([]string{
-				"--url",
-				"https://github.com/shipwright-io/build",
-				"--target",
-				"$(params.shp-source-root)",
-				"--result-file-commit-sha",
-				"$(results.shp-source-default-commit-sha.path)",
-				"--result-file-commit-author",
-				"$(results.shp-source-default-commit-author.path)",
-				"--result-file-branch-name",
-				"$(results.shp-source-default-branch-name.path)",
-				"--result-file-error-message",
-				"$(results.shp-error-message.path)",
-				"--result-file-error-reason",
-				"$(results.shp-error-reason.path)",
+				"--url", "https://github.com/shipwright-io/build",
+				"--target", "$(params.shp-source-root)",
+				"--result-file-commit-sha", "$(results.shp-source-default-commit-sha.path)",
+				"--result-file-commit-author", "$(results.shp-source-default-commit-author.path)",
+				"--result-file-branch-name", "$(results.shp-source-default-branch-name.path)",
+				"--result-file-error-message", "$(results.shp-error-message.path)",
+				"--result-file-error-reason", "$(results.shp-error-reason.path)",
+				"--result-file-source-timestamp", "$(results.shp-source-default-source-timestamp.path)",
 			}))
 		})
 	})
@@ -101,22 +95,15 @@ var _ = Describe("Git", func() {
 			Expect(taskSpec.Steps[0].Name).To(Equal("source-default"))
 			Expect(taskSpec.Steps[0].Image).To(Equal(cfg.GitContainerTemplate.Image))
 			Expect(taskSpec.Steps[0].Args).To(Equal([]string{
-				"--url",
-				"git@github.com:shipwright-io/build.git",
-				"--target",
-				"$(params.shp-source-root)",
-				"--result-file-commit-sha",
-				"$(results.shp-source-default-commit-sha.path)",
-				"--result-file-commit-author",
-				"$(results.shp-source-default-commit-author.path)",
-				"--result-file-branch-name",
-				"$(results.shp-source-default-branch-name.path)",
-				"--result-file-error-message",
-				"$(results.shp-error-message.path)",
-				"--result-file-error-reason",
-				"$(results.shp-error-reason.path)",
-				"--secret-path",
-				"/workspace/shp-source-secret",
+				"--url", "git@github.com:shipwright-io/build.git",
+				"--target", "$(params.shp-source-root)",
+				"--result-file-commit-sha", "$(results.shp-source-default-commit-sha.path)",
+				"--result-file-commit-author", "$(results.shp-source-default-commit-author.path)",
+				"--result-file-branch-name", "$(results.shp-source-default-branch-name.path)",
+				"--result-file-error-message", "$(results.shp-error-message.path)",
+				"--result-file-error-reason", "$(results.shp-error-reason.path)",
+				"--result-file-source-timestamp", "$(results.shp-source-default-source-timestamp.path)",
+				"--secret-path", "/workspace/shp-source-secret",
 			}))
 			Expect(len(taskSpec.Steps[0].VolumeMounts)).To(Equal(1))
 			Expect(taskSpec.Steps[0].VolumeMounts[0].Name).To(Equal("shp-a-secret"))

--- a/pkg/reconciler/buildrun/resources/sources/http.go
+++ b/pkg/reconciler/buildrun/resources/sources/http.go
@@ -29,7 +29,7 @@ func AppendHTTPStep(
 		httpStep := pipelineapi.Step{
 			Name:       RemoteArtifactsContainerName,
 			Image:      cfg.RemoteArtifactsContainerImage,
-			WorkingDir: fmt.Sprintf("$(params.%s-%s)", prefixParamsResultsVolumes, paramSourceRoot),
+			WorkingDir: fmt.Sprintf("$(params.%s-%s)", PrefixParamsResultsVolumes, paramSourceRoot),
 			Command: []string{
 				"/bin/sh",
 			},

--- a/pkg/reconciler/buildrun/resources/sources/utils.go
+++ b/pkg/reconciler/buildrun/resources/sources/utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	prefixParamsResultsVolumes = "shp"
+	PrefixParamsResultsVolumes = "shp"
 
 	paramSourceRoot = "source-root"
 )
@@ -56,7 +56,7 @@ func AppendSecretVolume(
 // SanitizeVolumeNameForSecretName creates the name of a Volume for a Secret
 func SanitizeVolumeNameForSecretName(secretName string) string {
 	// remove forbidden characters
-	sanitizedName := dnsLabel1123Forbidden.ReplaceAllString(fmt.Sprintf("%s-%s", prefixParamsResultsVolumes, secretName), "-")
+	sanitizedName := dnsLabel1123Forbidden.ReplaceAllString(fmt.Sprintf("%s-%s", PrefixParamsResultsVolumes, secretName), "-")
 
 	// ensure maximum length
 	if len(sanitizedName) > 63 {
@@ -69,7 +69,16 @@ func SanitizeVolumeNameForSecretName(secretName string) string {
 	return sanitizedName
 }
 
-func findResultValue(results []pipelineapi.TaskRunResult, name string) string {
+func TaskResultName(sourceName, resultName string) string {
+	return fmt.Sprintf("%s-source-%s-%s",
+		PrefixParamsResultsVolumes,
+		sourceName,
+		resultName,
+	)
+}
+
+func FindResultValue(results []pipelineapi.TaskRunResult, sourceName, resultName string) string {
+	var name = TaskResultName(sourceName, resultName)
 	for _, result := range results {
 		if result.Name == name {
 			return result.Value.StringVal

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -84,20 +84,14 @@ var _ = Describe("GenerateTaskrun", func() {
 				Expect(got.Steps[0].Name).To(Equal("source-default"))
 				Expect(got.Steps[0].Command[0]).To(Equal("/ko-app/git"))
 				Expect(got.Steps[0].Args).To(Equal([]string{
-					"--url",
-					*build.Spec.Source.URL,
-					"--target",
-					"$(params.shp-source-root)",
-					"--result-file-commit-sha",
-					"$(results.shp-source-default-commit-sha.path)",
-					"--result-file-commit-author",
-					"$(results.shp-source-default-commit-author.path)",
-					"--result-file-branch-name",
-					"$(results.shp-source-default-branch-name.path)",
-					"--result-file-error-message",
-					"$(results.shp-error-message.path)",
-					"--result-file-error-reason",
-					"$(results.shp-error-reason.path)",
+					"--url", *build.Spec.Source.URL,
+					"--target", "$(params.shp-source-root)",
+					"--result-file-commit-sha", "$(results.shp-source-default-commit-sha.path)",
+					"--result-file-commit-author", "$(results.shp-source-default-commit-author.path)",
+					"--result-file-branch-name", "$(results.shp-source-default-branch-name.path)",
+					"--result-file-error-message", "$(results.shp-error-message.path)",
+					"--result-file-error-reason", "$(results.shp-error-reason.path)",
+					"--result-file-source-timestamp", "$(results.shp-source-default-source-timestamp.path)",
 				}))
 			})
 

--- a/test/e2e/v1alpha1/validators_test.go
+++ b/test/e2e/v1alpha1/validators_test.go
@@ -173,6 +173,9 @@ func validateBuildRunResultsFromGitSource(testBuildRun *buildv1alpha1.BuildRun) 
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Sources[0].Git.CommitAuthor))
 			case "shp-source-default-branch-name":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Sources[0].Git.BranchName))
+			case "shp-source-default-source-timestamp":
+				Expect(strconv.ParseInt(result.Value.StringVal, 10, 64)).
+					To(Equal(testBuildRun.Status.Sources[0].Timestamp.Unix()))
 			case "shp-image-digest":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Output.Digest))
 			case "shp-image-size":

--- a/test/e2e/v1beta1/validators_test.go
+++ b/test/e2e/v1beta1/validators_test.go
@@ -172,6 +172,9 @@ func validateBuildRunResultsFromGitSource(testBuildRun *buildv1beta1.BuildRun) {
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Source.Git.CommitAuthor))
 			case "shp-source-default-branch-name":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Source.Git.BranchName))
+			case "shp-source-default-source-timestamp":
+				Expect(strconv.ParseInt(result.Value.StringVal, 10, 64)).
+					To(Equal(testBuildRun.Status.Source.Timestamp.Unix()))
 			case "shp-image-digest":
 				Expect(result.Value.StringVal).To(Equal(testBuildRun.Status.Output.Digest))
 			case "shp-image-size":

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 		Expect(err).To(BeNil())
 
 	})
+
 	// Delete the ClusterBuildStrategies after each test case
 	AfterEach(func() {
 

--- a/test/integration/build_to_git_test.go
+++ b/test/integration/build_to_git_test.go
@@ -7,10 +7,12 @@ package integration_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
-	test "github.com/shipwright-io/build/test/v1alpha1_samples"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	test "github.com/shipwright-io/build/test/v1alpha1_samples"
 )
 
 var _ = Describe("Integration tests Build and referenced Source url", func() {

--- a/test/integration/build_to_taskruns_test.go
+++ b/test/integration/build_to_taskruns_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Integration tests Build and TaskRun", func() {
 		err = tb.CreateClusterBuildStrategy(cbsObject)
 		Expect(err).To(BeNil())
 	})
+
 	// Delete the ClusterBuildStrategies after each test case
 	AfterEach(func() {
 		_, err = tb.GetBuild(buildObject.Name)

--- a/test/integration/buildrun_status_test.go
+++ b/test/integration/buildrun_status_test.go
@@ -1,0 +1,96 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package integration_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Checking BuildRun Status fields", func() {
+	Context("Verifying BuildRun status source results", func() {
+		var (
+			strategyName string
+			buildRunName string
+		)
+
+		BeforeEach(func() {
+			id := rand.String(5)
+			strategyName = fmt.Sprintf("cbs-%s", id)
+			buildRunName = fmt.Sprintf("buildrun-%s", id)
+		})
+
+		AfterEach(func() {
+			tb.DeleteBR(buildRunName)
+			tb.DeleteClusterBuildStrategy(strategyName)
+		})
+
+		It("should have the correct source timestamp for Git sources", func() {
+			// Use an empty strategy to only have the source step
+			strategy := tb.Catalog.ClusterBuildStrategy(strategyName)
+			Expect(tb.CreateClusterBuildStrategy(strategy)).To(Succeed())
+
+			// Setup BuildRun with fixed revision where we know the commit details
+			Expect(tb.CreateBR(&v1alpha1.BuildRun{
+				ObjectMeta: metav1.ObjectMeta{Name: buildRunName},
+				Spec: v1alpha1.BuildRunSpec{
+					BuildSpec: &v1alpha1.BuildSpec{
+						Strategy: v1alpha1.Strategy{Kind: (*v1alpha1.BuildStrategyKind)(&strategy.Kind), Name: strategy.Name},
+						Source: v1alpha1.Source{
+							URL:      pointer.String("https://github.com/shipwright-io/sample-go"),
+							Revision: pointer.String("v0.1.0"),
+						},
+					},
+				},
+			})).ToNot(HaveOccurred())
+
+			buildRun, err := tb.GetBRTillCompletion(buildRunName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buildRun).ToNot(BeNil())
+
+			Expect(buildRun.Status.Sources).ToNot(BeEmpty())
+			Expect(buildRun.Status.Sources[0].Timestamp).ToNot(BeNil())
+			Expect(buildRun.Status.Sources[0].Timestamp.Time).To(BeTemporally("==", time.Unix(1619426578, 0)))
+		})
+
+		It("should have the correct source timestamp for Bundle sources", func() {
+			// Use an empty strategy to only have the source step
+			strategy := tb.Catalog.ClusterBuildStrategy(strategyName)
+			Expect(tb.CreateClusterBuildStrategy(strategy)).To(Succeed())
+
+			// Setup BuildRun with fixed image sha where we know the timestamp details
+			Expect(tb.CreateBR(&v1alpha1.BuildRun{
+				ObjectMeta: metav1.ObjectMeta{Name: buildRunName},
+				Spec: v1alpha1.BuildRunSpec{
+					BuildSpec: &v1alpha1.BuildSpec{
+						Strategy: v1alpha1.Strategy{Kind: (*v1alpha1.BuildStrategyKind)(&strategy.Kind), Name: strategy.Name},
+						Source: v1alpha1.Source{
+							BundleContainer: &v1alpha1.BundleContainer{
+								Image: "ghcr.io/shipwright-io/sample-go/source-bundle@sha256:9a5e264c19980387b8416e0ffa7460488272fb8a6a56127c657edaa2682daab2",
+							},
+						},
+					},
+				},
+			})).ToNot(HaveOccurred())
+
+			buildRun, err := tb.GetBRTillCompletion(buildRunName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buildRun).ToNot(BeNil())
+
+			Expect(buildRun.Status.Sources).ToNot(BeEmpty())
+			Expect(buildRun.Status.Sources[0].Timestamp).ToNot(BeNil())
+			Expect(buildRun.Status.Sources[0].Timestamp.Time).To(BeTemporally("==", time.Unix(1691650396, 0)))
+		})
+	})
+})

--- a/test/v1alpha1_samples/catalog.go
+++ b/test/v1alpha1_samples/catalog.go
@@ -225,6 +225,9 @@ func (c *Catalog) BuildWithOutputSecret(name string, ns string, secretName strin
 // ClusterBuildStrategy to support tests
 func (c *Catalog) ClusterBuildStrategy(name string) *build.ClusterBuildStrategy {
 	return &build.ClusterBuildStrategy{
+		TypeMeta: metav1.TypeMeta{
+			Kind: string(build.ClusterBuildStrategyKind),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},


### PR DESCRIPTION
# Changes

Extend the API fields and CRD files to include the source timestamp in the source result.

Update Git step code to write commit timestamp result file.

Update Bundle step code to write source timestamp, which is the the most recent source file timestamp.

Extend task run setup logic to include respective command line flags for the Git and Bundle step CLIs to write the result files, which then can be used to extend the status sources fields of the BuildRun.

Fix timestamp issue in Bundle pack and push code so that only the image gets a neutral timestamp, but the packaged source files retain their respective filesystem modification timestamps.

Add integration test cases to verify the new status sources fields.

Fixes #1446

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Git and Bundle sources now produce additional status fields in a BuildRun to return the commit timestamp of the commit being used, or the image/source timestamp of Bundle images respectively.
```
