### PR TITLE
Install crane binary

### DIFF
--- a/.github/workflows/report-release-vulnerabilities.yaml
+++ b/.github/workflows/report-release-vulnerabilities.yaml
@@ -18,6 +18,8 @@ jobs:
           go-version: '1.22.x'
           cache: true
           check-latest: true
+      - name: Install crane
+        run: curl --location --silent "https://github.com/google/go-containerregistry/releases/download/$(curl -s https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r '.tag_name')/go-containerregistry_$(uname -s)_$(uname -m | sed -e 's/aarch64/arm64/').tar.gz" | sudo tar -xzf - -C /usr/local/bin crane
       - name: Install Retry
         run: curl --silent --location https://raw.githubusercontent.com/homeport/retry/main/hack/download.sh | bash
       - name: Install Trivy


### PR DESCRIPTION
# Changes

The new action to check for vulnerabilities was failing due to the unavailability of the `crane` command. https://github.com/shipwright-io/build/actions/runs/11655851486/job/32451121704

Adding it (and irritated why it succeeded in my fork).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
