### PR TITLE
fix: Add Markers and Move Comments for API Docs

### DIFF
--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -317,8 +317,7 @@ type BuildStatus struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// Build is the Schema representing a Build definition
+// +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:path=builds,scope=Namespaced
@@ -327,6 +326,8 @@ type BuildStatus struct {
 // +kubebuilder:printcolumn:name="BuildStrategyKind",type="string",JSONPath=".spec.strategy.kind",description="The BuildStrategy type which is used for this Build"
 // +kubebuilder:printcolumn:name="BuildStrategyName",type="string",JSONPath=".spec.strategy.name",description="The BuildStrategy name which is used for this Build"
 // +kubebuilder:printcolumn:name="CreationTime",type="date",JSONPath=".metadata.creationTimestamp",description="The create time of this Build"
+
+// Build is the Schema representing a Build definition
 type Build struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -336,6 +337,7 @@ type Build struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // BuildList contains a list of Build
 type BuildList struct {

--- a/pkg/apis/build/v1beta1/buildrun_types.go
+++ b/pkg/apis/build/v1beta1/buildrun_types.go
@@ -268,8 +268,7 @@ type FailureDetails struct {
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// BuildRun is the Schema representing an instance of build execution
+// +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:path=buildruns,scope=Namespaced,shortName=br;brs
@@ -277,6 +276,8 @@ type FailureDetails struct {
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type==\"Succeeded\")].reason",description="The Succeeded reason of the BuildRun"
 // +kubebuilder:printcolumn:name="StartTime",type="date",JSONPath=".status.startTime",description="The start time of this BuildRun"
 // +kubebuilder:printcolumn:name="CompletionTime",type="date",JSONPath=".status.completionTime",description="The completion time of this BuildRun"
+
+// BuildRun is the Schema representing an instance of build execution
 type BuildRun struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -286,6 +287,7 @@ type BuildRun struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // BuildRunList contains a list of BuildRun
 type BuildRunList struct {

--- a/pkg/apis/build/v1beta1/buildstrategy_types.go
+++ b/pkg/apis/build/v1beta1/buildstrategy_types.go
@@ -23,11 +23,12 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// BuildStrategy is the Schema representing a strategy in the namespace scope to build images from source code.
+// +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:path=buildstrategies,scope=Namespaced,shortName=bs;bss
+
+// BuildStrategy is the Schema representing a strategy in the namespace scope to build images from source code.
 type BuildStrategy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -37,6 +38,7 @@ type BuildStrategy struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // BuildStrategyList contains a list of BuildStrategy
 type BuildStrategyList struct {

--- a/pkg/apis/build/v1beta1/clusterbuildstrategy_types.go
+++ b/pkg/apis/build/v1beta1/clusterbuildstrategy_types.go
@@ -24,11 +24,12 @@ const (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// ClusterBuildStrategy is the Schema representing a strategy in the cluster scope to build images from source code.
+// +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:resource:path=clusterbuildstrategies,scope=Cluster,shortName=cbs;cbss
+
+// ClusterBuildStrategy is the Schema representing a strategy in the cluster scope to build images from source code.
 type ClusterBuildStrategy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -38,6 +39,7 @@ type ClusterBuildStrategy struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // ClusterBuildStrategyList contains a list of ClusterBuildStrategy
 type ClusterBuildStrategyList struct {

--- a/pkg/apis/build/v1beta1/register.go
+++ b/pkg/apis/build/v1beta1/register.go
@@ -4,9 +4,6 @@
 
 // NOTE: Boilerplate only.  Ignore this file.
 
-// Package v1beta1 contains API Schema definitions for the build v1beta1 API group
-// +k8s:deepcopy-gen=package,register
-// +groupName=shipwright.io
 package v1beta1
 
 import (

--- a/pkg/apis/build/v1beta1/trigger.go
+++ b/pkg/apis/build/v1beta1/trigger.go
@@ -1,6 +1,7 @@
 // Copyright The Shipwright Contributors
 //
 // SPDX-License-Identifier: Apache-2.0
+
 package v1beta1
 
 // Trigger represents the webhook trigger configuration for a Build.

--- a/pkg/apis/build/v1beta1/trigger_types.go
+++ b/pkg/apis/build/v1beta1/trigger_types.go
@@ -1,6 +1,7 @@
 // Copyright The Shipwright Contributors
 //
 // SPDX-License-Identifier: Apache-2.0
+
 package v1beta1
 
 // TriggerType set of TriggerWhen valid names.

--- a/pkg/apis/build/v1beta1/trigger_when.go
+++ b/pkg/apis/build/v1beta1/trigger_when.go
@@ -1,6 +1,7 @@
 // Copyright The Shipwright Contributors
 //
 // SPDX-License-Identifier: Apache-2.0
+
 package v1beta1
 
 // TriggerWhen a given scenario where the webhook trigger is applicable.


### PR DESCRIPTION
# Changes

Update our code comment markers and copyright notice placement so that the elastic/crd-ref-docs tool can generate API reference docs:

- Add `kubebuilder:object:root=true` marker for root CRD types. The crd-ref-docs tool looks for these to identify new `Kind` APIs.
- Move copyright comments so they are not mistaken for package-level docs.

Note - this only applies to the `v1beta1` API.

Needed for https://github.com/shipwright-io/website/pull/147

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
