### PR TITLE
Use major version for `peter-evans/create-pull-request` action

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "TO=$(git diff --unified=0 | grep '^[+].*image: .*/.*/.*:' | head --lines=1 | cut --delimiter=':' --fields='3' | sed 's/[^[[:digit:].]//g')" >> $GITHUB_OUTPUT
         id: image-diff
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: Bump ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}
           title: Bump ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,7 +99,7 @@ jobs:
         git commit -m "Update Readme with new Tag ${{ github.event.inputs.release }}"
         git clean -f
     - name: Create Readme PR
-      uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29
+      uses: peter-evans/create-pull-request@v6
       with:
         commit-message: Update Readme with new Tag
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
# Changes

Switch to using the major version for the `peter-evans/create-pull-request` GitHub action.

Bump to latest available `v6`.

This supersedes #1525.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
