### PR TITLE
Add NodeSelectors to Build and BuildRun objects

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -6916,6 +6916,14 @@ spec:
                           - name
                           type: object
                         type: array
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        type: object
                       output:
                         description: Output refers to the location where the built
                           image would be pushed.
@@ -9120,6 +9128,14 @@ spec:
                   - name
                   type: object
                 type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: |-
+                  NodeSelector is a selector which must be true for the pod to fit on a node.
+                  Selector which must match a node's labels for the pod to be scheduled on that node.
+                  More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                type: object
               output:
                 description: |-
                   Output refers to the location where the generated
@@ -11161,6 +11177,14 @@ spec:
                       - name
                       type: object
                     type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is a selector which must be true for the pod to fit on a node.
+                      Selector which must match a node's labels for the pod to be scheduled on that node.
+                      More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                    type: object
                   output:
                     description: Output refers to the location where the built image
                       would be pushed.

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -2488,6 +2488,14 @@ spec:
                   - name
                   type: object
                 type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: |-
+                  NodeSelector is a selector which must be true for the pod to fit on a node.
+                  Selector which must match a node's labels for the pod to be scheduled on that node.
+                  More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                type: object
               output:
                 description: Output refers to the location where the built image would
                   be pushed.

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,19 +6,25 @@ SPDX-License-Identifier: Apache-2.0
 
 # Build
 
-- [Overview](#overview)
-- [Build Controller](#build-controller)
-- [Build Validations](#build-validations)
-- [Configuring a Build](#configuring-a-build)
-  - [Defining the Source](#defining-the-source)
-  - [Defining the Strategy](#defining-the-strategy)
-  - [Defining ParamValues](#defining-paramvalues)
-  - [Defining the Builder or Dockerfile](#defining-the-builder-or-dockerfile)
-  - [Defining the Output](#defining-the-output)
-  - [Defining Retention Parameters](#defining-retention-parameters)
-  - [Defining Volumes](#defining-volumes)
-  - [Defining Triggers](#defining-triggers)
-- [BuildRun deletion](#buildrun-deletion)
+- [Build](#build)
+  - [Overview](#overview)
+  - [Build Controller](#build-controller)
+  - [Build Validations](#build-validations)
+  - [Configuring a Build](#configuring-a-build)
+    - [Defining the Source](#defining-the-source)
+    - [Defining the Strategy](#defining-the-strategy)
+    - [Defining ParamValues](#defining-paramvalues)
+      - [Example](#example)
+    - [Defining the Builder or Dockerfile](#defining-the-builder-or-dockerfile)
+    - [Defining the Output](#defining-the-output)
+    - [Defining the vulnerabilityScan](#defining-the-vulnerabilityscan)
+    - [Defining Retention Parameters](#defining-retention-parameters)
+    - [Defining Volumes](#defining-volumes)
+    - [Defining Triggers](#defining-triggers)
+      - [GitHub](#github)
+      - [Image](#image)
+      - [Tekton Pipeline](#tekton-pipeline)
+  - [BuildRun Deletion](#buildrun-deletion)
 
 ## Overview
 
@@ -33,6 +39,7 @@ A `Build` resource allows the user to define:
 - env
 - retention
 - volumes
+- nodeSelector
 
 A `Build` is available within a namespace.
 
@@ -118,6 +125,7 @@ The `Build` definition supports the following fields:
   - `spec.retention.ttlAfterSucceeded` - Specifies the duration for which a successful buildrun can exist.
   - `spec.retention.failedLimit` - Specifies the number of failed buildrun that can exist.
   - `spec.retention.succeededLimit` - Specifies the number of successful buildrun can exist.
+  - `spec.nodeSelector` - Specifies a selector which must match a node's labels for the build pod to be scheduled on that node.
 
 ### Defining the Source
 

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -6,25 +6,28 @@ SPDX-License-Identifier: Apache-2.0
 
 # BuildRun
 
-- [Overview](#overview)
-- [BuildRun Controller](#buildrun-controller)
-- [Configuring a BuildRun](#configuring-a-buildrun)
-  - [Defining the Build Reference](#defining-the-build-reference)
-  - [Defining the Build Specification](#defining-the-build-specification)
-  - [Defining ParamValues](#defining-paramvalues)
-  - [Defining the ServiceAccount](#defining-the-serviceaccount)
-  - [Defining Retention Parameters](#defining-retention-parameters)
-  - [Defining Volumes](#defining-volumes)
-- [Canceling a `BuildRun`](#canceling-a-buildrun)
-- [Automatic `BuildRun` deletion](#automatic-buildrun-deletion)
-- [Specifying Environment Variables](#specifying-environment-variables)
-- [BuildRun Status](#buildrun-status)
-  - [Understanding the state of a BuildRun](#understanding-the-state-of-a-buildrun)
-  - [Understanding failed BuildRuns](#understanding-failed-buildruns)
-    - [Understanding failed git-source step](#understanding-failed-git-source-step)
-  - [Step Results in BuildRun Status](#step-results-in-buildrun-status)
-  - [Build Snapshot](#build-snapshot)
-- [Relationship with Tekton Tasks](#relationship-with-tekton-tasks)
+- [BuildRun](#buildrun)
+  - [Overview](#overview)
+  - [BuildRun Controller](#buildrun-controller)
+  - [Configuring a BuildRun](#configuring-a-buildrun)
+    - [Defining the Build Reference](#defining-the-build-reference)
+    - [Defining the Build Specification](#defining-the-build-specification)
+    - [Defining the Build Source](#defining-the-build-source)
+    - [Defining ParamValues](#defining-paramvalues)
+    - [Defining the ServiceAccount](#defining-the-serviceaccount)
+    - [Defining Retention Parameters](#defining-retention-parameters)
+    - [Defining Volumes](#defining-volumes)
+  - [Canceling a `BuildRun`](#canceling-a-buildrun)
+  - [Automatic `BuildRun` deletion](#automatic-buildrun-deletion)
+  - [Specifying Environment Variables](#specifying-environment-variables)
+  - [BuildRun Status](#buildrun-status)
+    - [Understanding the state of a BuildRun](#understanding-the-state-of-a-buildrun)
+    - [Understanding failed BuildRuns](#understanding-failed-buildruns)
+    - [Understanding failed BuildRuns due to VulnerabilitiesFound](#understanding-failed-buildruns-due-to-vulnerabilitiesfound)
+      - [Understanding failed git-source step](#understanding-failed-git-source-step)
+    - [Step Results in BuildRun Status](#step-results-in-buildrun-status)
+    - [Build Snapshot](#build-snapshot)
+  - [Relationship with Tekton Tasks](#relationship-with-tekton-tasks)
 
 ## Overview
 
@@ -72,6 +75,7 @@ The `BuildRun` definition supports the following fields:
   - `spec.output.timestamp` - Overrides the output timestamp configuration of the referenced build to instruct the build to change the output image creation timestamp to the specified value. When omitted, the respective build strategy tool defines the output image timestamp.
   - `spec.output.vulnerabilityScan` - Overrides the output vulnerabilityScan configuration of the referenced build to run the vulnerability scan for the generated image.
   - `spec.env` - Specifies additional environment variables that should be passed to the build container. Overrides any environment variables that are specified in the `Build` resource. The available variables depend on the tool used by the chosen build strategy.
+  - `spec.nodeSelector` - Specifies a selector which must match a node's labels for the build pod to be scheduled on that node.
 
 **Note**: The `spec.build.name` and `spec.build.spec` are mutually exclusive. Furthermore, the overrides for `timeout`, `paramValues`, `output`, and `env` can only be combined with `spec.build.name`, but **not** with `spec.build.spec`.
 

--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -76,6 +76,8 @@ const (
 	OutputTimestampNotSupported BuildReason = "OutputTimestampNotSupported"
 	// OutputTimestampNotValid indicates that the output timestamp value is not valid
 	OutputTimestampNotValid BuildReason = "OutputTimestampNotValid"
+	// NodeSelectorNotValid indicates that the nodeSelector value is not valid
+	NodeSelectorNotValid BuildReason = "NodeSelectorNotValid"
 
 	// AllValidationsSucceeded indicates a Build was successfully validated
 	AllValidationsSucceeded = "all validations succeeded"
@@ -174,6 +176,13 @@ type BuildSpec struct {
 	//
 	// +optional
 	Volumes []BuildVolume `json:"volumes,omitempty"`
+
+	// NodeSelector is a selector which must be true for the pod to fit on a node.
+	// Selector which must match a node's labels for the pod to be scheduled on that node.
+	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+	//
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // BuildVolume is a volume that will be mounted in build pod during build step

--- a/pkg/apis/build/v1beta1/buildrun_types.go
+++ b/pkg/apis/build/v1beta1/buildrun_types.go
@@ -108,6 +108,13 @@ type BuildRunSpec struct {
 	// to be overridden. Must only contain volumes that exist in the corresponding BuildStrategy
 	// +optional
 	Volumes []BuildVolume `json:"volumes,omitempty"`
+
+	// NodeSelector is a selector which must be true for the pod to fit on a node.
+	// Selector which must match a node's labels for the pod to be scheduled on that node.
+	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+	//
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // BuildRunRequestedState defines the buildrun state the user can provide to override whatever is the current state.

--- a/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/build/v1beta1/zz_generated.deepcopy.go
@@ -280,6 +280,13 @@ func (in *BuildRunSpec) DeepCopyInto(out *BuildRunSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -393,6 +400,13 @@ func (in *BuildSpec) DeepCopyInto(out *BuildSpec) {
 		*out = make([]BuildVolume, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	return

--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -33,6 +33,7 @@ var validationTypes = [...]string{
 	validate.BuildName,
 	validate.Envs,
 	validate.Triggers,
+	validate.NodeSelector,
 }
 
 // ReconcileBuild reconciles a Build object

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -160,6 +160,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 						validate.NewSourceRef(build),
 						validate.NewBuildName(build),
 						validate.NewEnv(build),
+						validate.NewNodeSelector(build),
 					)
 
 					// an internal/technical error during validation happened

--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -1631,5 +1631,19 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
 			})
 		})
+
+		Context("when nodeSelector is specified", func() {
+			It("fails when the nodeSelector is invalid", func() {
+				// set nodeSelector to be invalid
+				buildSample.Spec.NodeSelector = map[string]string{strings.Repeat("s", 64): "amd64"}
+
+				statusCall := ctl.StubFunc(corev1.ConditionFalse, build.NodeSelectorNotValid, "must be no more than 63 characters")
+				statusWriter.UpdateCalls(statusCall)
+
+				_, err := reconciler.Reconcile(context.TODO(), buildRunRequest)
+				Expect(err).To(BeNil())
+				Expect(statusWriter.UpdateCallCount()).To(Equal(1))
+			})
+		})
 	})
 })

--- a/pkg/reconciler/buildrun/resources/taskrun.go
+++ b/pkg/reconciler/buildrun/resources/taskrun.go
@@ -18,6 +18,7 @@ import (
 	"github.com/shipwright-io/build/pkg/env"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources/steps"
 	"github.com/shipwright-io/build/pkg/volumes"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
@@ -232,6 +233,14 @@ func GenerateTaskRun(
 				},
 			},
 		},
+	}
+
+	// Merge Build and BuildRun NodeSelectors, giving preference to BuildRun NodeSelector
+	taskRunNodeSelector := mergeMaps(build.Spec.NodeSelector, buildRun.Spec.NodeSelector)
+	if len(taskRunNodeSelector) > 0 {
+		expectedTaskRun.Spec.PodTemplate = &pod.PodTemplate{
+			NodeSelector: taskRunNodeSelector,
+		}
 	}
 
 	// assign the annotations from the build strategy, filter out those that should not be propagated

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -632,5 +632,27 @@ var _ = Describe("GenerateTaskrun", func() {
 				Expect(paramOutputImageFound).To(BeTrue())
 			})
 		})
+
+		Context("when the build and buildrun both specify a nodeSelector", func() {
+			BeforeEach(func() {
+				build, err = ctl.LoadBuildYAML([]byte(test.MinimalBuildRunWithNodeSelector))
+				Expect(err).To(BeNil())
+
+				buildRun, err = ctl.LoadBuildRunFromBytes([]byte(test.MinimalBuildRunWithNodeSelector))
+				Expect(err).To(BeNil())
+
+				buildStrategy, err = ctl.LoadBuildStrategyFromBytes([]byte(test.ClusterBuildStrategyNoOp))
+				Expect(err).To(BeNil())
+			})
+
+			JustBeforeEach(func() {
+				got, err = resources.GenerateTaskRun(config.NewDefaultConfig(), build, buildRun, serviceAccountName, buildStrategy)
+				Expect(err).To(BeNil())
+			})
+
+			It("should give precedence to the nodeSelector specified in the buildRun", func() {
+				Expect(got.Spec.PodTemplate.NodeSelector).To(Equal(buildRun.Spec.NodeSelector))
+			})
+		})
 	})
 })

--- a/pkg/validate/nodeselector.go
+++ b/pkg/validate/nodeselector.go
@@ -1,0 +1,42 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/ptr"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+)
+
+// NodeSelectorRef contains all required fields
+// to validate a node selector
+type NodeSelectorRef struct {
+	Build *build.Build // build instance for analysis
+}
+
+func NewNodeSelector(build *build.Build) *NodeSelectorRef {
+	return &NodeSelectorRef{build}
+}
+
+// ValidatePath implements BuildPath interface and validates
+// that NodeSelector keys/values are valid labels
+func (b *NodeSelectorRef) ValidatePath(_ context.Context) error {
+	for key, value := range b.Build.Spec.NodeSelector {
+		if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+			b.Build.Status.Reason = ptr.To(build.NodeSelectorNotValid)
+			b.Build.Status.Message = ptr.To(strings.Join(errs, ", "))
+		}
+		if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+			b.Build.Status.Reason = ptr.To(build.NodeSelectorNotValid)
+			b.Build.Status.Message = ptr.To(strings.Join(errs, ", "))
+		}
+	}
+
+	return nil
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -35,6 +35,8 @@ const (
 	OwnerReferences = "ownerreferences"
 	// Triggers for validating the `.spec.triggers` entries
 	Triggers = "triggers"
+	// NodeSelector for validating `spec.nodeSelector` entry
+	NodeSelector = "nodeselector"
 )
 
 const (
@@ -75,6 +77,8 @@ func NewValidation(
 		return &Env{Build: build}, nil
 	case Triggers:
 		return &Trigger{build: build}, nil
+	case NodeSelector:
+		return &NodeSelectorRef{Build: build}, nil
 	default:
 		return nil, fmt.Errorf("unknown validation type")
 	}

--- a/test/v1beta1_samples/build_samples.go
+++ b/test/v1beta1_samples/build_samples.go
@@ -51,6 +51,25 @@ spec:
     value: Dockerfile
 `
 
+// MinimalBuildahBuildWithNodeSelector defines a simple
+// Build with a source, strategy, and nodeSelector
+const MinimalBuildahBuildWithNodeSelector = `
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildah
+spec:
+  source:
+    type: Git
+    git:
+      url: "https://github.com/shipwright-io/sample-go"
+  strategy:
+    name: buildah
+    kind: ClusterBuildStrategy
+  nodeSelector:
+    kubernetes.io/arch: amd64
+`
+
 // BuildahBuildWithOutput defines a simple
 // Build with a source, strategy and output
 const BuildahBuildWithOutput = `
@@ -520,8 +539,8 @@ spec:
     image: image-registry.openshift-image-registry.svc:5000/example/buildpacks-app
 `
 
-// BuildWithRestrictedParam defines a Build using params that are reserved only
-// for shipwright
+// MinimalBuild defines a simple
+// Build with a strategy output
 const MinimalBuild = `
 apiVersion: shipwright.io/v1beta1
 kind: Build
@@ -530,6 +549,20 @@ spec:
     kind: ClusterBuildStrategy
   output:
     image: image-registry.openshift-image-registry.svc:5000/example/buildpacks-app
+`
+
+// MinimalBuildWithNodeSelector defines a simple
+// Build with a strategy, output, and NodeSelector
+const MinimalBuildWithNodeSelector = `
+apiVersion: shipwright.io/v1beta1
+kind: Build
+spec:
+  strategy:
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/example/buildpacks-app
+  nodeSelector:
+    kubernetes.io/arch: amd64
 `
 
 // BuildWithUndefinedParameter defines a param that was not declared under the

--- a/test/v1beta1_samples/buildrun_samples.go
+++ b/test/v1beta1_samples/buildrun_samples.go
@@ -56,6 +56,20 @@ spec:
     name: buildah
 `
 
+// MinimalBuildahBuildRunWithNodeSelector defines a simple
+// BuildRun with a referenced Build and nodeSelector
+const MinimalBuildahBuildRunWithNodeSelector = `
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+metadata:
+  name: buildah-run
+spec:
+  build:
+    name: buildah
+  nodeSelector:
+    kubernetes.io/arch: amd64
+`
+
 // BuildahBuildRunWithSA defines a BuildRun
 // with a service-account
 const BuildahBuildRunWithSA = `
@@ -211,6 +225,19 @@ spec:
     image: foobar.registry.com
   build:
     name: foobar
+`
+
+// MinimalBuildRunWithNodeSelector defines a minimal BuildRun
+// with a reference to a not existing Build,
+// and a nodeSelector
+const MinimalBuildRunWithNodeSelector = `
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+spec:
+  build:
+    name: foobar
+  nodeSelector:
+    kubernetes.io/arch: amd64
 `
 
 // MinimalBuildRunWithVulnerabilityScan defines a BuildRun with


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Allows NodeSelector to be set on Build and BuildRun objects. 

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

Fixes #1635 

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Added NodeSelector on Build and BuildRun objects, which enables specifying the scheduling behavior of TaskRuns.
```
