### PR TITLE
Add automation to trigger automatic updates of the BuildKit image in our sample build strategies

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -13,6 +13,8 @@ jobs:
         include:
           - image: gcr.io/kaniko-project/executor
             latest-release-url: https://api.github.com/repos/GoogleContainerTools/kaniko/releases/latest
+          - image: moby/buildkit
+            latest-release-url: https://api.github.com/repos/moby/buildkit/releases/latest
           - image: quay.io/containers/buildah
             latest-release-url: https://quay.io/api/v1/repository/containers/buildah/tag/
     steps:

--- a/hack/check-latest-images.sh
+++ b/hack/check-latest-images.sh
@@ -36,7 +36,7 @@ function update() {
         echo "[INFO] Processing directory ${DIRECTORY}"
 
         # Search the image URL recursively and parse the current image tag
-        CURRENT_TAG="$( (grep --no-filename --recursive "${IMAGE}:" "${DIRECTORY}" || true) | head --lines=1 | sed -E "s#.*${IMAGE}:([v\.0-9]*).*?#\1#")"
+        CURRENT_TAG="$( (grep --no-filename --recursive "${IMAGE}:" "${DIRECTORY}" || true) | head --lines=1 | sed -E "s#.*${IMAGE}:([v\.0-9]*(-rootless)?).*?#\1#")"
         if [ "${CURRENT_TAG}" == "" ]; then
                 echo "[INFO] No image reference found"
                 return
@@ -49,6 +49,10 @@ function update() {
                 QUERY="[.tags[] | select(.name | endswith(\"immutable\") | not) ] | sort_by(.name) | reverse | .[0].name"
         fi
         LATEST_TAG="$(curl --silent --retry 3 "${LATEST_RELEASE_URL}" | jq --raw-output "${QUERY}")"
+
+        if [[ ${IMAGE} == *buildkit* ]]; then
+                LATEST_TAG="${LATEST_TAG}-rootless"
+        fi
 
         echo "[INFO] Determined latest tag ${LATEST_TAG}"
 


### PR DESCRIPTION
# Changes

As we recently changed the BuildKit image to be based on the latest release instead of nightly, I am hereby adding the automation to automatically bump it.

Fixes #1724

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
