### PR TITLE
Use specific tag for BuildKit

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -428,7 +428,7 @@ spec:
   steps:
     ...
     - name: build-and-push
-      image: moby/buildkit:nightly-rootless
+      image: moby/buildkit:v0.17.0-rootless
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       ...

--- a/samples/v1alpha1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -29,7 +29,7 @@ spec:
     defaults: []
   buildSteps:
     - name: build-and-push
-      image: moby/buildkit:nightly-rootless
+      image: moby/buildkit:v0.17.0-rootless
       imagePullPolicy: Always
       securityContext:
         allowPrivilegeEscalation: true

--- a/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -33,7 +33,7 @@ spec:
     default: "Dockerfile"
   steps:
     - name: build-and-push
-      image: moby/buildkit:nightly-rootless
+      image: moby/buildkit:v0.17.0-rootless
       imagePullPolicy: Always
       securityContext:
         allowPrivilegeEscalation: true


### PR DESCRIPTION
# Changes

In our sample build strategies for BuildKit, we never used a specific version as tag. Instead, we used nightly which is the main branch. This finally broke us as our e2e are failing:

```
  #9 ERROR: process "/bin/sh -c pwd &&     ls -l &&     npm install &&     npm run print-http-server-version" did not complete successfully: buildkit-runc did not terminate successfully: exit status 1: unable to destroy container: unable to remove container's cgroup: open /sys/fs/cgroup/5aqt7rzovvis0vrkm6iuwynpu: no such file or directory
```

I am hereby changing the strategy to use the images of the latest BuildKit release instead. This is inline with everything comparable that we have (kaniko, buildah).

[A separate PR will be needed to add automatic bumping of the image tag on a new version.](https://github.com/shipwright-io/build/issues/1724)

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The sample build strategy for BuildKit now uses the latest BuildKit release instead of its nightly build
```
