### PR TITLE
Move README to v1beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,21 +88,22 @@ Shipwright supports any tool that can build container images in Kubernetes clust
   ```bash
   REGISTRY_ORG=<your_registry_org>
   cat <<EOF | kubectl apply -f -
-  apiVersion: shipwright.io/v1alpha1
+  apiVersion: shipwright.io/v1beta1
   kind: Build
   metadata:
     name: buildpack-nodejs-build
   spec:
     source:
-      url: https://github.com/shipwright-io/sample-nodejs
+      type: Git
+      git:
+        url: https://github.com/shipwright-io/sample-nodejs
       contextDir: source-build
     strategy:
       name: buildpacks-v3
       kind: ClusterBuildStrategy
     output:
       image: docker.io/${REGISTRY_ORG}/sample-nodejs:latest
-      credentials:
-        name: push-secret
+      pushSecret: push-secret
   EOF
   ```
 
@@ -119,12 +120,12 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 
   ```bash
   cat <<EOF | kubectl create -f -
-  apiVersion: shipwright.io/v1alpha1
+  apiVersion: shipwright.io/v1beta1
   kind: BuildRun
   metadata:
     generateName: buildpack-nodejs-buildrun-
   spec:
-    buildRef:
+    build:
       name: buildpack-nodejs-build
   EOF
   ```


### PR DESCRIPTION
# Changes

Move README to v1beta1
Move CRs to use v1beta1 as the apiVersion and adjust the objects definition.

Fixes #1502 

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

