### PR TITLE
Correct multiple secret values in one array parameter that references different secret variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ anaconda-mode/
 *.dylib
 # Test binary, build with 'go test -c'
 *.test
+# Ginkgo report
+ginkgo.report
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 ### Vim ###

--- a/pkg/reconciler/buildrun/resources/params.go
+++ b/pkg/reconciler/buildrun/resources/params.go
@@ -160,7 +160,8 @@ func HandleTaskRunParam(taskRun *pipelineapi.TaskRun, parameterDefinition *build
 			return nil
 
 		default:
-			for index, value := range paramValue.Values {
+			for index := range paramValue.Values {
+				value := paramValue.Values[index]
 				switch {
 				case value.ConfigMapValue != nil:
 					envVarName, err := addConfigMapEnvVar(taskRun, paramValue.Name, value.ConfigMapValue.Name, value.ConfigMapValue.Key)


### PR DESCRIPTION
# Changes

There is a bug when defining the following Build:

```yaml
spec:
  paramValues:
    name: param-name
    values:
    - secretValue:
        name: secret-name
        key: key-1
        format: ARG_NAME1=${SECRET_VALUE}
    - secretValue:
        name: secret-name
        key: key-2
        format: ARG_NAME2=${SECRET_VALUE}
```

Due to the way we iterate over the values, we caused the TaskRun to only have references to `key-2`. Unfortunatly, our existing unit test did not capture that. Also extending those.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The usage of different secrets or secret keys as values inside one array parameter is now possible
```
