### PR TITLE
Pin to newer Node version that is still supported by Paketo

### DIFF
--- a/test/e2e/v1alpha1/common_suite_test.go
+++ b/test/e2e/v1alpha1/common_suite_test.go
@@ -110,6 +110,14 @@ func (b *buildPrototype) Dockerfile(dockerfile string) *buildPrototype {
 	return b
 }
 
+func (b *buildPrototype) Env(key string, value string) *buildPrototype {
+	b.build.Spec.Env = append(b.build.Spec.Env, core.EnvVar{
+		Name:  key,
+		Value: value,
+	})
+	return b
+}
+
 func (b *buildPrototype) determineParameterIndex(name string) int {
 	index := -1
 	for i, paramValue := range b.build.Spec.ParamValues {

--- a/test/e2e/v1alpha1/e2e_image_mutate_test.go
+++ b/test/e2e/v1alpha1/e2e_image_mutate_test.go
@@ -181,6 +181,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 						OutputImageCredentials(os.Getenv(EnvVarImageRepoSecret)).
 						OutputImageInsecure(insecure).
 						OutputTimestamp(outputTimestamp).
+						Env("BP_NODE_VERSION", "~20").
 						BuildSpec()).
 					MustCreate()
 			}

--- a/test/e2e/v1beta1/common_suite_test.go
+++ b/test/e2e/v1beta1/common_suite_test.go
@@ -154,6 +154,14 @@ func (b *buildPrototype) OutputImage(image string) *buildPrototype {
 	return b
 }
 
+func (b *buildPrototype) Env(key string, value string) *buildPrototype {
+	b.build.Spec.Env = append(b.build.Spec.Env, core.EnvVar{
+		Name:  key,
+		Value: value,
+	})
+	return b
+}
+
 func (b *buildPrototype) OutputVulnerabilitySettings(settings buildv1beta1.VulnerabilityScanOptions) *buildPrototype {
 	b.build.Spec.Output.VulnerabilityScan = &settings
 	return b

--- a/test/e2e/v1beta1/e2e_image_mutate_test.go
+++ b/test/e2e/v1beta1/e2e_image_mutate_test.go
@@ -181,6 +181,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 						OutputImageCredentials(os.Getenv(EnvVarImageRepoSecret)).
 						OutputImageInsecure(insecure).
 						OutputTimestamp(outputTimestamp).
+						Env("BP_NODE_VERSION", "~20").
 						BuildSpec()).
 					MustCreate()
 			}


### PR DESCRIPTION
# Changes

https://github.com/shipwright-io/sample-nodejs/pull/12 updated the node version in our sample to 18 because Paketo removed support for Node 16. Though, the e2e test case for image mutation is using a specific commit of that repository to be able to test that the source timestamp is correct.

To fix this, I am changing the configuration of the Build to use an environment variable that tells Paketo to use Node 20.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
