### PR TITLE
Add script for storage version migartion of crds

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,24 +168,24 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 
 ### Read the Docs
 
-| Version | Docs                           | Examples                    |
-| ------- | ------------------------------ | --------------------------- |
-| HEAD    | [Docs @ HEAD](docs/README.md) | [Examples @ HEAD](samples) |
-| [v0.13.0](https://github.com/shipwright-io/build/releases/tag/v0.13.0)    | [Docs @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.13.0/docs) | [Examples @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.13.0/samples) |
-| [v0.12.0](https://github.com/shipwright-io/build/releases/tag/v0.12.0)    | [Docs @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/samples) |
-| [v0.11.0](https://github.com/shipwright-io/build/releases/tag/v0.11.0)    | [Docs @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/docs) | [Examples @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/samples) |
-| [v0.10.0](https://github.com/shipwright-io/build/releases/tag/v0.10.0)    | [Docs @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/docs) | [Examples @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/samples) |
-| [v0.9.0](https://github.com/shipwright-io/build/releases/tag/v0.9.0)    | [Docs @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/docs) | [Examples @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/samples) |
-| [v0.8.0](https://github.com/shipwright-io/build/releases/tag/v0.8.0)    | [Docs @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/docs) | [Examples @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/samples) |
-| [v0.7.0](https://github.com/shipwright-io/build/releases/tag/v0.7.0)    | [Docs @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/docs) | [Examples @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/samples) |
-| [v0.6.0](https://github.com/shipwright-io/build/releases/tag/v0.6.0)    | [Docs @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/docs) | [Examples @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/samples) |
-| [v0.5.1](https://github.com/shipwright-io/build/releases/tag/v0.5.1)    | [Docs @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/docs) | [Examples @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/samples) |
-| [v0.5.0](https://github.com/shipwright-io/build/releases/tag/v0.5.0)    | [Docs @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/docs) | [Examples @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/samples) |
-| [v0.4.0](https://github.com/shipwright-io/build/releases/tag/v0.4.0)    | [Docs @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/docs) | [Examples @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/samples) |
-| [v0.3.0](https://github.com/shipwright-io/build/releases/tag/v0.3.0)    | [Docs @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/docs) | [Examples @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/samples) |
-| [v0.2.0](https://github.com/shipwright-io/build/releases/tag/v0.2.0)    | [Docs @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/docs) | [Examples @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/samples) |
-| [v0.1.1](https://github.com/shipwright-io/build/releases/tag/v0.1.1)    | [Docs @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/docs) | [Examples @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/samples) |
-| [v0.1.0](https://github.com/shipwright-io/build/releases/tag/v0.1.0)    | [Docs @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/docs) | [Examples @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/samples) |
+| Version                                                                | Docs                                                                       | Examples                                                                          |
+|------------------------------------------------------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| HEAD                                                                   | [Docs @ HEAD](docs/README.md)                                              | [Examples @ HEAD](samples)                                                        |
+| [v0.13.0](https://github.com/shipwright-io/build/releases/tag/v0.13.0) | [Docs @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.13.0/samples) |
+| [v0.12.0](https://github.com/shipwright-io/build/releases/tag/v0.12.0) | [Docs @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/samples) |
+| [v0.11.0](https://github.com/shipwright-io/build/releases/tag/v0.11.0) | [Docs @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/docs) | [Examples @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/samples) |
+| [v0.10.0](https://github.com/shipwright-io/build/releases/tag/v0.10.0) | [Docs @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/docs) | [Examples @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/samples) |
+| [v0.9.0](https://github.com/shipwright-io/build/releases/tag/v0.9.0)   | [Docs @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/docs)   | [Examples @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/samples)   |
+| [v0.8.0](https://github.com/shipwright-io/build/releases/tag/v0.8.0)   | [Docs @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/docs)   | [Examples @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/samples)   |
+| [v0.7.0](https://github.com/shipwright-io/build/releases/tag/v0.7.0)   | [Docs @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/docs)   | [Examples @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/samples)   |
+| [v0.6.0](https://github.com/shipwright-io/build/releases/tag/v0.6.0)   | [Docs @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/docs)   | [Examples @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/samples)   |
+| [v0.5.1](https://github.com/shipwright-io/build/releases/tag/v0.5.1)   | [Docs @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/docs)   | [Examples @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/samples)   |
+| [v0.5.0](https://github.com/shipwright-io/build/releases/tag/v0.5.0)   | [Docs @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/docs)   | [Examples @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/samples)   |
+| [v0.4.0](https://github.com/shipwright-io/build/releases/tag/v0.4.0)   | [Docs @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/docs)   | [Examples @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/samples)   |
+| [v0.3.0](https://github.com/shipwright-io/build/releases/tag/v0.3.0)   | [Docs @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/docs)   | [Examples @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/samples)   |
+| [v0.2.0](https://github.com/shipwright-io/build/releases/tag/v0.2.0)   | [Docs @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/docs)   | [Examples @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/samples)   |
+| [v0.1.1](https://github.com/shipwright-io/build/releases/tag/v0.1.1)   | [Docs @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/docs)   | [Examples @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/samples)   |
+| [v0.1.0](https://github.com/shipwright-io/build/releases/tag/v0.1.0)   | [Docs @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/docs)   | [Examples @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/samples)   |
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright deployment. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.12.0/release.yaml --server-side
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.12.0/hack/setup-webhook-cert.sh | bash
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.13.0/release.yaml --server-side
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.13.0/hack/setup-webhook-cert.sh | bash
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
   ```
 
   To install the latest nightly release, run:
@@ -56,12 +57,13 @@ Shipwright supports any tool that can build container images in Kubernetes clust
   ```bash
   kubectl apply --filename "https://github.com/shipwright-io/build/releases/download/nightly/nightly-$(curl --silent --location https://github.com/shipwright-io/build/releases/download/nightly/latest.txt).yaml" --server-side
   curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/setup-webhook-cert.sh | bash
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
   ```
 
 - Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.12.0/sample-strategies.yaml --server-side
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.13.0/sample-strategies.yaml --server-side
   ```
 
   To install the latest nightly release, run:
@@ -166,23 +168,24 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 
 ### Read the Docs
 
-| Version                                                                | Docs                                                                       | Examples                                                                          |
-|------------------------------------------------------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| HEAD                                                                   | [Docs @ HEAD](docs/README.md)                                              | [Examples @ HEAD](samples)                                                        |
-| [v0.12.0](https://github.com/shipwright-io/build/releases/tag/v0.12.0) | [Docs @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/samples) |
-| [v0.11.0](https://github.com/shipwright-io/build/releases/tag/v0.11.0) | [Docs @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/docs) | [Examples @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/samples) |
-| [v0.10.0](https://github.com/shipwright-io/build/releases/tag/v0.10.0) | [Docs @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/docs) | [Examples @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/samples) |
-| [v0.9.0](https://github.com/shipwright-io/build/releases/tag/v0.9.0)   | [Docs @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/docs)   | [Examples @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/samples)   |
-| [v0.8.0](https://github.com/shipwright-io/build/releases/tag/v0.8.0)   | [Docs @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/docs)   | [Examples @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/samples)   |
-| [v0.7.0](https://github.com/shipwright-io/build/releases/tag/v0.7.0)   | [Docs @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/docs)   | [Examples @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/samples)   |
-| [v0.6.0](https://github.com/shipwright-io/build/releases/tag/v0.6.0)   | [Docs @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/docs)   | [Examples @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/samples)   |
-| [v0.5.1](https://github.com/shipwright-io/build/releases/tag/v0.5.1)   | [Docs @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/docs)   | [Examples @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/samples)   |
-| [v0.5.0](https://github.com/shipwright-io/build/releases/tag/v0.5.0)   | [Docs @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/docs)   | [Examples @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/samples)   |
-| [v0.4.0](https://github.com/shipwright-io/build/releases/tag/v0.4.0)   | [Docs @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/docs)   | [Examples @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/samples)   |
-| [v0.3.0](https://github.com/shipwright-io/build/releases/tag/v0.3.0)   | [Docs @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/docs)   | [Examples @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/samples)   |
-| [v0.2.0](https://github.com/shipwright-io/build/releases/tag/v0.2.0)   | [Docs @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/docs)   | [Examples @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/samples)   |
-| [v0.1.1](https://github.com/shipwright-io/build/releases/tag/v0.1.1)   | [Docs @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/docs)   | [Examples @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/samples)   |
-| [v0.1.0](https://github.com/shipwright-io/build/releases/tag/v0.1.0)   | [Docs @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/docs)   | [Examples @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/samples)   |
+| Version | Docs                           | Examples                    |
+| ------- | ------------------------------ | --------------------------- |
+| HEAD    | [Docs @ HEAD](docs/README.md) | [Examples @ HEAD](samples) |
+| [v0.13.0](https://github.com/shipwright-io/build/releases/tag/v0.13.0)    | [Docs @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.13.0/docs) | [Examples @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.13.0/samples) |
+| [v0.12.0](https://github.com/shipwright-io/build/releases/tag/v0.12.0)    | [Docs @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/samples) |
+| [v0.11.0](https://github.com/shipwright-io/build/releases/tag/v0.11.0)    | [Docs @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/docs) | [Examples @ v0.11.0](https://github.com/shipwright-io/build/tree/v0.11.0/samples) |
+| [v0.10.0](https://github.com/shipwright-io/build/releases/tag/v0.10.0)    | [Docs @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/docs) | [Examples @ v0.10.0](https://github.com/shipwright-io/build/tree/v0.10.0/samples) |
+| [v0.9.0](https://github.com/shipwright-io/build/releases/tag/v0.9.0)    | [Docs @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/docs) | [Examples @ v0.9.0](https://github.com/shipwright-io/build/tree/v0.9.0/samples) |
+| [v0.8.0](https://github.com/shipwright-io/build/releases/tag/v0.8.0)    | [Docs @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/docs) | [Examples @ v0.8.0](https://github.com/shipwright-io/build/tree/v0.8.0/samples) |
+| [v0.7.0](https://github.com/shipwright-io/build/releases/tag/v0.7.0)    | [Docs @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/docs) | [Examples @ v0.7.0](https://github.com/shipwright-io/build/tree/v0.7.0/samples) |
+| [v0.6.0](https://github.com/shipwright-io/build/releases/tag/v0.6.0)    | [Docs @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/docs) | [Examples @ v0.6.0](https://github.com/shipwright-io/build/tree/v0.6.0/samples) |
+| [v0.5.1](https://github.com/shipwright-io/build/releases/tag/v0.5.1)    | [Docs @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/docs) | [Examples @ v0.5.1](https://github.com/shipwright-io/build/tree/v0.5.1/samples) |
+| [v0.5.0](https://github.com/shipwright-io/build/releases/tag/v0.5.0)    | [Docs @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/docs) | [Examples @ v0.5.0](https://github.com/shipwright-io/build/tree/v0.5.0/samples) |
+| [v0.4.0](https://github.com/shipwright-io/build/releases/tag/v0.4.0)    | [Docs @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/docs) | [Examples @ v0.4.0](https://github.com/shipwright-io/build/tree/v0.4.0/samples) |
+| [v0.3.0](https://github.com/shipwright-io/build/releases/tag/v0.3.0)    | [Docs @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/docs) | [Examples @ v0.3.0](https://github.com/shipwright-io/build/tree/v0.3.0/samples) |
+| [v0.2.0](https://github.com/shipwright-io/build/releases/tag/v0.2.0)    | [Docs @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/docs) | [Examples @ v0.2.0](https://github.com/shipwright-io/build/tree/v0.2.0/samples) |
+| [v0.1.1](https://github.com/shipwright-io/build/releases/tag/v0.1.1)    | [Docs @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/docs) | [Examples @ v0.1.1](https://github.com/shipwright-io/build/tree/v0.1.1/samples) |
+| [v0.1.0](https://github.com/shipwright-io/build/releases/tag/v0.1.0)    | [Docs @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/docs) | [Examples @ v0.1.0](https://github.com/shipwright-io/build/tree/v0.1.0/samples) |
 
 ### Dependencies
 

--- a/deploy/200-role.yaml
+++ b/deploy/200-role.yaml
@@ -27,7 +27,7 @@ rules:
   resources: ['buildruns']
   # The build-run-deletion annotation sets an owner ref on BuildRun objects.
   # With the OwnerReferencesPermissionEnforcement admission controller enabled, controllers need the "delete" permission on objects that they set owner references on.
-  verbs:     ['get', 'list', 'watch', 'update', 'delete']
+  verbs:     ['get', 'list', 'watch', 'update', 'delete', 'patch']
 
 - apiGroups: ['shipwright.io']
   # BuildRuns are set as the owners of Tekton TaskRuns.
@@ -41,7 +41,7 @@ rules:
 
 - apiGroups: ['shipwright.io']
   resources: ['builds']
-  verbs:     ['get', 'list', 'watch']
+  verbs:     ['get', 'list', 'watch', 'patch']
 
 - apiGroups: ['shipwright.io']
   # The build-run-deletion annotation makes Builds an owner of BuildRun objects.
@@ -55,11 +55,11 @@ rules:
 
 - apiGroups: ['shipwright.io']
   resources: ['buildstrategies']
-  verbs:     ['get', 'list', 'watch']
+  verbs:     ['get', 'list', 'watch', 'patch']
 
 - apiGroups: ['shipwright.io']
   resources: ['clusterbuildstrategies']
-  verbs:     ['get', 'list', 'watch']
+  verbs:     ['get', 'list', 'watch', 'patch']
 
 - apiGroups: ['tekton.dev']
   resources: ['taskruns']
@@ -82,3 +82,7 @@ rules:
 - apiGroups: ['']
   resources: ['serviceaccounts']
   verbs:     ['get', 'list', 'watch', 'create', 'update', 'delete']
+
+- apiGroups: ['apiextensions.k8s.io']
+  resources: ['customresourcedefinitions', 'customresourcedefinitions/status']
+  verbs:     ['get', 'patch']

--- a/hack/storage-version-migration.sh
+++ b/hack/storage-version-migration.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if ! hash jq >/dev/null 2>&1 ; then
+  echo "[ERROR] jq is not installed"
+  exit 1
+fi
+
+# Delete old job for storage version migration
+kubectl -n shipwright-build delete job --selector app=storage-version-migration-shipwright --wait=true
+
+# create new job for storage version migration
+cat <<EOF | kubectl create -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: storage-version-migration-shipwright-
+  labels:
+    app: storage-version-migration-shipwright
+    app.kubernetes.io/component: storage-version-migration-job
+    app.kubernetes.io/name: shipwright-build
+  namespace: shipwright-build
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: storage-version-migration-shipwright
+        app.kubernetes.io/component: storage-version-migration-job
+        app.kubernetes.io/name: shipwright-build
+    spec:
+      serviceAccountName: shipwright-build-controller
+      containers:
+        - args:
+            - buildruns.shipwright.io
+            - builds.shipwright.io
+            - buildstrategies.shipwright.io
+            - clusterbuildstrategies.shipwright.io
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+          name: migrate
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      restartPolicy: OnFailure
+  ttlSecondsAfterFinished: 600
+EOF
+
+JOB_NAME=$(kubectl -n shipwright-build get job --selector app=storage-version-migration-shipwright -o jsonpath='{.items[0].metadata.name}')
+
+while [ "$(kubectl -n shipwright-build get job "${JOB_NAME}" -o json | jq -r '.status.completionTime // ""')" == "" ]; do
+    echo "[INFO] Storage version migraton job is still running"
+    sleep 10
+done
+
+isFailed="$(kubectl -n shipwright-build get job "${JOB_NAME}" -o json | jq -r '.status.conditions[] | select(.type == "Failed") | .status')"
+
+if [ "${isFailed}" == "True" ]; then
+    echo "[ERROR] Storage version migration failed"
+    kubectl -n shipwright-build logs "job/${JOB_NAME}"
+    exit 1
+fi
+
+echo "[DONE]"


### PR DESCRIPTION
# Changes

Add script for storage version migartion of crds

Fixes https://github.com/shipwright-io/build/issues/1603

# Submitter Checklist

- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
You can now run a post-installation step to migrate the storage version of the custom resources
```
