### PR TITLE
Include GitHub action version in Dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,12 @@ updates:
   - dependency-name: github.com/tektoncd/pipeline
   - dependency-name: k8s.io/*
   - dependency-name: sigs.k8s.io/*
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+    time: "06:00"
+  labels:
+  - kind/dependency-change
+  - release-note-none
+  open-pull-requests-limit: 10


### PR DESCRIPTION
# Changes

Extend Dependabot setup to also bump GitHub actions.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
