### PR TITLE
SHIP-0038: Run CI on Release Branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,14 @@ on:
   pull_request:
     branches:
     - main
+    - "release-v*" # release branches
   push:
     paths-ignore:
     - 'README.md'
     - 'docs/**'
     branches:
     - main
+    - "release-v*" # release branches
 
 jobs:
   unit:

--- a/.github/workflows/release-notes-linter.yaml
+++ b/.github/workflows/release-notes-linter.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-v*" # release branches
 
 jobs:
   release-note-linter:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -6,9 +6,11 @@ on:
       - '**'
     branches:
       - main
+      - "release-v*" # release branches
   pull_request:
     branches:
       - main
+      - "release-v*" # release branches
 
 permissions:
   contents: read


### PR DESCRIPTION
# Changes

Update our CI-oriented GitHub actions to run when commits merge in a `release-v*` branch, or a pull request is opened against a `release-v*` branch. With this change, future release branches will automatically have CI checks enabled. This commit should be backported to enable CI in a prior release branch.

This implements a portion of SHIP-0038.

See also https://github.com/shipwright-io/community/issues/85

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
