### PR TITLE
Configure commit author, signing and signoff in GitHub action for image updates

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -32,7 +32,17 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
+          # Branch details:
+          branch: ${{ matrix.image }}
+          delete-branch: true
+
+          # Commit details
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: Bump ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}
+          sign-commits: true
+          signoff: true
+
+          # PR details
           title: Bump ${{ matrix.image }} from ${{ steps.image-diff.outputs.FROM }} to ${{ steps.image-diff.outputs.TO }}
           body: |
             # Changes
@@ -51,5 +61,3 @@ jobs:
             NONE
             ```
           labels: kind/dependency-change
-          branch: ${{ matrix.image }}
-          delete-branch: true


### PR DESCRIPTION
# Changes

The GitHub action we are using to create a pull request is distinguishing author and committer of the commit it creates. See https://github.com/peter-evans/create-pull-request/tree/v7/?tab=readme-ov-file#action-inputs

In https://github.com/shipwright-io/build/pull/1692, the author is somehow the openshift-merge-robot.

Based on the action documentation, the author is taken from github.actor.

Based on https://github.com/orgs/community/discussions/25067, github.actor for a workflow run triggered by a schedule is the latest user that modified the schedule trigger. In our case that is the openshift-merge-robot because it merges our PRs including the PR that introduced or modified the GitHub action.

I am hereby changing the action configuration to use the GitHub Actions Bot also as author.

In addition, I am enabling commit signing and the sign-off in the commit message so that DCO can pass.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
