### PR TITLE
fixed container name for shipwright-webhook

### DIFF
--- a/deploy/700-deployment-webhook.yaml
+++ b/deploy/700-deployment-webhook.yaml
@@ -27,7 +27,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: shipwright-build-webhook
       containers:
-      - name:  shp-build-webhook
+      - name:  shipwright-build-webhook
         image: ko://github.com/shipwright-io/build/cmd/shipwright-build-webhook
         volumeMounts:
         - name: webhook-certs


### PR DESCRIPTION
# Changes
- Fixed container name for shipwright-webhook from `shp-build-webhook ` to `shipwright-build-webhook `
- Fixes #1648 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```