### PR TITLE
Enforce ordered execution of tests

### DIFF
--- a/cmd/image-processing/main_test.go
+++ b/cmd/image-processing/main_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-var _ = Describe("Image Processing Resource", func() {
+var _ = Describe("Image Processing Resource", Ordered, func() {
 	run := func(args ...string) error {
 		log.SetOutput(GinkgoWriter)
 


### PR DESCRIPTION
# Changes

Mitigation for #1621

Enforce ordered execution since the introduction of the latest test context in `cmd/image-processing` led to failures when using Ginkgo CLI to drive the tests. Since the PR status checks are driven by `go test` this regression was not obvious.

```
$ go run github.com/onsi/ginkgo/v2/ginkgo run --coverprofile=unit.coverprofile --output-dir=build/coverage --randomize-all --trace ./cmd/image-processing

Running Suite: Image Processing Command Suite - /Users/mdiester/go/src/github.com/shipwright-io/build/cmd/image-processing
==========================================================================================================================
Random Seed: 1718369287 - will randomize all specs

Will run 23 of 23 specs
•••••••••••••••
------------------------------
• [FAILED] [0.431 seconds]
Image Processing Resource mutating the image [It] should mutate an image with single annotation
/Users/mdiester/go/src/github.com/shipwright-io/build/cmd/image-processing/main_test.go:256

  Timeline >>
  GET /v2/
  HEAD /v2/temp-image/manifests/nskxt 404 NAME_UNKNOWN Unknown name
  HEAD /v2/temp-image/blobs/sha256:5b943e2b943f6c81dbbd4e2eca5121f4fcc39139e3d1219d6d89bd925b77d9fe 404 BLOB_UNKNOWN Unknown blob
  POST /v2/temp-image/blobs/uploads/
  PATCH /v2/temp-image/blobs/uploads/8973636687925678644
  PUT /v2/temp-image/blobs/uploads/8973636687925678644?digest=sha256%3A5b943e2b943f6c81dbbd4e2eca5121f4fcc39139e3d1219d6d89bd925b77d9fe
  PUT /v2/temp-image/manifests/nskxt
  2024/06/14 14:48:41 Loading the image from the registry "127.0.0.1:50479/temp-image:nskxt"
  GET /v2/
  HEAD /v2/temp-image/manifests/nskxt
  GET /v2/
  GET /v2/temp-image/manifests/nskxt
  2024/06/14 14:48:41 Loaded single image
  2024/06/14 14:48:41 Mutating the image
  GET /v2/
  GET /v2/temp-image/manifests/nskxt
  GET /v2/temp-image/blobs/sha256:5b943e2b943f6c81dbbd4e2eca5121f4fcc39139e3d1219d6d89bd925b77d9fe
  [FAILED] in [It] - /Users/mdiester/go/src/github.com/shipwright-io/build/cmd/image-processing/main_test.go:262 @ 06/14/24 14:48:42.11
  << Timeline

  [FAILED] Unexpected error:
      <*fs.PathError | 0x1400042bbc0>:
      open : no such file or directory
      {
          Op: "open",
          Path: "",
          Err: <syscall.Errno>0x2,
      }
  occurred
  In [It] at: /Users/mdiester/go/src/github.com/shipwright-io/build/cmd/image-processing/main_test.go:262 @ 06/14/24 14:48:42.11
```

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
