### PR TITLE
Change error check in `pkg/git`

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -6,6 +6,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-git/go-git/v5/config"
@@ -45,7 +46,7 @@ func ValidateGitURLExists(ctx context.Context, urlPath string) error {
 			// path doesn't exist, func will return `authentication required`,
 			// this is maybe misleading. So convert this error message to:
 			// `remote repository unreachable`
-			if err == transport.ErrAuthenticationRequired {
+			if errors.Is(err, transport.ErrAuthenticationRequired) {
 				return fmt.Errorf("remote repository unreachable")
 			}
 


### PR DESCRIPTION
# Changes

Ref: https://github.com/shipwright-io/build/pull/1765

Change the way to check for the error so that it finds the error in an error chain.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
