### PR TITLE
Fix issue with non-writable sub-directories

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -231,12 +231,34 @@ func Pack(directory string) (io.ReadCloser, error) {
 // Unpack reads a tar stream and writes the content into the local file system
 // with all files and directories.
 func Unpack(in io.Reader, targetPath string) (*UnpackDetails, error) {
+	type chmod struct {
+		name string
+		mode os.FileMode
+	}
+
+	// Make sure the target path exists and is a directory
+	if stat, err := os.Stat(targetPath); err != nil {
+		if err := os.MkdirAll(targetPath, os.FileMode(0755)); err != nil {
+			return nil, err
+		}
+	} else if !stat.IsDir() {
+		return nil, fmt.Errorf("target %q exists, but it's not a directory", targetPath)
+	}
+
+	var chmods []chmod
 	var details = UnpackDetails{}
 	var tr = tar.NewReader(in)
 	for {
 		header, err := tr.Next()
 		switch {
 		case err == io.EOF:
+			// before leaving, make sure to set the file permissions to the ones specified in the tar stream
+			for _, chmod := range chmods {
+				if err := os.Chmod(chmod.name, chmod.mode); err != nil {
+					return nil, err
+				}
+			}
+
 			return &details, nil
 
 		case err != nil:
@@ -253,9 +275,16 @@ func Unpack(in io.Reader, targetPath string) (*UnpackDetails, error) {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(target, fileMode(header)); err != nil {
+			// Skip the root directory, since it already exists
+			if target == targetPath {
+				continue
+			}
+
+			if err := os.MkdirAll(target, os.FileMode(0777)); err != nil {
 				return nil, err
 			}
+
+			chmods = append(chmods, chmod{name: target, mode: fileMode(header)})
 
 		case tar.TypeReg:
 			// Edge case in which that tarball did not have a directory entry


### PR DESCRIPTION
# Changes

There are file system setups where there is a file in a directory, but the directory does not have the write bit set (anymore). This kind of setup is perfect fine, however, the bundle logic is unable to unpack it.

Fix unpack logic so that it is not setting the file permissions of directories in the moment it creates the directory, but later when all other files are unpacked already and no more write operations are required.

/kind bug

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixed an issue when unpacking a code bundle that contains a non-writable sub-directory.
```
