### PR TITLE
Use Go `1.22` in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version: 1.22.x
           cache: true
           check-latest: true
       - name: Install Trivy
@@ -76,7 +76,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version: 1.22.x
           cache: true
           check-latest: true
       - name: Install Ko
@@ -162,7 +162,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version: 1.22.x
           cache: true
           check-latest: true
       - name: Install kubectl

--- a/.github/workflows/cleanup-nightly-assets.yaml
+++ b/.github/workflows/cleanup-nightly-assets.yaml
@@ -26,7 +26,7 @@ jobs:
       run: |
         WORK_DIR=`mktemp -d -p "$DIR"`
         gh release download nightly -D ${WORK_DIR}
-        
+
         ASSETS_TOTAL=$(ls $WORK_DIR | wc -l)
         echo "[INFO] Currently ${ASSETS_TOTAL} assets for nightly release"
 
@@ -48,4 +48,3 @@ jobs:
 
         rm -rf "$WORK_DIR"
         echo "[INFO] Deleted temporary directory ${WORK_DIR}"
-  

--- a/.github/workflows/mirror-images.yaml
+++ b/.github/workflows/mirror-images.yaml
@@ -24,6 +24,7 @@ jobs:
             library/golang:1.19 \
             library/golang:1.20 \
             library/golang:1.21 \
+            library/golang:1.22 \
             library/maven:3-jdk-8-openj9 \
             library/node:12 \
             library/node:14 \

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.21.x'
+        go-version: 1.22.x
         cache: true
         check-latest: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         fetch-depth: 0  # Fetch all history, needed for release note generation.
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.21.x'
+        go-version: 1.22.x
         cache: true
         check-latest: true
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21.x'
+        go-version: 1.22.x
         cache: true
         check-latest: true
         cache-dependency-path: go/src/github.com/shipwright-io/build


### PR DESCRIPTION
# Changes

Use latest Go version `1.22` for any Go related GitHub Action.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
