### PR TITLE
Add automation to bump Tekton automatically

### DIFF
--- a/.github/bump-tekton-lts.sh
+++ b/.github/bump-tekton-lts.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+usage() {
+  echo
+  echo "Usage:"
+  echo "  $0 [--output SOME_FILE]"
+  echo
+  exit 1
+}
+
+OUTPUT_FILE=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      shift
+      OUTPUT_FILE="$1"
+      ;;
+
+    *)
+      echo "Unknown flag $1"
+      usage
+      ;;
+  esac
+  shift
+done
+
+# Retrieve current Tekton version
+OLD_VERSION="$(
+  grep github.com/tektoncd/pipeline "${BASEDIR}/go.mod" |
+  sed s#github.com/tektoncd/pipeline## |
+  tr -d ' \t'
+)"
+
+# Retrieve the latest Tekton LTS version
+# Assumption: every third Tekton release is LTS
+NEW_VERSION="$(
+  curl -s 'https://api.github.com/repos/tektoncd/pipeline/releases?per_page=100' |
+  jq -r '.[] | select(.draft == false and .prerelease == false and (.tag_name | split(".") | .[1] | tonumber) % 3 == 2) | .tag_name' |
+  sort  --version-sort |
+  tail -n 1
+)"
+
+# Write output
+if [ -n "${OUTPUT_FILE}" ]; then
+  echo "OLD_VERSION=${OLD_VERSION}" >>"${OUTPUT_FILE}"
+  echo "NEW_VERSION=${NEW_VERSION}" >>"${OUTPUT_FILE}"
+fi
+
+# Update go.mod
+pushd "${BASEDIR}" >/dev/null
+go get "github.com/tektoncd/pipeline@${NEW_VERSION}"
+go mod tidy
+go mod vendor
+popd >/dev/null
+
+# Update ci.yml
+sed -i "s/- v.* # RETAIN-COMMENT: TEKTON_NEWEST_LTS/- ${NEW_VERSION} # RETAIN-COMMENT: TEKTON_NEWEST_LTS/" "${BASEDIR}/.github/workflows/ci.yml"
+
+# Update Makefile
+sed -i "s/TEKTON_VERSION ?= v.*/TEKTON_VERSION ?= ${NEW_VERSION}/" "${BASEDIR}/Makefile"
+
+# Update install-tekton.sh
+sed -i "s/TEKTON_VERSION:-v.*}/TEKTON_VERSION:-${NEW_VERSION}}/" "${BASEDIR}/hack/install-tekton.sh"
+
+# Update README.md
+sed -i "s#https://storage.googleapis.com/tekton-releases/pipeline/previous/v.*/release.yaml#https://storage.googleapis.com/tekton-releases/pipeline/previous/${NEW_VERSION}/release.yaml#" "${BASEDIR}/README.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           # oldest LTS that exists at the time of our planned next release
           - v0.53.5
           # newest LTS that exists at the time of our planned next release
-          - v0.59.2
+          - v0.59.2 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
     runs-on: ubuntu-latest
     steps:
@@ -143,7 +143,7 @@ jobs:
           # oldest LTS that exists at the time of our planned next release
           - v0.53.5
           # newest LTS that exists at the time of our planned next release
-          - v0.59.2
+          - v0.59.2 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-tekton-version.yaml
+++ b/.github/workflows/update-tekton-version.yaml
@@ -1,0 +1,53 @@
+---
+name: Update Tekton version
+on:
+  schedule:
+  - cron: '0 0 * * *'
+  issue_comment:
+    types: [created, edited]
+jobs:
+  check-new-versions:
+    if: contains(github.event.comment.body, '/rebase') || github.event_name == 'schedule'
+    permissions:
+      pull-requests: write # To be able to create pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+          cache: true
+          check-latest: true
+
+      - name: Update Tekton version
+        id: update-tekton
+        run: ./.github/bump-tekton-lts.sh --output "${GITHUB_OUTPUT}"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Bump Tekton Pipeline from ${{ steps.update-tekton.outputs.OLD_VERSION }} to ${{ steps.update-tekton.outputs.NEW_VERSION }}
+          title: Bump Tekton Pipeline from ${{ steps.update-tekton.outputs.OLD_VERSION }} to ${{ steps.update-tekton.outputs.NEW_VERSION }}
+          body: |
+            # Changes
+
+            Bumps Tekton Pipeline from ${{ steps.update-tekton.outputs.OLD_VERSION }} to ${{ steps.update-tekton.outputs.NEW_VERSION }}
+
+            You can trigger a rebase manually by commenting `/rebase` and resolve any conflicts with this PR.
+
+            # Submitter Checklist
+            - [ ] Includes tests if functionality changed/was added
+            - [ ] Includes docs if changes are user-facing
+            - [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
+            - [x] Release notes block has been filled in, or marked NONE
+
+            # Release Notes
+
+            ```release-note
+            Update the the new latest Tekton LTS release ${{ steps.update-tekton.outputs.NEW_VERSION }}
+            ```
+          labels: kind/dependency-change
+          branch: bump-tekton-pipeline
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 
 - We assume you already have a Kubernetes cluster (v1.27+). If you don't, you can use [KinD](https://kind.sigs.k8s.io), which you can install by running [`./hack/install-kind.sh`](./hack/install-kind.sh).
 
-- We also require a Tekton installation (v0.50.+). To install it, run:
+- We also require a Tekton installation (v0.50.+). To install the latest LTS release, run:
 
   ```bash
   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.50.5/release.yaml


### PR DESCRIPTION
# Changes

This PR adds automation to bump to the latest Tekton LTS release. The first PR it will open will have an inconsistent from/to message because we have different from Tekton versions at various places. From then onwards, the messages will be consistent.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
