### PR TITLE
Fix the BuildRun conversion from alpha to beta when .spec.serviceAccount.generate=true

### DIFF
--- a/pkg/apis/build/v1beta1/buildrun_conversion.go
+++ b/pkg/apis/build/v1beta1/buildrun_conversion.go
@@ -212,6 +212,9 @@ func (dest *BuildRunSpec) ConvertFrom(orig *v1alpha1.BuildRunSpec) error {
 
 	if orig.ServiceAccount != nil {
 		dest.ServiceAccount = orig.ServiceAccount.Name
+		if orig.ServiceAccount.Generate != nil && *orig.ServiceAccount.Generate {
+			dest.ServiceAccount = pointer.String(".generate")
+		}
 	}
 
 	dest.Timeout = orig.Timeout


### PR DESCRIPTION
# Changes

This fixes the conversion from v1alpha1 to v1beta1 of a BuildRun when the BuildRun uses a generated service account.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
A BuildRun object in v1alpha1 version is now correctly converted to v1beta1 when it has .spec.serviceAccount.generate set to true
```
