### PR TITLE
[1567] Release Workflow Action No Longer Maintained

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,21 +60,10 @@ jobs:
 
     - name: Draft release
       id: draft_release
-      # TODO: This action is no longer mainained. We should use a different action
-      # or the gh command line directly.
-      uses: actions/create-release@v1
-      with:
-        release_name: "Shipwright Build release ${{ inputs.release }}"
-        tag_name: ${{ inputs.release }}
-        body_path: Changes.md
-        draft: true
-        prerelease: true
-        # create-release assumes one of two things if commitish is not set
-        # 1. Release is from the "latest commit" on the repo's default branch.
-        # 2. Release is for an existing tag with the same name
-        commitish: ${{ inputs.git-ref }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create ${TAG} --title "Shipwright Build release ${TAG}" --notes-file Changes.md --draft --prerelease --target ${{ inputs.git-ref }}
 
     - name: Generate and upload release.yaml
       env:


### PR DESCRIPTION
# Changes

- Modify the "Draft release" task to use the gh command line tool instead of the actions/create-release action

Fixes #1567 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixed deprecated release-actions in favor of gh command line.
```
