### PR TITLE
Use dedicated token for the workflow that bumps the Tekton version

### DIFF
--- a/.github/workflows/update-tekton-version.yaml
+++ b/.github/workflows/update-tekton-version.yaml
@@ -1,4 +1,9 @@
 ---
+# This workflow updates the Tekton version insight Shipwright Build to the latest LTS.
+# As part of that it uses a Personal Access Token that is stored as secret in shipwrigh-io/build
+# using the name SHIPWRIGHT_BUILD_WRITE_WORKFLOWS. The token expires every 90 days. Instructions
+# to renew it can be found in the "HOW TO update SHIPWRIGHT_BUILD_WRITE_WORKFLOWS" note in the
+# 1Password store that Shipwright Administrators have access to.
 name: Update Tekton version
 on:
   schedule:
@@ -8,12 +13,12 @@ on:
 jobs:
   check-new-versions:
     if: contains(github.event.comment.body, '/rebase') || github.event_name == 'schedule'
-    permissions:
-      pull-requests: write # To be able to create pull requests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SHIPWRIGHT_BUILD_WRITE_WORKFLOWS }}
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -28,6 +33,8 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.SHIPWRIGHT_BUILD_WRITE_WORKFLOWS }}
+
           commit-message: Bump Tekton Pipeline from ${{ steps.update-tekton.outputs.OLD_VERSION }} to ${{ steps.update-tekton.outputs.NEW_VERSION }}
           title: Bump Tekton Pipeline from ${{ steps.update-tekton.outputs.OLD_VERSION }} to ${{ steps.update-tekton.outputs.NEW_VERSION }}
           body: |


### PR DESCRIPTION
# Changes

The action that I recently introduced fails. Took me some time to figure out why. The reason is that the workflow tries to update a file insight .github/workflows. This requires a permission (workflows:write) that one cannot grant through a GitHub action permission itself. Instead one must use a personal access token. Reference: https://github.com/orgs/community/discussions/35410#discussioncomment-7645702

I created a personal access token for it and stored it as secret.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
