### PR TITLE
Test two different Tekton versions in e2e and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,12 @@ jobs:
         kubernetes:
           - v1.27.11
           - v1.29.2
-      max-parallel: 2
+        tekton:
+          # oldest LTS that exists at the time of our planned next release
+          - v0.53.5
+          # newest LTS that exists at the time of our planned next release
+          - v0.59.2
+      max-parallel: 4
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -109,6 +114,8 @@ jobs:
             exit 1
           fi
       - name: Install Tekton
+        env:
+          TEKTON_VERSION: ${{ matrix.tekton }}
         run: |
           make kind-tekton
           kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-controller --timeout=1m
@@ -132,7 +139,12 @@ jobs:
         kubernetes:
           - v1.27.11
           - v1.29.2
-      max-parallel: 2
+        tekton:
+          # oldest LTS that exists at the time of our planned next release
+          - v0.53.5
+          # newest LTS that exists at the time of our planned next release
+          - v0.59.2
+      max-parallel: 4
     runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
@@ -185,6 +197,8 @@ jobs:
             exit 1
           fi
       - name: Install Tekton
+        env:
+          TEKTON_VERSION: ${{ matrix.tekton }}
         run: |
           make kind-tekton
           kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-controller --timeout=1m


### PR DESCRIPTION
# Changes

As [discussed in the last community meeting](https://github.com/shipwright-io/community/issues/227#issuecomment-2228523745), this PR changes the e2e and integration to test two different Tekton versions.

We could actually think about automation that automatically updates the newest LTS version.

We will need to red-merge this one to then change the branch configuration to the changed check names that this change introduces.

Part of https://github.com/shipwright-io/build/issues/1640

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Shipwright Build is now validated on the oldest supported and the newest available Tekton LTS releases
```
