### PR TITLE
Update minimum Tekton LTS to v0.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           - v1.31.0
         tekton:
           # oldest LTS that exists at the time of our planned next release
-          - v0.53.5
+          - v0.56.8
           # newest LTS that exists at the time of our planned next release
           - v0.65.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
@@ -147,7 +147,7 @@ jobs:
           - v1.31.0
         tekton:
           # oldest LTS that exists at the time of our planned next release
-          - v0.53.5
+          - v0.56.8
           # newest LTS that exists at the time of our planned next release
           - v0.65.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 | Dependency                           | Supported versions           |
 |--------------------------------------|------------------------------|
 | [Kubernetes](https://kubernetes.io/) | v1.27.\*, v1.28.\*, v1.29.\* |
-| [Tekton](https://tekton.dev)         | v0.50.\*, v0.53.\*, v0.56.\* |
+| [Tekton](https://tekton.dev)         | v0.56.\*, v0.59.\*, v0.62.\*, v0.65.\* |
 
 ### Platform support
 


### PR DESCRIPTION
# Changes

See https://github.com/tektoncd/pipeline/blob/main/releases.md

Tekton v0.53 has an end of support in 10/2024. I am therefore changing the minimum required Tekton version to v0.56.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The new minimum Tekton version is v0.56
```
