### PR TITLE
Improve conversion webhook logging

### DIFF
--- a/pkg/apis/build/v1beta1/build_conversion.go
+++ b/pkg/apis/build/v1beta1/build_conversion.go
@@ -27,7 +27,7 @@ var _ webhook.Conversion = (*Build)(nil)
 
 // ConvertTo converts this Build object to v1alpha1 format.
 func (src *Build) ConvertTo(ctx context.Context, obj *unstructured.Unstructured) error {
-	ctxlog.Debug(ctx, "Converting Build from beta to alpha", "namespace", src.Namespace, "name", src.Name)
+	ctxlog.Info(ctx, "converting Build from beta to alpha", "namespace", src.Namespace, "name", src.Name)
 
 	var alphaBuild v1alpha1.Build
 
@@ -75,7 +75,7 @@ func (src *Build) ConvertFrom(ctx context.Context, obj *unstructured.Unstructure
 		ctxlog.Error(ctx, err, "failed unstructuring the convertedObject")
 	}
 
-	ctxlog.Debug(ctx, "Converting Build from alpha to beta", "namespace", alphaBuild.Namespace, "name", alphaBuild.Name)
+	ctxlog.Info(ctx, "converting Build from alpha to beta", "namespace", alphaBuild.Namespace, "name", alphaBuild.Name)
 
 	src.ObjectMeta = alphaBuild.ObjectMeta
 	src.TypeMeta = alphaBuild.TypeMeta

--- a/pkg/apis/build/v1beta1/buildrun_conversion.go
+++ b/pkg/apis/build/v1beta1/buildrun_conversion.go
@@ -21,7 +21,7 @@ var _ webhook.Conversion = (*BuildRun)(nil)
 
 // To Alpha
 func (src *BuildRun) ConvertTo(ctx context.Context, obj *unstructured.Unstructured) error {
-	ctxlog.Debug(ctx, "Converting BuildRun from beta to alpha", "namespace", src.Namespace, "name", src.Name)
+	ctxlog.Info(ctx, "converting BuildRun from beta to alpha", "namespace", src.Namespace, "name", src.Name)
 
 	var alphaBuildRun v1alpha1.BuildRun
 
@@ -194,7 +194,7 @@ func (src *BuildRun) ConvertFrom(ctx context.Context, obj *unstructured.Unstruct
 		ctxlog.Error(ctx, err, "failed unstructuring the buildrun convertedObject")
 	}
 
-	ctxlog.Debug(ctx, "Converting BuildRun from alpha to beta", "namespace", alphaBuildRun.Namespace, "name", alphaBuildRun.Name)
+	ctxlog.Info(ctx, "converting BuildRun from alpha to beta", "namespace", alphaBuildRun.Namespace, "name", alphaBuildRun.Name)
 
 	src.ObjectMeta = alphaBuildRun.ObjectMeta
 	src.TypeMeta = alphaBuildRun.TypeMeta

--- a/pkg/apis/build/v1beta1/buildstrategy_conversion.go
+++ b/pkg/apis/build/v1beta1/buildstrategy_conversion.go
@@ -22,7 +22,7 @@ var _ webhook.Conversion = (*BuildStrategy)(nil)
 
 // ConvertTo converts this object to its v1alpha1 equivalent
 func (src *BuildStrategy) ConvertTo(ctx context.Context, obj *unstructured.Unstructured) error {
-	ctxlog.Debug(ctx, "Converting BuildStrategy from beta to alpha", "namespace", src.Namespace, "name", src.Name)
+	ctxlog.Info(ctx, "converting BuildStrategy from beta to alpha", "namespace", src.Namespace, "name", src.Name)
 
 	var bs v1alpha1.BuildStrategy
 	bs.TypeMeta = src.TypeMeta
@@ -154,7 +154,7 @@ func (src *BuildStrategy) ConvertFrom(ctx context.Context, obj *unstructured.Uns
 		ctxlog.Error(ctx, err, "failed unstructuring the buildrun convertedObject")
 	}
 
-	ctxlog.Debug(ctx, "Converting BuildStrategy from alpha to beta", "namespace", bs.Namespace, "name", bs.Name)
+	ctxlog.Info(ctx, "converting BuildStrategy from alpha to beta", "namespace", bs.Namespace, "name", bs.Name)
 
 	src.ObjectMeta = bs.ObjectMeta
 	src.TypeMeta = bs.TypeMeta

--- a/pkg/apis/build/v1beta1/clusterbuildstrategy_conversion.go
+++ b/pkg/apis/build/v1beta1/clusterbuildstrategy_conversion.go
@@ -19,7 +19,7 @@ var _ webhook.Conversion = (*ClusterBuildStrategy)(nil)
 
 // ConvertTo converts this object to its v1alpha1 equivalent
 func (src *ClusterBuildStrategy) ConvertTo(ctx context.Context, obj *unstructured.Unstructured) error {
-	ctxlog.Debug(ctx, "Converting ClusterBuildStrategy from beta to alpha", "namespace", src.Namespace, "name", src.Name)
+	ctxlog.Info(ctx, "converting ClusterBuildStrategy from beta to alpha", "namespace", src.Namespace, "name", src.Name)
 
 	var bs v1alpha1.ClusterBuildStrategy
 	bs.TypeMeta = src.TypeMeta
@@ -47,7 +47,7 @@ func (src *ClusterBuildStrategy) ConvertFrom(ctx context.Context, obj *unstructu
 		ctxlog.Error(ctx, err, "failed unstructuring the buildrun convertedObject")
 	}
 
-	ctxlog.Debug(ctx, "Converting ClusterBuildStrategy from alpha to beta", "namespace", cbs.Namespace, "name", cbs.Name)
+	ctxlog.Info(ctx, "converting ClusterBuildStrategy from alpha to beta", "namespace", cbs.Namespace, "name", cbs.Name)
 
 	src.ObjectMeta = cbs.ObjectMeta
 	src.TypeMeta = cbs.TypeMeta

--- a/pkg/webhook/conversion/conversion.go
+++ b/pkg/webhook/conversion/conversion.go
@@ -83,7 +83,7 @@ func serve(ctx context.Context, w http.ResponseWriter, r *http.Request, convert 
 		return
 	}
 
-	ctxlog.Info(ctx, "handling request")
+	ctxlog.Debug(ctx, "handling request")
 
 	obj, gvk, err := serializer.Decode(body, nil, nil)
 	if err != nil {
@@ -104,9 +104,10 @@ func serve(ctx context.Context, w http.ResponseWriter, r *http.Request, convert 
 			http.Error(w, msg, http.StatusBadRequest)
 			return
 		}
+		ctxlog.Info(ctx, "conversion request", "uid", convertReview.Request.UID)
 		convertReview.Response = doConversion(ctx, convertReview.Request, convert)
 		convertReview.Response.UID = convertReview.Request.UID
-		ctxlog.Info(ctx, fmt.Sprintf("sending response: %v", convertReview.Response))
+		ctxlog.Info(ctx, "conversion response", "status", convertReview.Response.Result.Status, "uid", convertReview.Response.UID)
 
 		convertReview.Request = &v1.ConversionRequest{}
 		responseObj = convertReview

--- a/pkg/webhook/conversion/converter.go
+++ b/pkg/webhook/conversion/converter.go
@@ -28,7 +28,7 @@ const (
 // convertSHPCR takes an unstructured object with certain CR apiversion, parses it to a known Object type,
 // modify the type to a desired version of that type, and converts it back to unstructured
 func convertSHPCR(ctx context.Context, Object *unstructured.Unstructured, toVersion string) (*unstructured.Unstructured, metav1.Status) {
-	ctxlog.Info(ctx, "converting custom resource")
+	ctxlog.Debug(ctx, "converting custom resource")
 
 	convertedObject := Object.DeepCopy()
 	fromVersion := Object.GetAPIVersion()
@@ -44,7 +44,6 @@ func convertSHPCR(ctx context.Context, Object *unstructured.Unstructured, toVers
 
 		case alphaGroupVersion:
 			if convertedObject.Object[KIND] == buildKind {
-
 				unstructured := convertedObject.UnstructuredContent()
 				var build v1beta1.Build
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured, &build)


### PR DESCRIPTION
# Changes

Ensure Info log is kept to a minimal
Ensure log content is valuable:

- provide conversion request UID
- provide conversion response UID and status

Upon conversion of an object, this is how the webhook will log:

```sh
{"level":"debug","ts":"2024-03-20T12:31:01Z","logger":"shp-build-webhook","msg":"handling request"}
{"level":"info","ts":"2024-03-20T12:31:01Z","logger":"shp-build-webhook","msg":"conversion request","uid":"0fea4dac-0a67-4c2f-b01c-4798ae7de382"}
{"level":"debug","ts":"2024-03-20T12:31:01Z","logger":"shp-build-webhook","msg":"converting custom resource"}
{"level":"info","ts":"2024-03-20T12:31:01Z","logger":"shp-build-webhook","msg":"converting Build from beta to alpha","namespace":"default","name":"buildkit-build"}
{"level":"info","ts":"2024-03-20T12:31:01Z","logger":"shp-build-webhook","msg":"conversion response","status":"Success","uid":"0fea4dac-0a67-4c2f-b01c-4798ae7de382"}
```


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE


# Release Notes


```release-note
Improve conversion webhook logging
```
