### PR TITLE
Fix Heruko buildpacks samples that failed to determine the target OS

### DIFF
--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -8,6 +8,12 @@ spec:
     - name: platform-env
       emptyDir: {}
   parameters:
+    - name: operating-system
+      description: The target operating system for the buildpacks build.
+      default: "linux"
+    - name: system-architecture
+      description: The target system architecture for the buildpacks build.
+      default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.7"
@@ -15,6 +21,10 @@ spec:
     - name: build-and-push
       image: heroku/builder:22
       env:
+        - name: CNB_TARGET_OS
+          value: $(params.operating-system)
+        - name: CNB_TARGET_ARCH
+          value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT
@@ -62,7 +72,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -8,6 +8,12 @@ spec:
     - name: platform-env
       emptyDir: {}
   parameters:
+    - name: operating-system
+      description: The target operating system for the buildpacks build.
+      default: "linux"
+    - name: system-architecture
+      description: The target system architecture for the buildpacks build.
+      default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.7"
@@ -15,6 +21,10 @@ spec:
     - name: build-and-push
       image: heroku/builder:22
       env:
+        - name: CNB_TARGET_OS
+          value: $(params.operating-system)
+        - name: CNB_TARGET_ARCH
+          value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -8,6 +8,12 @@ spec:
     - name: platform-env
       emptyDir: {}
   parameters:
+    - name: operating-system
+      description: The target operating system for the buildpacks build.
+      default: "linux"
+    - name: system-architecture
+      description: The target system architecture for the buildpacks build.
+      default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.7"
@@ -15,6 +21,10 @@ spec:
     - name: build-and-push
       image: heroku/builder:22
       env:
+        - name: CNB_TARGET_OS
+          value: $(params.operating-system)
+        - name: CNB_TARGET_ARCH
+          value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT
@@ -62,7 +72,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -8,6 +8,12 @@ spec:
     - name: platform-env
       emptyDir: {}
   parameters:
+    - name: operating-system
+      description: The target operating system for the buildpacks build.
+      default: "linux"
+    - name: system-architecture
+      description: The target system architecture for the buildpacks build.
+      default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.7"
@@ -15,6 +21,10 @@ spec:
     - name: build-and-push
       image: heroku/builder:22
       env:
+        - name: CNB_TARGET_OS
+          value: $(params.operating-system)
+        - name: CNB_TARGET_ARCH
+          value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT


### PR DESCRIPTION
# Changes

Add `CNB_TARGET_OS` and `CNB_TARGET_ARCH` to fix error during the detect phase, where the target system cannot be detected:
```
[Error: Internal Buildpack Error]
Couldn't determine target os: environment variable not found
err:  heroku/procfile@3.0.0 (1)
======== Output: heroku/procfile@3.0.0 ========
```

There seems to be a changed behavior that was introduced in the common buildpacks library that is in use that expects these environment variables to be present to detect the target system OS and architecture.

Ref: https://github.com/heroku/procfile-cnb/issues/214
Ref: https://github.com/heroku/libcnb.rs/commit/033f6128c647b7bc6effc8b80fae8b96a4373169

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
