### PR TITLE
Bump Buildpacks platform version to `0.12` in build strategy samples

### DIFF
--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   buildSteps:
     - name: build-and-push
       image: heroku/builder:22

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   buildSteps:
     - name: build-and-push
       image: heroku/builder:22

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   steps:
     - name: build-and-push
       image: heroku/builder:22

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   steps:
     - name: build-and-push
       image: heroku/builder:22

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   steps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.7"
+      default: "0.12"
   steps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest


### PR DESCRIPTION
# Changes

Change Cloud Native Buildpacks platform API version to [`0.12`](https://github.com/buildpacks/spec/tree/platform/v0.12).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
