### PR TITLE
Set Build to empty object because GetBuildObject will fill but not initialize it

### DIFF
--- a/test/e2e/v1beta1/common_test.go
+++ b/test/e2e/v1beta1/common_test.go
@@ -136,14 +136,13 @@ func amendBuild(identifier string, b *buildv1beta1.Build) {
 
 // retrieveBuildAndBuildRun will retrieve the build and buildRun
 func retrieveBuildAndBuildRun(testBuild *utils.TestBuild, namespace string, buildRunName string) (*buildv1beta1.Build, *buildv1beta1.BuildRun, error) {
-	var build *buildv1beta1.Build
-
 	buildrun, err := testBuild.LookupBuildRun(types.NamespacedName{Name: buildRunName, Namespace: namespace})
 	if err != nil {
 		Logf("Failed to get BuildRun %q: %s", buildRunName, err)
 		return nil, nil, err
 	}
 
+	build := &buildv1beta1.Build{}
 	if err := resources.GetBuildObject(testBuild.Context, testBuild.ControllerRuntimeClient, buildrun, build); err != nil {
 		Logf("Failed to get Build from BuildRun %s: %s", buildRunName, err)
 		return nil, buildrun, err


### PR DESCRIPTION
# Changes

This fixes the following panic we see in `AfterEach` hooks of the e2e tests that actually prevent us to identify the root cause.

```
[PANICKED] Test Panicked
  In [AfterEach] at: /opt/hostedtoolcache/go/1.22.8/x64/src/runtime/panic.go:261 @ 10/30/24 14:53:26.63

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/shipwright-io/build/pkg/reconciler/buildrun/resources.GetBuildObject({0x2358398?, 0xc00076aaa0?}, {0x2368620?, 0xc00076d5f0?}, 0xedeb43f66?, 0x0?)
    	/home/runner/work/build/build/pkg/reconciler/buildrun/resources/build.go:39 +0x28b
    github.com/shipwright-io/build/test/e2e/v1beta1_test.retrieveBuildAndBuildRun(0xc000102b60, {0xc00005c1d7?, 0x0?}, {0xc000429e75, 0xb})
    	/home/runner/work/build/build/test/e2e/v1beta1/common_test.go:147 +0x105
```

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
