### PR TITLE
Fix action on release vulnerabilities

### DIFF
--- a/.github/report-release-vulnerabilities.sh
+++ b/.github/report-release-vulnerabilities.sh
@@ -107,10 +107,10 @@ for image in "${images[@]}"; do
 done
 
 # check if issue exists, if yes, update description, otherwise create one, or close it if vulnerabilities are gone
+assignees="$(dyff json OWNERS | jq -r '.approvers | join(",")')"
 issues="$(gh issue list --label release-vulnerabilities --json number)"
 
 if [ "$(jq length <<<"${issues}")" == "0" ]; then
-  assignees="$(dyff json OWNERS | jq -r '.approvers | join(",")')"
 
   if [ "${hasVulnerabilities}" == "true" ]; then
     # create new issue
@@ -130,7 +130,7 @@ else
     # update issue
     echo "[INFO] Updating existing issue ${issueNumber}"
     gh issue edit "${issueNumber}" \
-      --assignee "${assignees}" \
+      --add-assignee "${assignees}" \
       --body-file /tmp/report.md
   else
     gh issue close --reason "No vulnerabilities found in the latest release ${RELEASE_TAG}"

--- a/.github/workflows/report-release-vulnerabilities.yaml
+++ b/.github/workflows/report-release-vulnerabilities.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          path: main
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -22,12 +24,17 @@ jobs:
         run: curl --location --silent "https://github.com/google/go-containerregistry/releases/download/$(curl -s https://api.github.com/repos/google/go-containerregistry/releases/latest | jq -r '.tag_name')/go-containerregistry_$(uname -s)_$(uname -m | sed -e 's/aarch64/arm64/').tar.gz" | sudo tar -xzf - -C /usr/local/bin crane
       - name: Install dyff
         run: curl --silent --location https://raw.githubusercontent.com/homeport/dyff/main/scripts/download-latest.sh | bash
+      - name: Install Ko
+        uses: ko-build/setup-ko@v0.7
+        with:
+          version: v0.17.1
       - name: Install Retry
         run: curl --location --silent  https://raw.githubusercontent.com/homeport/retry/main/hack/download.sh | bash
       - name: Install semver
         run: go install gitlab.com/usvc/utils/semver/cmd/semver@latest
       - name: Install Trivy
         run: make install-trivy
+        working-directory: ${{ github.workspace }}/main
       - name: Update Trivy database
         env:
           TRIVY_USERNAME: ${{ github.repository_owner }}
@@ -40,22 +47,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./.github/download-latest-release.sh
+        working-directory: ${{ github.workspace }}/main
       - name: Checkout release branch
         uses: actions/checkout@v4
         with:
-          path: /tmp/release-branch
-          ref: ${{ steps.download-latest-release.release-branch }}
+          path: release-branch
+          ref: ${{ steps.download-latest-release.outputs.release-branch }}
       - name: Install Go version of latest release
         uses: actions/setup-go@v5
         with:
-          go-version: "${{ steps.download-latest-release.go-version }}.x"
+          go-version: "${{ steps.download-latest-release.outputs.go-version }}.x"
           cache: true
           check-latest: true
       - name: Report vulnerabilities
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_BRANCH: ${{ steps.download-latest-release.release-branch }}
-          RELEASE_TAG: ${{ steps.download-latest-release.release-tag }}
-          RELEASE_YAML: ${{ steps.download-latest-release.release-yaml }}
-          REPOSITORY: /tmp/release-branch
+          RELEASE_BRANCH: ${{ steps.download-latest-release.outputs.release-branch }}
+          RELEASE_TAG: ${{ steps.download-latest-release.outputs.release-tag }}
+          RELEASE_YAML: ${{ steps.download-latest-release.outputs.release-yaml }}
+          REPOSITORY: ${{ github.workspace }}/release-branch
         run: ./.github/report-release-vulnerabilities.sh
+        working-directory: ${{ github.workspace }}/main


### PR DESCRIPTION
# Changes

Fixing various things. Worked here: https://github.com/shipwright-io/build/actions/runs/12668225863/job/35303199697. Output is https://github.com/shipwright-io/build/issues/1742. It did not trigger the release workflow because there is [one vulnerability that is not yet fixed in v0.14](https://github.com/shipwright-io/build/pull/1768).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
