### PR TITLE
Fixed buildCredentialserences function name

### DIFF
--- a/pkg/validate/secrets.go
+++ b/pkg/validate/secrets.go
@@ -36,7 +36,7 @@ func (s Credentials) ValidatePath(ctx context.Context) error {
 	var missingSecrets []string
 	secret := &corev1.Secret{}
 
-	secretNames := s.buildCredentialserences()
+	secretNames := s.buildCredentialReferences()
 
 	for refSecret, secretType := range secretNames {
 		if err := s.Client.Get(ctx, types.NamespacedName{Name: refSecret, Namespace: s.Build.Namespace}, secret); err != nil && !apierrors.IsNotFound(err) {
@@ -58,7 +58,7 @@ func (s Credentials) ValidatePath(ctx context.Context) error {
 	return nil
 }
 
-func (s Credentials) buildCredentialserences() map[string]build.BuildReason {
+func (s Credentials) buildCredentialReferences() map[string]build.BuildReason {
 	// Validate if the referenced secrets exist in the namespace
 	secretRefMap := map[string]build.BuildReason{}
 	if s.Build.Spec.Output.PushSecret != nil {


### PR DESCRIPTION
## Description:

This Pull Request Fixes #1501  by improving the naming of the buildCredentialserences function in secrets.go. The current function name is misleading and grammatically incorrect. The function has been renamed to buildCredentialReferences to better reflect its purpose and adhere to proper naming conventions.

## Changes
- Renamed the function buildCredentialserences to buildCredentialReferences in secrets.go.
- Updated all references to the function throughout the codebase to use the new name.



# Release Notes

```release-note
NONE
```

