### PR TITLE
Change to errors.New because strings passed to fmt.Errorf should be constants according to govet

### DIFF
--- a/pkg/image/delete.go
+++ b/pkg/image/delete.go
@@ -7,6 +7,7 @@ package image
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -173,7 +174,7 @@ func dockerHubLogin(username string, password string) (string, error) {
 		return fmt.Sprintf("JWT %s", loginToken.Token), nil
 
 	default:
-		return "", fmt.Errorf(string(bodyData))
+		return "", errors.New(string(bodyData))
 	}
 }
 


### PR DESCRIPTION
# Changes

Currently, all our PRs are red due to this finding:

```txt

run golangci-lint
  Running [/home/runner/golangci-lint-1.60.1-linux-amd64/golangci-lint run --path-prefix=go/src/github.com/shipwright-io/build --timeout=10m] in [/home/runner/work/build/build/go/src/github.com/shipwright-io/build] ...
  Received 1105143 of 1105143 (100.0%), 1.1 MBs/sec
  Error: go/src/github.com/shipwright-io/build/pkg/image/delete.go:176:25: printf: non-constant format string in call to fmt.Errorf (govet)
  		return "", fmt.Errorf(string(bodyData))
```

I am changing our code accordingly.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
