### PR TITLE
Use ubuntu-latest-16-cores from CNCF for e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,18 +151,8 @@ jobs:
           # newest LTS that exists at the time of our planned next release
           - v0.65.5 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c
-        with:
-          root-reserve-mb: 30720
-          swap-size-mb: 1024
-          remove-android: "true"
-          remove-codeql: "true"
-          remove-docker-images: "true"
-          remove-dotnet: "true"
-          remove-haskell: "true"
       - name: Check out code
         uses: actions/checkout@v4
       - name: Install Go


### PR DESCRIPTION
# Changes

In e2e we had disk space issues and therefore used the maximize-build-space action. We still sometimes had failures and with the more complex cluster setup needed in #1711, we need again more disk space.

Switching to the larger custom runners that we get from CNCF for e2e tests. They have more than 500 G disk space, that will be enough for us.

With the additional compute power, e2e completes in ≈ 21 minutes instead of ≈ 35 minutes. (We run ginkgo with `-p` without any explicit parallism. It automatically used 15. See "Running in parallel across 15 processes" in logs, the default workers had just 4).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
