### PR TITLE
Fix broken submodule unit test

### DIFF
--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -410,7 +410,7 @@ var _ = Describe("Git Resource", func() {
 	})
 
 	Context("cloning repositories with submodules", func() {
-		const exampleRepo = "https://github.com/shipwright-io/website"
+		const exampleRepo = "https://github.com/shipwright-io/sample-submodule"
 
 		It("should Git clone a repository with a submodule", func() {
 			withTempDir(func(target string) {
@@ -420,7 +420,7 @@ var _ = Describe("Git Resource", func() {
 				))).ToNot(HaveOccurred())
 
 				Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
-				Expect(filepath.Join(target, "themes", "docsy", "README.md")).To(BeAnExistingFile())
+				Expect(filepath.Join(target, "src", "sample-go", "README.md")).To(BeAnExistingFile())
 			})
 		})
 	})


### PR DESCRIPTION
# Changes

Replace website as the example repository, since it changed and its structure doesn't work for the unit test anymore. Switch to purely synthetic sample.

/kind bug

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
