### PR TITLE
Update Readme with new Tags v0.14.1 + v0.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright deployment. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.0/release.yaml --server-side
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.0/hack/setup-webhook-cert.sh | bash
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.1/release.yaml --server-side
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.1/hack/setup-webhook-cert.sh | bash
   curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
   ```
 
@@ -63,7 +63,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.0/sample-strategies.yaml --server-side
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.1/sample-strategies.yaml --server-side
   ```
 
   To install the latest nightly release, run:
@@ -171,6 +171,7 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 | Version                                                                | Docs                                                                       | Examples                                                                          |
 |------------------------------------------------------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | HEAD                                                                   | [Docs @ HEAD](docs/README.md)                                              | [Examples @ HEAD](samples)                                                        |
+| [v0.14.1](https://github.com/shipwright-io/build/releases/tag/v0.14.1) | [Docs @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/docs) | [Examples @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/samples) |
 | [v0.14.0](https://github.com/shipwright-io/build/releases/tag/v0.14.0) | [Docs @ v0.14.0](https://github.com/shipwright-io/build/tree/v0.14.0/docs) | [Examples @ v0.14.0](https://github.com/shipwright-io/build/tree/v0.14.0/samples) |
 | [v0.13.0](https://github.com/shipwright-io/build/releases/tag/v0.13.0) | [Docs @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.13.0/samples) |
 | [v0.12.0](https://github.com/shipwright-io/build/releases/tag/v0.12.0) | [Docs @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.12.0](https://github.com/shipwright-io/build/tree/v0.12.0/samples) |


### PR DESCRIPTION
# Changes

The release automation PR'ed to the release-v0.14 branch. Cherry-picking the readme updates into main.

Also added a commit to automatically update the tag of the link pointing to the storage migration script.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
