### PR TITLE
Retry trivy when it fails to download the vulnerability database due to rate-limiting

### DIFF
--- a/pkg/image/vulnerability_scan.go
+++ b/pkg/image/vulnerability_scan.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
@@ -51,14 +52,33 @@ func RunVulnerabilityScan(ctx context.Context, imagePath string, settings builda
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "trivy", trivyArgs...)
+	var result []byte
+	var err error
 
-	cmd.Stdin = nil
+	for i := 0; i < 10; i++ {
+		cmd := exec.CommandContext(ctx, "trivy", trivyArgs...)
+		cmd.Stdin = nil
 
-	result, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("failed to run trivy:\n%s", string(result))
-		return nil, fmt.Errorf("failed to run trivy: %w", err)
+		result, err = cmd.CombinedOutput()
+		if err == nil {
+			break
+		}
+
+		sResult := string(result)
+		log.Printf("failed to run trivy:\n%s", sResult)
+
+		// Retry the following errors
+		//
+		// FATAL    Fatal error    init error: DB error: failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
+		//  GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 508.904┬Ás, allowed: 44000/minute
+		//
+		// FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from any source
+		if i < 10 && strings.Contains(sResult, "failed to download vulnerability DB") {
+			log.Println("Will retry")
+			time.Sleep(time.Second)
+		} else {
+			return nil, fmt.Errorf("failed to run trivy: %w", err)
+		}
 	}
 
 	var trivyResult TrivyResult


### PR DESCRIPTION
# Changes

Part of https://github.com/shipwright-io/build/issues/1689

This changes the image processing step to perform a simple retry in case of Trivy failures due to rate limiting.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The image-processing step now retries the vulnerability scan using Trivy if that failed to download the vulnerability database due to rate-limiting
```
