### PR TITLE
Corrections in vulnerability action triggering new release

### DIFF
--- a/.github/report-release-vulnerabilities.sh
+++ b/.github/report-release-vulnerabilities.sh
@@ -148,10 +148,11 @@ if [ "${hasVulnerabilities}" == "true" ] && [ "${allVulnerabilitiesFixedByRebuil
   else
     echo "[INFO] Triggering build of release ${nextTag} for branch ${RELEASE_BRANCH}"
     gh workflow run release.yaml \
+      --ref "${RELEASE_BRANCH}" \
       --raw-field "git-ref=${RELEASE_BRANCH}" \
       --raw-field "tags=${RELEASE_TAG}" \
       --raw-field "release=${nextTag}"
 
-    gh issue comment "${issueNumber}" --body "Triggered a release build in branch ${RELEASE_BRANCH} for ${RELEASE_TAG}. Please check whether this succeeded. A maintainer must release this."
+    gh issue comment "${issueNumber}" --body "Triggered a release build in branch ${RELEASE_BRANCH} for ${nextTag}. Please check whether this succeeded. A maintainer must release this."
   fi
 fi


### PR DESCRIPTION
# Changes

The report vulnerabilities action today correctly determined that everything is fixed and triggered a new release automatically. Though, the comment in https://github.com/shipwright-io/build/issues/1742#issuecomment-2579141929 was not accurate as it stated the wrong tag. Correcting this.

Also, the action (https://github.com/shipwright-io/build/actions/runs/12683451116) ran with the workflow definition from the main branch. It should have been the release branch. This did not matter this time because the release workflow was not changed. But it can matter in the future. I am also correcting this.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
