### PR TITLE
Fix gh command that closes the issue when all vulnerabilities are fixed

### DIFF
--- a/.github/report-release-vulnerabilities.sh
+++ b/.github/report-release-vulnerabilities.sh
@@ -111,7 +111,6 @@ assignees="$(dyff json OWNERS | jq -r '.approvers | join(",")')"
 issues="$(gh issue list --label release-vulnerabilities --json number)"
 
 if [ "$(jq length <<<"${issues}")" == "0" ]; then
-
   if [ "${hasVulnerabilities}" == "true" ]; then
     # create new issue
     echo "[INFO] Creating new issue"
@@ -133,7 +132,9 @@ else
       --add-assignee "${assignees}" \
       --body-file /tmp/report.md
   else
-    gh issue close --reason "No vulnerabilities found in the latest release ${RELEASE_TAG}"
+    gh issue close "${issueNumber}" \
+      --comment  "No vulnerabilities found in the latest release ${RELEASE_TAG}" \
+      --reason completed
   fi
 fi
 

--- a/.github/workflows/report-release-vulnerabilities.yaml
+++ b/.github/workflows/report-release-vulnerabilities.yaml
@@ -5,6 +5,10 @@ name: Report release vulnerabilities
 on:
   schedule:
     - cron: '0 4 * * *' # 4:00 am UTC = 1 hour after base image build
+  release:
+    types:
+      - edited
+      - published
   workflow_dispatch: {}
 jobs:
   report-vulnerabilities:


### PR DESCRIPTION
# Changes

The [scheduled workflow run this morning](https://github.com/shipwright-io/build/actions/runs/12703058506/job/35410244246) failed to close the issue because the `gh` command was not correct.

I corrected this, tried it out [here](https://github.com/shipwright-io/build/actions/runs/12705564792/job/35416821868) and [the issue was closed successfully](https://github.com/shipwright-io/build/issues/1742#issuecomment-2582007841).

I have also added an event trigger to the workflow so that it runs when a release is published or edited (which potentially means that it was marked latest). Therefore the action will close the vulnerabilities issues earlier and not (only) in the nightly run that comes next.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
