### PR TITLE
Fix unknown strategy kind reconcile issue

### DIFF
--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -16,6 +16,8 @@ type BuildReason string
 const (
 	// SucceedStatus indicates that all validations Succeeded
 	SucceedStatus BuildReason = "Succeeded"
+	// UnknownBuildStrategyKind indicates that neither namespace-scope or cluster-scope strategy kind was used
+	UnknownBuildStrategyKind BuildReason = "UnknownBuildStrategyKind"
 	// BuildStrategyNotFound indicates that a namespaced-scope strategy was not found in the namespace
 	BuildStrategyNotFound BuildReason = "BuildStrategyNotFound"
 	// ClusterBuildStrategyNotFound indicates that a cluster-scope strategy was not found

--- a/pkg/validate/strategies.go
+++ b/pkg/validate/strategies.go
@@ -69,7 +69,7 @@ func (s Strategy) validateBuildStrategy(ctx context.Context, strategyName string
 
 	if apierrors.IsNotFound(err) {
 		s.Build.Status.Reason = build.BuildReasonPtr(build.BuildStrategyNotFound)
-		s.Build.Status.Message = pointer.String(fmt.Sprintf("buildStrategy %s does not exist in namespace %s", s.Build.Spec.Strategy.Name, s.Build.Namespace))
+		s.Build.Status.Message = pointer.String(fmt.Sprintf("buildStrategy %s does not exist in namespace %s", strategyName, s.Build.Namespace))
 		return nil
 	}
 
@@ -87,7 +87,7 @@ func (s Strategy) validateClusterBuildStrategy(ctx context.Context, strategyName
 
 	if apierrors.IsNotFound(err) {
 		s.Build.Status.Reason = build.BuildReasonPtr(build.ClusterBuildStrategyNotFound)
-		s.Build.Status.Message = pointer.String(fmt.Sprintf("clusterBuildStrategy %s does not exist", s.Build.Spec.Strategy.Name))
+		s.Build.Status.Message = pointer.String(fmt.Sprintf("clusterBuildStrategy %s does not exist", strategyName))
 		return nil
 	}
 

--- a/pkg/validate/strategies_test.go
+++ b/pkg/validate/strategies_test.go
@@ -1,0 +1,167 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/shipwright-io/build/pkg/controller/fakes"
+	. "github.com/shipwright-io/build/pkg/validate"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	crc "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("BuildStrategy", func() {
+	var ctx context.Context
+	var client *fakes.FakeClient
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		client = &fakes.FakeClient{}
+	})
+
+	var sampleBuild = func(kind build.BuildStrategyKind, name string) *build.Build {
+		return &build.Build{
+			Spec: build.BuildSpec{
+				Strategy: build.Strategy{
+					Kind: &kind,
+					Name: name,
+				},
+			},
+		}
+	}
+
+	Context("namespaced build strategy is used", func() {
+		It("should pass when the referenced build strategy exists", func() {
+			sample := sampleBuild(build.NamespacedBuildStrategyKind, "buildkit")
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				switch object := object.(type) {
+				case *build.BuildStrategy:
+					(&build.BuildStrategy{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: nn.Namespace,
+							Name:      nn.Name},
+					}).DeepCopyInto(object)
+					return nil
+				}
+
+				return errors.NewNotFound(schema.GroupResource{}, "schema not found")
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).To(Succeed())
+			Expect(sample.Status.Reason).To(BeNil())
+		})
+
+		It("should fail when the referenced build strategy does not exists", func() {
+			sample := sampleBuild(build.NamespacedBuildStrategyKind, "buildkit")
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				return errors.NewNotFound(schema.GroupResource{}, "schema not found")
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).To(Succeed())
+			Expect(*sample.Status.Reason).To(Equal(build.BuildStrategyNotFound))
+		})
+
+		It("should error when there is an unexpected result", func() {
+			sample := sampleBuild(build.NamespacedBuildStrategyKind, "buildkit")
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				return errors.NewInternalError(fmt.Errorf("monkey wrench"))
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).ToNot(Succeed())
+		})
+	})
+
+	Context("cluster build strategy is used", func() {
+		It("should pass when the referenced build strategy exists", func() {
+			sample := sampleBuild(build.ClusterBuildStrategyKind, "buildkit")
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				switch object := object.(type) {
+				case *build.ClusterBuildStrategy:
+					(&build.ClusterBuildStrategy{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: nn.Namespace,
+							Name:      nn.Name},
+					}).DeepCopyInto(object)
+					return nil
+				}
+
+				return errors.NewNotFound(schema.GroupResource{}, "schema not found")
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).To(Succeed())
+			Expect(sample.Status.Reason).To(BeNil())
+		})
+
+		It("should fail when the referenced build strategy does not exists", func() {
+			sample := sampleBuild(build.ClusterBuildStrategyKind, "buildkit")
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				return errors.NewNotFound(schema.GroupResource{}, "schema not found")
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).To(Succeed())
+			Expect(*sample.Status.Reason).To(Equal(build.ClusterBuildStrategyNotFound))
+		})
+
+		It("should error when there is an unexpected result", func() {
+			sample := sampleBuild(build.ClusterBuildStrategyKind, "buildkit")
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				return errors.NewInternalError(fmt.Errorf("monkey wrench"))
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).ToNot(Succeed())
+		})
+	})
+
+	Context("edge cases", func() {
+		It("should default to namespace build strategy when kind is nil", func() {
+			sample := &build.Build{
+				Spec: build.BuildSpec{
+					Strategy: build.Strategy{
+						Kind: nil,
+						Name: "foobar",
+					},
+				},
+			}
+
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				switch object := object.(type) {
+				case *build.BuildStrategy:
+					(&build.BuildStrategy{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: nn.Namespace,
+							Name:      nn.Name},
+					}).DeepCopyInto(object)
+					return nil
+				}
+
+				return errors.NewNotFound(schema.GroupResource{}, "schema not found")
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).To(Succeed())
+			Expect(sample.Status.Reason).To(BeNil())
+		})
+
+		It("should fail validation if the strategy kind is unknown", func() {
+			sample := sampleBuild("abc", "xyz")
+			client.GetCalls(func(_ context.Context, nn types.NamespacedName, object crc.Object, getOptions ...crc.GetOption) error {
+				return errors.NewNotFound(schema.GroupResource{}, "schema not found")
+			})
+
+			Expect(NewStrategies(client, sample).ValidatePath(ctx)).To(Succeed())
+			Expect(*sample.Status.Reason).To(Equal(build.UnknownBuildStrategyKind))
+		})
+	})
+})

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -88,7 +88,7 @@ func All(ctx context.Context, validations ...BuildPath) error {
 }
 
 // BuildRunFields runs field validations against a BuildRun to detect
-// disallowed field combinations
+// disallowed field combinations and issues
 func BuildRunFields(buildRun *build.BuildRun) (string, string) {
 	if buildRun.Spec.Build.Spec == nil && buildRun.Spec.Build.Name == nil {
 		return resources.BuildRunNoRefOrSpec,

--- a/test/integration/build_to_buildruns_test.go
+++ b/test/integration/build_to_buildruns_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
 	test "github.com/shipwright-io/build/test/v1beta1_samples"
 )
 
@@ -251,7 +252,7 @@ var _ = Describe("Integration tests Build and BuildRuns", func() {
 			Expect(err).To(BeNil())
 
 			Expect(br.Status.GetCondition(v1beta1.Succeeded).Status).To(Equal(corev1.ConditionFalse))
-			Expect(br.Status.GetCondition(v1beta1.Succeeded).Reason).To(Equal("BuildRegistrationFailed"))
+			Expect(br.Status.GetCondition(v1beta1.Succeeded).Reason).To(Equal(resources.ConditionBuildRegistrationFailed))
 			Expect(br.Status.GetCondition(v1beta1.Succeeded).Message).To(ContainSubstring("Build is not registered correctly"))
 		})
 	})

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -305,7 +305,7 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 
 			reason, err := tb.GetBRReason(buildRunObject.Name)
 			Expect(err).To(BeNil())
-			Expect(reason).To(Equal("BuildRegistrationFailed"))
+			Expect(reason).To(Equal(resources.ConditionBuildRegistrationFailed))
 
 			_, err = tb.GetTaskRunFromBuildRun(buildRunObject.Name)
 			Expect(err).ToNot(BeNil())


### PR DESCRIPTION
# Changes

Set status when strategy kind is not one of the supported ones.

Add test cases to strategy validation.

Refactor strategy validation code to be more compact and readable.

Fixes #1531

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
