### PR TITLE
Revisit image tags in BuildAh sample build strategy

### DIFF
--- a/hack/check-latest-images.sh
+++ b/hack/check-latest-images.sh
@@ -46,7 +46,7 @@ function update() {
         # Determine the latest tag
         QUERY=".tag_name"
         if [[ ${IMAGE} == *buildah* ]]; then
-                QUERY=".tags | sort_by(.name) | reverse | .[0].name"
+                QUERY="[.tags[] | select(.name | endswith(\"immutable\") | not) ] | sort_by(.name) | reverse | .[0].name"
         fi
         LATEST_TAG="$(curl --silent --retry 3 "${LATEST_RELEASE_URL}" | jq --raw-output "${QUERY}")"
 

--- a/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
@@ -7,6 +7,7 @@ spec:
   buildSteps:
     - name: build
       image: quay.io/containers/buildah:v1.35.3
+      imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true

--- a/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
@@ -7,6 +7,7 @@ spec:
   buildSteps:
     - name: build-and-push
       image: quay.io/containers/buildah:v1.35.3
+      imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:

--- a/samples/v1alpha1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -22,6 +22,7 @@ spec:
           mountPath: /s2i
     - name: buildah
       image: quay.io/containers/buildah:v1.35.3
+      imagePullPolicy: Always
       workingDir: /s2i
       securityContext:
         privileged: true

--- a/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
@@ -7,6 +7,7 @@ spec:
   steps:
     - name: build
       image: quay.io/containers/buildah:v1.35.3
+      imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true

--- a/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
@@ -7,6 +7,7 @@ spec:
   steps:
     - name: build-and-push
       image: quay.io/containers/buildah:v1.35.3
+      imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:

--- a/samples/v1beta1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/v1beta1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -24,6 +24,7 @@ spec:
           mountPath: /s2i
     - name: buildah
       image: quay.io/containers/buildah:v1.35.3
+      imagePullPolicy: Always
       workingDir: /s2i
       securityContext:
         capabilities:


### PR DESCRIPTION
# Changes

BuildAh image tags are based on the BuildAh version (e. g. v1.35.3) and are mutable, meaning the tag that you consume gets rebuilt by the BuildAh team regularly to address vulnerabilities.

Recently, the BuildAh team also added immutable tags which are never rebuilt, but may be removed. https://lists.podman.io/archives/list/podman@lists.podman.io/thread/FP6I3OAHRYXDV5S7NFZHNJBV7AQQZHPD/

Especially the fact that those might get removed is imo meaning that we should not use them in our sample build strategies.

I therefore adjust our update script to filter out those tags to make sure we won't get PRs like https://github.com/shipwright-io/build/pull/1599/files again.

I am also changing the BuildAh step of our build strategies to use imagePullPolicy=Always to ensure the latest available image is always pulled.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The sample build strategies now uses imagePullPolicy=Always for the BuildAh steps to ensure the latest available image version is always used
```
