### PR TITLE
Address G115 findings

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -6768,11 +6768,13 @@ spec:
                           failedLimit:
                             description: FailedLimit defines the maximum number of
                               failed buildruns that should exist.
+                            maximum: 10000
                             minimum: 1
                             type: integer
                           succeededLimit:
                             description: SucceededLimit defines the maximum number
                               of succeeded buildruns that should exist.
+                            maximum: 10000
                             minimum: 1
                             type: integer
                           ttlAfterFailed:
@@ -10874,11 +10876,13 @@ spec:
                       failedLimit:
                         description: FailedLimit defines the maximum number of failed
                           buildruns that should exist.
+                        maximum: 10000
                         minimum: 1
                         type: integer
                       succeededLimit:
                         description: SucceededLimit defines the maximum number of
                           succeeded buildruns that should exist.
+                        maximum: 10000
                         minimum: 1
                         type: integer
                       ttlAfterFailed:

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -2507,11 +2507,13 @@ spec:
                   failedLimit:
                     description: FailedLimit defines the maximum number of failed
                       buildruns that should exist.
+                    maximum: 10000
                     minimum: 1
                     type: integer
                   succeededLimit:
                     description: SucceededLimit defines the maximum number of succeeded
                       buildruns that should exist.
+                    maximum: 10000
                     minimum: 1
                     type: integer
                   ttlAfterFailed:

--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -343,11 +343,13 @@ type BuildRetention struct {
 	//
 	// +optional
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=10000
 	FailedLimit *uint `json:"failedLimit,omitempty"`
 	// SucceededLimit defines the maximum number of succeeded buildruns that should exist.
 	//
 	// +optional
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=10000
 	SucceededLimit *uint `json:"succeededLimit,omitempty"`
 	// TTLAfterFailed defines the maximum duration of time the failed buildrun should exist.
 	//

--- a/pkg/reconciler/buildlimitcleanup/build_limit_cleanup.go
+++ b/pkg/reconciler/buildlimitcleanup/build_limit_cleanup.go
@@ -99,13 +99,15 @@ func (r *ReconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 
 	// Check limits and delete oldest buildruns if limit is reached.
 	if b.Spec.Retention.SucceededLimit != nil {
-		if len(buildRunSucceeded) > int(*b.Spec.Retention.SucceededLimit) {
+		// #nosec G115, is validated in the type
+		succeededLimit := int(*b.Spec.Retention.SucceededLimit)
+		if len(buildRunSucceeded) > succeededLimit {
 			// Sort buildruns with oldest one at the beginning
 			sort.Slice(buildRunSucceeded, func(i, j int) bool {
 				return buildRunSucceeded[i].ObjectMeta.CreationTimestamp.Before(&buildRunSucceeded[j].ObjectMeta.CreationTimestamp)
 			})
 			lenOfList := len(buildRunSucceeded)
-			for i := 0; i < lenOfList-int(*b.Spec.Retention.SucceededLimit); i++ {
+			for i := 0; i < lenOfList-succeededLimit; i++ {
 				ctxlog.Info(ctx, "Deleting succeeded buildrun as cleanup limit has been reached.", namespace, request.Namespace, name, buildRunSucceeded[i].Name)
 				err := r.client.Delete(ctx, &buildRunSucceeded[i], &client.DeleteOptions{})
 				if err != nil {
@@ -120,13 +122,15 @@ func (r *ReconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 	}
 
 	if b.Spec.Retention.FailedLimit != nil {
-		if len(buildRunFailed) > int(*b.Spec.Retention.FailedLimit) {
+		// #nosec G115, is validated in the type
+		failedLimit := int(*b.Spec.Retention.FailedLimit)
+		if len(buildRunFailed) > failedLimit {
 			// Sort buildruns with oldest one at the beginning
 			sort.Slice(buildRunFailed, func(i, j int) bool {
 				return buildRunFailed[i].ObjectMeta.CreationTimestamp.Before(&buildRunFailed[j].ObjectMeta.CreationTimestamp)
 			})
 			lenOfList := len(buildRunFailed)
-			for i := 0; i < lenOfList-int(*b.Spec.Retention.FailedLimit); i++ {
+			for i := 0; i < lenOfList-failedLimit; i++ {
 				ctxlog.Info(ctx, "Deleting failed buildrun as cleanup limit has been reached.", namespace, request.Namespace, name, buildRunFailed[i].Name)
 				err := r.client.Delete(ctx, &buildRunFailed[i], &client.DeleteOptions{})
 				if err != nil {

--- a/pkg/reconciler/buildlimitcleanup/controller.go
+++ b/pkg/reconciler/buildlimitcleanup/controller.go
@@ -67,8 +67,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler, maxConcurrentReconciles in
 					return true
 				} else if n.Spec.Retention.SucceededLimit != nil && o.Spec.Retention.SucceededLimit == nil {
 					return true
+					// #nosec G115, is validated in the type
 				} else if n.Spec.Retention.FailedLimit != nil && o.Spec.Retention.FailedLimit != nil && int(*n.Spec.Retention.FailedLimit) < int(*o.Spec.Retention.FailedLimit) {
 					return true
+					// #nosec G115, is validated in the type
 				} else if n.Spec.Retention.SucceededLimit != nil && o.Spec.Retention.SucceededLimit != nil && int(*n.Spec.Retention.SucceededLimit) < int(*o.Spec.Retention.SucceededLimit) {
 					return true
 				}


### PR DESCRIPTION
# Changes

We have new gosec findings in https://github.com/shipwright-io/build/actions/runs/10484927930/job/29040118261?pr=1668 for the new G115 rule. Interestingly, gosec has not even released that while golangci-lint already validates it.

We actually had one real though unrealistic finding for the limits that we allow users to define for number of buildruns in a build. We have a uint there and casted it to int which theoretically can fail if a user would use an unreasonably high value that goes beyond math.MaxInt. I therefore declared a reasnably high maximum in the type and nosec'ed it.

In the bundle package, the finding is imo unrealistic but suddenly Go's tar Header type uses an int64 where it should be better using maybe directly os.FileMode.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
