### PR TITLE
Add v0.14.2 and v0.14.3 and v0.14.4 to readme

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,6 +96,7 @@ jobs:
         sed -i 's#https://github.com/shipwright-io/build/releases/download/'"$PREVIOUS_TAG"'/release.yaml#https://github.com/shipwright-io/build/releases/download/'"$NEW_TAG"'/release.yaml#g' README.md
         sed -i 's#https://github.com/shipwright-io/build/releases/download/'"$PREVIOUS_TAG"'/sample-strategies.yaml#https://github.com/shipwright-io/build/releases/download/'"$NEW_TAG"'/sample-strategies.yaml#g' README.md
         sed -i 's#https://raw.githubusercontent.com/shipwright-io/build/'"$PREVIOUS_TAG"'/hack/setup-webhook-cert.sh#https://raw.githubusercontent.com/shipwright-io/build/'"$NEW_TAG"'/hack/setup-webhook-cert.sh#g' README.md
+        sed -i 's#https://raw.githubusercontent.com/shipwright-io/build/'"$PREVIOUS_TAG"'/hack/storage-version-migration.sh#https://raw.githubusercontent.com/shipwright-io/build/'"$NEW_TAG"'/hack/storage-version-migration.sh#g' README.md
         sed -i '/Examples @ HEAD/a | ['"$NEW_TAG"'](https://github.com/shipwright-io/build/releases/tag/'"$NEW_TAG"')    | [Docs @ '"$NEW_TAG"'](https://github.com/shipwright-io/build/tree/'"$NEW_TAG"'/docs) | [Examples @ '"$NEW_TAG"'](https://github.com/shipwright-io/build/tree/'"$NEW_TAG"'/samples) |' README.md
 
     - name: Create Readme commits

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright deployment. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.1/release.yaml --server-side
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.1/hack/setup-webhook-cert.sh | bash
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.2/release.yaml --server-side
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.2/hack/setup-webhook-cert.sh | bash
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.2/hack/storage-version-migration.sh | bash
   ```
 
   To install the latest nightly release, run:
@@ -63,7 +63,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.1/sample-strategies.yaml --server-side
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.2/sample-strategies.yaml --server-side
   ```
 
   To install the latest nightly release, run:
@@ -171,6 +171,7 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 | Version                                                                | Docs                                                                       | Examples                                                                          |
 |------------------------------------------------------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | HEAD                                                                   | [Docs @ HEAD](docs/README.md)                                              | [Examples @ HEAD](samples)                                                        |
+| [v0.14.2](https://github.com/shipwright-io/build/releases/tag/v0.14.2)    | [Docs @ v0.14.2](https://github.com/shipwright-io/build/tree/v0.14.2/docs) | [Examples @ v0.14.2](https://github.com/shipwright-io/build/tree/v0.14.2/samples) |
 | [v0.14.1](https://github.com/shipwright-io/build/releases/tag/v0.14.1) | [Docs @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/docs) | [Examples @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/samples) |
 | [v0.14.0](https://github.com/shipwright-io/build/releases/tag/v0.14.0) | [Docs @ v0.14.0](https://github.com/shipwright-io/build/tree/v0.14.0/docs) | [Examples @ v0.14.0](https://github.com/shipwright-io/build/tree/v0.14.0/samples) |
 | [v0.13.0](https://github.com/shipwright-io/build/releases/tag/v0.13.0) | [Docs @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.12.0/docs) | [Examples @ v0.13.0](https://github.com/shipwright-io/build/tree/v0.13.0/samples) |

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright deployment. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.2/release.yaml --server-side
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.2/hack/setup-webhook-cert.sh | bash
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.2/hack/storage-version-migration.sh | bash
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.3/release.yaml --server-side
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.3/hack/setup-webhook-cert.sh | bash
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.3/hack/storage-version-migration.sh | bash
   ```
 
   To install the latest nightly release, run:
@@ -63,7 +63,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.2/sample-strategies.yaml --server-side
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.3/sample-strategies.yaml --server-side
   ```
 
   To install the latest nightly release, run:
@@ -171,6 +171,7 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 | Version                                                                | Docs                                                                       | Examples                                                                          |
 |------------------------------------------------------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | HEAD                                                                   | [Docs @ HEAD](docs/README.md)                                              | [Examples @ HEAD](samples)                                                        |
+| [v0.14.3](https://github.com/shipwright-io/build/releases/tag/v0.14.3)    | [Docs @ v0.14.3](https://github.com/shipwright-io/build/tree/v0.14.3/docs) | [Examples @ v0.14.3](https://github.com/shipwright-io/build/tree/v0.14.3/samples) |
 | [v0.14.2](https://github.com/shipwright-io/build/releases/tag/v0.14.2)    | [Docs @ v0.14.2](https://github.com/shipwright-io/build/tree/v0.14.2/docs) | [Examples @ v0.14.2](https://github.com/shipwright-io/build/tree/v0.14.2/samples) |
 | [v0.14.1](https://github.com/shipwright-io/build/releases/tag/v0.14.1) | [Docs @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/docs) | [Examples @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/samples) |
 | [v0.14.0](https://github.com/shipwright-io/build/releases/tag/v0.14.0) | [Docs @ v0.14.0](https://github.com/shipwright-io/build/tree/v0.14.0/docs) | [Examples @ v0.14.0](https://github.com/shipwright-io/build/tree/v0.14.0/samples) |

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright deployment. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.3/release.yaml --server-side
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.3/hack/setup-webhook-cert.sh | bash
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.3/hack/storage-version-migration.sh | bash
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.4/release.yaml --server-side
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.4/hack/setup-webhook-cert.sh | bash
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.14.4/hack/storage-version-migration.sh | bash
   ```
 
   To install the latest nightly release, run:
@@ -63,7 +63,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.3/sample-strategies.yaml --server-side
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.14.4/sample-strategies.yaml --server-side
   ```
 
   To install the latest nightly release, run:
@@ -171,6 +171,7 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 | Version                                                                | Docs                                                                       | Examples                                                                          |
 |------------------------------------------------------------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | HEAD                                                                   | [Docs @ HEAD](docs/README.md)                                              | [Examples @ HEAD](samples)                                                        |
+| [v0.14.4](https://github.com/shipwright-io/build/releases/tag/v0.14.4)    | [Docs @ v0.14.4](https://github.com/shipwright-io/build/tree/v0.14.4/docs) | [Examples @ v0.14.4](https://github.com/shipwright-io/build/tree/v0.14.4/samples) |
 | [v0.14.3](https://github.com/shipwright-io/build/releases/tag/v0.14.3)    | [Docs @ v0.14.3](https://github.com/shipwright-io/build/tree/v0.14.3/docs) | [Examples @ v0.14.3](https://github.com/shipwright-io/build/tree/v0.14.3/samples) |
 | [v0.14.2](https://github.com/shipwright-io/build/releases/tag/v0.14.2)    | [Docs @ v0.14.2](https://github.com/shipwright-io/build/tree/v0.14.2/docs) | [Examples @ v0.14.2](https://github.com/shipwright-io/build/tree/v0.14.2/samples) |
 | [v0.14.1](https://github.com/shipwright-io/build/releases/tag/v0.14.1) | [Docs @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/docs) | [Examples @ v0.14.1](https://github.com/shipwright-io/build/tree/v0.14.1/samples) |


### PR DESCRIPTION
# Changes

Cherry-picked the three updates from the v0.14 branch to main. Also updated the release logic to bump the version of the storage-version-migration script (I had manually added that so far).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
