### PR TITLE
Use `--vv` and `--trace` in E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ TEST_NAMESPACE ?= default
 TEKTON_VERSION ?= v0.65.0
 
 # E2E test flags
-TEST_E2E_FLAGS ?= -r -p --randomize-all -timeout=1h -trace -v
+TEST_E2E_FLAGS ?= -r -p --randomize-all --timeout=1h --trace --vv
 
 # E2E test service account name to be used for the build runs, can be set to generated to use the generated service account feature
 TEST_E2E_SERVICEACCOUNT_NAME ?= pipeline


### PR DESCRIPTION
# Changes

Based on the documentation, increase verbosity to improve the ability to debug issues based on the Ginkgo output:

```
  --vv
    If set, emits with maximal verbosity - includes skipped and pending tests.

  --trace
    If set, default reporter prints out the full stack trace when a failure
    occurs
```

This should help us to address the panic in the AfterEach for example here that blocks us to determine why the test case actually faliled:

```
2024-10-30T12:09:48Z 1 Still waiting for build run 'timestamp-lm5jx' to succeed.
  2024-10-30T12:10:48Z 1 Still waiting for build run 'timestamp-lm5jx' to succeed.
  [FAILED] in [It] - /home/runner/work/build/build/test/e2e/v1beta1/validators_test.go:134 @ 10/30/24 12:11:08.558
  2024-10-30T12:11:08Z 1 Print failed BuildRun's log
  [PANICKED] in [AfterEach] - /opt/hostedtoolcache/go/1.22.8/x64/src/runtime/panic.go:261 @ 10/30/24 12:11:08.561
  << Timeline

  [FAILED] BuildRun status doesn't move to Succeeded
  Expected
      <v1.ConditionStatus>: False
  not to equal
      <v1.ConditionStatus>: False
  In [It] at: /home/runner/work/build/build/test/e2e/v1beta1/validators_test.go:134 @ 10/30/24 12:11:08.558

  Full Stack Trace
    github.com/shipwright-io/build/test/e2e/v1beta1_test.validateBuildRunToSucceed.func1()
    	/home/runner/work/build/build/test/e2e/v1beta1/validators_test.go:134 +0x3d5
    reflect.Value.call({0x1c3d0e0?, 0xc0008e8150?, 0xc00006dbf8?}, {0x20037cc, 0x4}, {0x35254a0, 0x0, 0xc00006dc4a?})
    	/opt/hostedtoolcache/go/1.22.8/x64/src/reflect/value.go:596 +0xca6
    reflect.Value.Call({0x1c3d0e0?, 0xc0008e8150?, 0x20?}, {0x35254a0?, 0x1?, 0x3?})
    	/opt/hostedtoolcache/go/1.22.8/x64/src/reflect/value.go:380 +0xb9
    github.com/onsi/gomega/internal.(*AsyncAssertion).buildActualPoller.func3()
    	/home/runner/work/build/build/vendor/github.com/onsi/gomega/internal/async_assertion.go:325 +0x11f
    github.com/onsi/gomega/internal.(*AsyncAssertion).match(0xc00039ab60, {0x234ba60, 0xc0009a5cb0}, 0x1, {0xc0009a5cc0, 0x1, 0x1})
    	/home/runner/work/build/build/vendor/github.com/onsi/gomega/internal/async_assertion.go:548 +0x7cc
    github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0xc00039ab60, {0x234ba60, 0xc0009a5cb0}, {0xc0009a5cc0, 0x1, 0x1})
    	/home/runner/work/build/build/vendor/github.com/onsi/gomega/internal/async_assertion.go:145 +0x86
    github.com/shipwright-io/build/test/e2e/v1beta1_test.validateBuildRunToSucceed(0xc0002d8af0, 0xc0000f5000)
    	/home/runner/work/build/build/test/e2e/v1beta1/validators_test.go:144 +0x342
    github.com/shipwright-io/build/test/e2e/v1beta1_test.init.func1.6.4.4()
    	/home/runner/work/build/build/test/e2e/v1beta1/e2e_image_mutate_test.go:202 +0x47

  There were additional failures detected.  To view them in detail run ginkgo -vv
```

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
