### PR TITLE
Fix underscore showing up between badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 <p align="center">
     <img alt="Work in Progress" src="https://img.shields.io/badge/Status-Work%20in%20Progress-informational">
-    <a alt="GoReport" href="https://goreportcard.com/report/github.com/shipwright-io/build">
-        <img src="https://goreportcard.com/badge/github.com/shipwright-io/build">
-    </a>
-    <img alt="License" src="https://img.shields.io/github/license/shipwright-io/build">
-    <a href="https://pkg.go.dev/mod/github.com/shipwright-io/build"> <img src="https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white"></a>
+    <a alt="GoReport" href="https://goreportcard.com/report/github.com/shipwright-io/build"><img src="https://goreportcard.com/badge/github.com/shipwright-io/build"></a>
+    <a href="https://github.com/shipwright-io/build/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/shipwright-io/build"></a>
+    <a href="https://pkg.go.dev/mod/github.com/shipwright-io/build"><img src="https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white"></a>
     <a href="https://bestpractices.coreinfrastructure.org/projects/5315"><img src="https://bestpractices.coreinfrastructure.org/projects/5315/badge"></a>
 </p>
 


### PR DESCRIPTION
# Changes

Fix additional underscore that show up between the badges in the README header.

> <img width="201" alt="image" src="https://github.com/shipwright-io/build/assets/1979133/0b72cedc-9834-425c-b2f5-83d1703fc904">


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
