### PR TITLE
Add StepOutOfMemory as reason for BuildRun failure

### DIFF
--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -391,6 +391,7 @@ The following table illustrates the different states a BuildRun can have under i
 | False   | BuildRunAmbiguousBuild                  | Yes                   | The defined `BuildRun` uses both `spec.build.name` and `spec.build.spec`. Only one of them is allowed at the same time.                                                                                                                                                                               |
 | False   | BuildRunBuildFieldOverrideForbidden     | Yes                   | The defined `BuildRun` uses an override (e.g. `timeout`, `paramValues`, `output`, or `env`) in combination with `spec.build.spec`, which is not allowed. Use the `spec.build.spec` to directly specify the respective value.                                                                          |
 | False   | PodEvicted                              | Yes                   | The BuildRun Pod was evicted from the node it was running on. See [API-initiated Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/) and [Node-pressure Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/) for more information. |
+| False   | StepOutOfMemory                         | Yes                   | The BuildRun Pod failed because a step went out of memory. |
 
 **Note**: We heavily rely on the Tekton TaskRun [Conditions](https://github.com/tektoncd/pipeline/blob/main/docs/taskruns.md#monitoring-execution-status) for populating the BuildRun ones, with some exceptions.
 

--- a/pkg/apis/build/v1beta1/buildrun_types.go
+++ b/pkg/apis/build/v1beta1/buildrun_types.go
@@ -106,6 +106,9 @@ const (
 	// BuildRunStatePodEvicted indicates that if the pods got evicted
 	// due to some reason. (Probably ran out of ephemeral storage)
 	BuildRunStatePodEvicted = "PodEvicted"
+
+	// BuildRunStateStepOutOfMemory indicates that a step failed because it went out of memory.
+	BuildRunStateStepOutOfMemory = "StepOutOfMemory"
 )
 
 // SourceResult holds the results emitted from the different sources

--- a/test/integration/buildruns_to_taskruns_test.go
+++ b/test/integration/buildruns_to_taskruns_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Integration tests BuildRuns and TaskRuns", func() {
 					condition := buildRun.Status.GetCondition(v1beta1.Succeeded)
 					Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 					Expect(condition.Reason).To(Equal("Failed"))
-					Expect(condition.Message).To(ContainSubstring("buildrun step %s failed in pod %s", "step-step-build-and-push", taskRun.Status.PodName))
+					Expect(condition.Message).To(ContainSubstring("buildrun step %s failed", "step-step-build-and-push"))
 				})
 			})
 		})


### PR DESCRIPTION
# Changes

When a BuildRun Pod fails because of too much ephemeral storage usage and is therefore evicted, then we expose this nicely in the BuildRun status as the condition reason is set to PodEvicted. In case a container went out of memory, we did not expose that at all in the BuildRun status while it is quite obvious in the TaskRun and Pod status who print the step/container status.

I am therefore proposing here to introduce the BuildRun failure reason StepOutOfMemory.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
You can now easily determine that your BuildRun failed because a step went out of memory as the reason is now set to StepOutOfMemory
```