### PR TITLE
[fixed] : Order of Local Source between Builds and BuildRuns

### DIFF
--- a/pkg/reconciler/buildrun/resources/sources.go
+++ b/pkg/reconciler/buildrun/resources/sources.go
@@ -29,14 +29,12 @@ func isLocalCopyBuildSource(
 	buildRun *buildv1beta1.BuildRun,
 ) *buildv1beta1.Local {
 
-	// Note: In v1alpha1 we will append all sources across builds and buildruns, and then return
-	// the first source of type Local.
-	if build.Spec.Source.Type == buildv1beta1.LocalType {
-		return build.Spec.Source.LocalSource
-	}
-
 	if buildRun.Spec.Source != nil && buildRun.Spec.Source.Type == buildv1beta1.LocalType {
 		return buildRun.Spec.Source.LocalSource
+	}
+
+	if build.Spec.Source.Type == buildv1beta1.LocalType {
+		return build.Spec.Source.LocalSource
 	}
 
 	return nil


### PR DESCRIPTION
# Changes

This Pull Request fixes shipwright-io#1500 by improving the "isLocalCopyBuildSource" function. Here's a summary of the changes made:

- The check for the local source in the BuildRun is moved to the top of the function. This adjustment ensures that if a local source is defined in the BuildRun, it will be returned without further checks.
- If no local source is found in the BuildRun, the function then checks if the Build has a local source defined and returns it if found.
- If neither the BuildRun nor the Build has a local source defined, the function returns nil.

Removed redundant condition:
With the first conditional handling the case where a local source is defined in the BuildRun, there's no need to check if the Build has a local source if the BuildRun already has one.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```