### PR TITLE
Do not panic if there are no vulnerabilities / Fix severity parsing

### DIFF
--- a/pkg/reconciler/buildrun/resources/results.go
+++ b/pkg/reconciler/buildrun/resources/results.go
@@ -82,8 +82,12 @@ func getTaskSpecResults() []pipelineapi.TaskResult {
 }
 
 func getImageVulnerabilitiesResult(result pipelineapi.TaskRunResult) []build.Vulnerability {
-	vulnerabilities := strings.Split(result.Value.StringVal, ",")
 	var vulns []build.Vulnerability
+	if len(result.Value.StringVal) == 0 {
+		return vulns
+	}
+
+	vulnerabilities := strings.Split(result.Value.StringVal, ",")
 	for _, vulnerability := range vulnerabilities {
 		vuln := strings.Split(vulnerability, ":")
 		severity := getSeverity(vuln[1])
@@ -96,7 +100,7 @@ func getImageVulnerabilitiesResult(result pipelineapi.TaskRunResult) []build.Vul
 }
 
 func getSeverity(sev string) build.VulnerabilitySeverity {
-	switch sev {
+	switch strings.ToUpper(sev) {
 	case "L":
 		return build.Low
 	case "M":


### PR DESCRIPTION
# Changes

When running with image vulnerability scanning enabled, and there is not vulnerability, the controller panics:

```txt
{"level":"info","ts":"2024-06-15T20:40:20Z","msg":"surfacing taskRun results to BuildRun status","controller":"buildrun-controller","object":{"name":"ubi-nonroot-9-minimal-fw69g-ndngd","namespace":"container-images-build"},"namespace":"container-images-build","name":"ubi-nonroot-9-minimal-fw69g-ndngd","reconcileID":"a72dd0d7-5697-4ef9-9f36-275ebb758466","namespace":"container-images-build","name":"ubi-nonroot-9-minimal-fw69g-ndngd"}
{"level":"info","ts":"2024-06-15T20:40:20Z","msg":"Observed a panic in reconciler: runtime error: index out of range [1] with length 1","controller":"buildrun-controller","object":{"name":"ubi-nonroot-9-minimal-fw69g-ndngd","namespace":"container-images-build"},"namespace":"container-images-build","name":"ubi-nonroot-9-minimal-fw69g-ndngd","reconcileID":"a72dd0d7-5697-4ef9-9f36-275ebb758466"}
panic: runtime error: index out of range [1] with length 1 [recovered]
    panic: runtime error: index out of range [1] with length 1

goroutine 224 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
    sigs.k8s.io/controller-runtime@v0.15.3/pkg/internal/controller/controller.go:115 +0x1a4
panic({0x15a0ae0?, 0x4000b08150?})
    runtime/panic.go:770 +0x124
github.com/shipwright-io/build/pkg/reconciler/buildrun/resources.getImageVulnerabilitiesResult({{0x4000914ae0, 0x19}, {0x40008f5286, 0x6}, {{0x16c3136, 0x6}, {0x0, 0x0}, {0x0, 0x0, ...}, ...}})
    github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/results.go:89 +0x244
github.com/shipwright-io/build/pkg/reconciler/buildrun/resources.updateBuildRunStatusWithOutputResult({0x1997428, 0x400034eee0}, 0x4000b2f2c0, {0x4000b33408?, 0x6?, 0x12a87e0?}, {{{0x40008e4f00?, 0x4000b2b260?}, {0x40008876b0?, 0x1704c2d?}}})
    github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/results.go:58 +0x2f4
github.com/shipwright-io/build/pkg/reconciler/buildrun/resources.UpdateBuildRunUsingTaskResults({0x1997428, 0x400034eee0}, 0x4000b2f2c0, {0x4000b33408, 0x6, 0x6}, {{{0x40008e4f00?, 0x19adef0?}, {0x40008876b0?, 0x0?}}})
    github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/results.go:38 +0x88
github.com/shipwright-io/build/pkg/reconciler/buildrun.(*ReconcileBuildRun).Reconcile(0x40002c6960, {0x1997380?, 0x4000b2b2f0?}, {{{0x40008e4f00?, 0x4000b23ce8?}, {0x40008876b0?, 0x30?}}})
    github.com/shipwright-io/build/pkg/reconciler/buildrun/buildrun.go:391 +0xc40
...
```

And as it was in the same file, adding a second fix ... the TaskRun status is like this:

```yaml
  - name: shp-image-vulnerabilities
    type: string
    value: CVE-2023-30571:m,CVE-2024-2398:m
```

Severity is a lower-case letter, but the code was checking for upper-case letters resulting in all of them reported as unknown in the BuildRun status.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The controller now does not panic when no vulnerabilities are found, also severity is correctly parsed
```
