### PR TITLE
Bump Kind from v0.22.0 to v0.24.0

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -927,7 +927,7 @@ If we apply the following resources:
 
   ```yaml
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -949,7 +949,7 @@ If we apply the following resources:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         privileged: true
       command:

--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -13,11 +13,12 @@ set -eu
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 # kind version
-KIND_VERSION="${KIND_VERSION:-v0.22.0}"
+KIND_VERSION="${KIND_VERSION:-v0.24.0}"
 
 if ! hash kind > /dev/null 2>&1 ; then
     echo "# Installing KinD..."
     go install "sigs.k8s.io/kind@${KIND_VERSION}"
+    export PATH=$PATH:$(go env GOPATH)/bin
 fi
 
 # print kind version

--- a/hack/install-kind.sh
+++ b/hack/install-kind.sh
@@ -18,7 +18,8 @@ KIND_VERSION="${KIND_VERSION:-v0.24.0}"
 if ! hash kind > /dev/null 2>&1 ; then
     echo "# Installing KinD..."
     go install "sigs.k8s.io/kind@${KIND_VERSION}"
-    export PATH=$PATH:$(go env GOPATH)/bin
+    readonly PATH_TO_KIND="$(go env GOPATH)/bin"
+    export PATH="$PATH:$PATH_TO_KIND"
 fi
 
 # print kind version

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -98,7 +98,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			It("should ensure IMAGE is replaced by builder image when needed.", func() {
-				Expect(got.Steps[1].Image).To(Equal("quay.io/containers/buildah:v1.37.3"))
+				Expect(got.Steps[1].Image).To(Equal("quay.io/containers/buildah:v1.37.5"))
 			})
 
 			It("should ensure ImagePullPolicy can be set by the build strategy author.", func() {

--- a/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:

--- a/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:

--- a/samples/v1alpha1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -21,7 +21,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       imagePullPolicy: Always
       workingDir: /s2i
       securityContext:

--- a/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   steps:
     - name: build
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:

--- a/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   steps:
     - name: build-and-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:

--- a/samples/v1beta1/buildstrategy/multiarch-native-buildah/buildstrategy_multiarch_native_buildah_cr.yaml
+++ b/samples/v1beta1/buildstrategy/multiarch-native-buildah/buildstrategy_multiarch_native_buildah_cr.yaml
@@ -194,7 +194,7 @@ spec:
                 restartPolicy: Never
                 containers:
                   - name: build
-                    image: quay.io/containers/buildah:v1.37.3
+                    image: quay.io/containers/buildah:v1.37.5
                     volumeMounts:
                       - mountPath: /var/workdir
                         name: workdir
@@ -412,7 +412,7 @@ spec:
         - --architectures
         - $(params.architectures[*])
     - name: package-manifest-list-and-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         privileged: true
       workingDir: /var/oci-archive-storage

--- a/samples/v1beta1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
+++ b/samples/v1beta1/buildstrategy/source-to-image/buildstrategy_source-to-image-redhat_cr.yaml
@@ -23,7 +23,7 @@ spec:
         - name: s2i
           mountPath: /s2i
     - name: buildah
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       imagePullPolicy: Always
       workingDir: /s2i
       securityContext:

--- a/test/v1alpha1_samples/buildstrategy_samples.go
+++ b/test/v1alpha1_samples/buildstrategy_samples.go
@@ -18,7 +18,7 @@ spec:
       emptyDir: {}
   buildSteps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:
@@ -41,7 +41,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         capabilities:
           add: ["SETFCAP"]
@@ -83,7 +83,7 @@ spec:
       default: "vfs"
   buildSteps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:
@@ -114,7 +114,7 @@ spec:
             fieldRef:
               fieldPath: "my-fieldpath"
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         capabilities:
           add: ["SETFCAP"]

--- a/test/v1alpha1_samples/clusterbuildstrategy_samples.go
+++ b/test/v1alpha1_samples/clusterbuildstrategy_samples.go
@@ -24,7 +24,7 @@ spec:
       default: "vfs"
   buildSteps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:
@@ -48,7 +48,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         capabilities:
           add: ["SETFCAP"]
@@ -91,7 +91,7 @@ spec:
       default: "vfs"
   buildSteps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:
@@ -115,7 +115,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         capabilities:
           add: ["SETFCAP"]

--- a/test/v1beta1_samples/buildstrategy_samples.go
+++ b/test/v1beta1_samples/buildstrategy_samples.go
@@ -18,7 +18,7 @@ spec:
       emptyDir: {}
   steps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -40,7 +40,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         privileged: true
       command:
@@ -81,7 +81,7 @@ spec:
       emptyDir: {}
   steps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -110,7 +110,7 @@ spec:
             fieldRef:
               fieldPath: "my-fieldpath"
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         privileged: true
       command:

--- a/test/v1beta1_samples/clusterbuildstrategy_samples.go
+++ b/test/v1beta1_samples/clusterbuildstrategy_samples.go
@@ -19,7 +19,7 @@ spec:
         emptyDir: {}
   steps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -41,7 +41,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         privileged: true
       command:
@@ -77,7 +77,7 @@ spec:
         emptyDir: {}
   steps:
     - name: buildah-bud
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
@@ -99,7 +99,7 @@ spec:
         - name: buildah-images
           mountPath: /var/lib/containers/storage
     - name: buildah-push
-      image: quay.io/containers/buildah:v1.37.3
+      image: quay.io/containers/buildah:v1.37.5
       securityContext:
         privileged: true
       command:


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Bumps Kind from v0.22.0 to v0.24.0
Added the kind installation directory to the $PATH to fix `kind: command not found` error after installation.
<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
