### PR TITLE
Refactor/simplify test asset directory look-up

### DIFF
--- a/cmd/image-processing/main_test.go
+++ b/cmd/image-processing/main_test.go
@@ -405,12 +405,7 @@ var _ = Describe("Image Processing Resource", Ordered, func() {
 	})
 
 	Context("vulnerability scanning", func() {
-		var directory string
-		BeforeEach(func() {
-			cwd, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			directory = path.Clean(path.Join(cwd, "../..", "test/data/images/vuln-image-in-oci"))
-		})
+		directory := path.Join("..", "..", "test", "data", "images", "vuln-image-in-oci")
 
 		It("should run vulnerability scanning if it is enabled and output vulnerabilities equal to the limit defined", func() {
 			vulnOptions := &buildapi.VulnerabilityScanOptions{
@@ -491,7 +486,6 @@ var _ = Describe("Image Processing Resource", Ordered, func() {
 
 				_, err = remote.Get(ref)
 				Expect(err).To(HaveOccurred())
-
 			})
 		})
 
@@ -540,6 +534,5 @@ var _ = Describe("Image Processing Resource", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-
 	})
 })


### PR DESCRIPTION
# Changes

Simplify the look-up for the test asset directory. No need for path cleaning function since it is a test case and the look-up is relative by default, so there is no need to look-up the current working directory.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
