### PR TITLE
Do not set dockerfile parameter to an empty string to align with behavior of alpha controller

### DIFF
--- a/pkg/apis/build/v1beta1/build_conversion.go
+++ b/pkg/apis/build/v1beta1/build_conversion.go
@@ -166,7 +166,7 @@ func (dest *BuildSpec) ConvertFrom(orig *v1alpha1.BuildSpec) error {
 	}
 
 	//handle spec.Dockerfile migration
-	if orig.Dockerfile != nil {
+	if orig.Dockerfile != nil && *orig.Dockerfile != "" {
 		dockerfileParam := ParamValue{
 			Name: "dockerfile",
 			SingleValue: &SingleValue{


### PR DESCRIPTION
# Changes

When the Build controller still reconciled the Alpha version of Builds, it handled `spec.dockerfile` here: https://github.com/shipwright-io/build/blob/v0.12.0/pkg/reconciler/buildrun/resources/taskrun.go#L361-L369.

Basically if the value was nil, the parameter value was not added. With that, its default value, `"Dockerfile"` was used. https://github.com/shipwright-io/build/blob/v0.12.0/pkg/reconciler/buildrun/resources/taskrun.go#L74-L81

Suddenly, this was also happening when the `spec.dockerfile` was set to an empty string.

To mimic the same behavior with the conversion to Beta, I am changing our conversion code to behave the same = not adding the parameter value to be an empty string.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
An Alpha Build where `spec.dockerfile` is set to `""`, is now transformed to a Beta Build without the dockerfile parameter to behave like in Alpha
```