### PR TITLE
Fix nil pointer access in AfterEach of failed e2e test cases

### DIFF
--- a/test/e2e/v1alpha1/common_test.go
+++ b/test/e2e/v1alpha1/common_test.go
@@ -165,7 +165,15 @@ func printTestFailureDebugInfo(testBuild *utils.TestBuild, namespace string, bui
 	}
 
 	if build != nil {
-		Logf("The status of Build %s: registered=%s, reason=%s", build.Name, *build.Status.Registered, *build.Status.Reason)
+		registered := "nil"
+		if build.Status.Registered != nil {
+			registered = string(*build.Status.Registered)
+		}
+		reason := "nil"
+		if build.Status.Reason != nil {
+			reason = string(*build.Status.Reason)
+		}
+		Logf("The status of Build %s: registered=%s, reason=%s", build.Name, registered, reason)
 		if buildJSON, err := json.Marshal(build); err == nil {
 			Logf("The full Build: %s", string(buildJSON))
 		}
@@ -255,7 +263,7 @@ func printTestFailureDebugInfo(testBuild *utils.TestBuild, namespace string, bui
 func GetBuildObject(ctx context.Context, client client.Client, buildRun *buildv1alpha1.BuildRun, build *buildv1alpha1.Build) error {
 	// Option #1: BuildRef is specified
 	// An actual Build resource is specified by name and needs to be looked up in the cluster.
-	if buildRun.Spec.BuildRef.Name != "" {
+	if buildRun.Spec.BuildRef != nil && buildRun.Spec.BuildRef.Name != "" {
 		err := client.Get(ctx, types.NamespacedName{Name: buildRun.Spec.BuildName(), Namespace: buildRun.Namespace}, build)
 		if apierrors.IsNotFound(err) {
 			// stop reconciling and mark the BuildRun as Failed

--- a/test/e2e/v1beta1/common_test.go
+++ b/test/e2e/v1beta1/common_test.go
@@ -161,7 +161,15 @@ func printTestFailureDebugInfo(testBuild *utils.TestBuild, namespace string, bui
 	}
 
 	if build != nil {
-		Logf("The status of Build %s: registered=%s, reason=%s", build.Name, *build.Status.Registered, *build.Status.Reason)
+		registered := "nil"
+		if build.Status.Registered != nil {
+			registered = string(*build.Status.Registered)
+		}
+		reason := "nil"
+		if build.Status.Reason != nil {
+			reason = string(*build.Status.Reason)
+		}
+		Logf("The status of Build %s: registered=%s, reason=%s", build.Name, registered, reason)
 		if buildJSON, err := json.Marshal(build); err == nil {
 			Logf("The full Build: %s", string(buildJSON))
 		}


### PR DESCRIPTION
# Changes

Fixing the following panic in e2e AfterEach:

```
  [PANICKED] Test Panicked
  In [AfterEach] at: /opt/hostedtoolcache/go/1.22.8/x64/src/runtime/panic.go:261 @ 11/04/24 10:12:22.241

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/shipwright-io/build/test/e2e/v1alpha1_test.GetBuildObject({0x23570d8?, 0xc000598410?}, {0x2367360?, 0xc0001573b0?}, 0xe31de5d?, 0xedeba9506?)
    	/home/runner/work/build/build/test/e2e/v1alpha1/common_test.go:258 +0x41
    github.com/shipwright-io/build/test/e2e/v1alpha1_test.retrieveBuildAndBuildRun(0xc00027e3f0, {0xc00005c1bf?, 0x0?}, {0xc000940960, 0xf})
    	/home/runner/work/build/build/test/e2e/v1alpha1/common_test.go:150 +0x11a
    github.com/shipwright-io/build/test/e2e/v1alpha1_test.printTestFailureDebugInfo(0xc00027e3f0, {0xc00005c1bf, 0x7}, {0xc000940960, 0xf})
    	/home/runner/work/build/build/test/e2e/v1alpha1/common_test.go:162 +0x8a
    github.com/shipwright-io/build/test/e2e/v1alpha1_test.init.func2.4()
    	/home/runner/work/build/build/test/e2e/v1alpha1/e2e_image_mutate_test.go:53 +0xd2
```

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
