### PR TITLE
Remove usages of "new" as variable name

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -14,15 +14,15 @@ import (
 // MergeEnvVars merges one slice of corev1.EnvVar into another slice of corev1.EnvVar
 // if overwriteValues is false, this function will return an error if a duplicate EnvVar name is encountered
 // if overwriteValues is true, this function will overwrite the existing value with the new value if a duplicate is encountered
-func MergeEnvVars(new []corev1.EnvVar, into []corev1.EnvVar, overwriteValues bool) ([]corev1.EnvVar, error) {
-	// if new, into, or both are empty, there is no need to run through the processing logic
+func MergeEnvVars(from []corev1.EnvVar, into []corev1.EnvVar, overwriteValues bool) ([]corev1.EnvVar, error) {
+	// if from, into, or both are empty, there is no need to run through the processing logic
 	// just quickly return the appropriate value
-	if len(new) == 0 && len(into) == 0 {
+	if len(from) == 0 && len(into) == 0 {
 		return []corev1.EnvVar{}, nil
-	} else if len(new) == 0 {
+	} else if len(from) == 0 {
 		return into, nil
 	} else if len(into) == 0 {
-		return new, nil
+		return from, nil
 	}
 
 	// create a map of the original (into) env vars with the name as the key and
@@ -38,7 +38,7 @@ func MergeEnvVars(new []corev1.EnvVar, into []corev1.EnvVar, overwriteValues boo
 
 	// merge the new env vars into the original env vars list following a few simple rules
 	// based on if the name already exists and whether overwriteValues is true or false
-	for _, n := range new {
+	for _, n := range from {
 		_, exists := originalEnvs[n.Name]
 
 		switch {

--- a/pkg/volumes/volumes.go
+++ b/pkg/volumes/volumes.go
@@ -69,11 +69,11 @@ func isReadOnlyVolume(strategyVolume *buildv1beta1.BuildStrategyVolume) bool {
 // MergeBuildVolumes merges Build Volumes from one list into the other. It only allows to merge those that have property
 // Overridable set to true. In case it is empty or false, it is not allowed to be overridden, so Volume cannot be merged
 // Merging in this context means copying the VolumeSource from one object to the other.
-func MergeBuildVolumes(into []buildv1beta1.BuildStrategyVolume, new []buildv1beta1.BuildVolume) ([]buildv1beta1.BuildStrategyVolume, error) {
-	if len(new) == 0 && len(into) == 0 {
+func MergeBuildVolumes(into []buildv1beta1.BuildStrategyVolume, from []buildv1beta1.BuildVolume) ([]buildv1beta1.BuildStrategyVolume, error) {
+	if len(from) == 0 && len(into) == 0 {
 		return []buildv1beta1.BuildStrategyVolume{}, nil
 	}
-	if len(new) == 0 {
+	if len(from) == 0 {
 		return into, nil
 	}
 
@@ -87,7 +87,7 @@ func MergeBuildVolumes(into []buildv1beta1.BuildStrategyVolume, new []buildv1bet
 		mergeMap[vol.Name] = *vol.DeepCopy()
 	}
 
-	for _, merger := range new {
+	for _, merger := range from {
 		original, ok := mergeMap[merger.Name]
 		if !ok {
 			errors = append(errors, fmt.Errorf("Build Volume %q is not found in the BuildStrategy", merger.Name))


### PR DESCRIPTION
# Changes

Golangci-lint started to complain the usage of `new` as variable name: https://github.com/shipwright-io/build/actions/runs/11785633189/job/32827274452?pr=1730

```txt
  Running [/home/runner/golangci-lint-1.62.0-linux-amd64/golangci-lint run --path-prefix=go/src/github.com/shipwright-io/build --timeout=10m] in [/home/runner/work/build/build/go/src/github.com/shipwright-io/build] ...
  Error: go/src/github.com/shipwright-io/build/pkg/env/env.go:17:19: redefines-builtin-id: redefinition of the built-in function new (revive)
  func MergeEnvVars(new []corev1.EnvVar, into []corev1.EnvVar, overwriteValues bool) ([]corev1.EnvVar, error) {
                    ^
  Error: go/src/github.com/shipwright-io/build/pkg/volumes/volumes.go:72:65: redefines-builtin-id: redefinition of the built-in function new (revive)
  func MergeBuildVolumes(into []buildv1beta1.BuildStrategyVolume, new []buildv1beta1.BuildVolume) ([]buildv1beta1.BuildStrategyVolume, error) {
```

I am renaming those two.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
