### PR TITLE
doc: 2025 Release Schedule

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # Project Roadmap
 
+Shipwright's detailed roadmap can be found on the
+[Shipwright Overview GitHub Project](https://github.com/orgs/shipwright-io/projects/6).
+
+## Focus Areas
+
 - Security
   - Incorporate Supply Chain Security Best Practices and deliver them to users through our Build API.
   - Continuously address and communicate vulnerability findings across our projects.
@@ -24,3 +29,33 @@ SPDX-License-Identifier: Apache-2.0
   - Periodically evaluate and update our existing integrations.
   - Ensure Integrations with CI/CD tools that can leverage Shipwright or existing CI/CD pipelines.
   - Encourage contributors to create integrations.
+
+## 2025 Release Schedule
+
+The build sub-project releases minor version updates quarterly with new features and
+updates to its dependencies. We use the latest Kubernetes minor version and Tekton LTS version for
+development and testing. Older versions of Kubernetes and Tekton may be supported by the community
+on a best-effort basis.
+
+Below is the tentative release schedule for 2025, with the anticipated versions of Kubernetes and
+Tekton used for development. Actual release dates may vary based on community availability and
+release stability.
+
+- v0.15.0: week of 2025-02-14
+  - Kubernetes version: 1.32
+  - Tekton Pipelines version: 0.68-LTS (expected)
+- v0.16.0: week of 2025-05-16
+  - Kubernetes version: 1.33 (expected)
+  - Tekton Pipelines version: 0.71-LTS (expected)
+- v0.17.0: week of 2025-08-15
+  - Kubernetes version: 1.33 or 1.34 (expected)
+  - Tekton Pipelines version: 0.74-LTS
+- v0.18.0: week of 2025-11-14
+  - Kubernetes version: 1.34 (expected)
+  - Tekton Pipelines version: 0.77-LTS (expected)
+
+The build sub-project leads the overall
+[Shipwright release schedule](https://github.com/shipwright-io/community/blob/main/ROADMAP.md) by
+two weeks. This facilitates updates to dependent Shipwright sub-projects, such as the
+[operator](https://github.com/shipwright-io/operator) and
+[shp CLI](https://github.com/shipwright-io/cli).


### PR DESCRIPTION
# Changes

Update the roadmap to include the tentative release schedule for 2025. This schedule includes the expected versions of Kubernetes and Tekton used for development and CI testing. The dates lead the overall project release schedule by two weeks to encourage updates/rebases in downstream projects, such as the CLI and operator.

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
