### PR TITLE
Move seccomp profile definition to container securityContext

### DIFF
--- a/samples/v1alpha1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -6,9 +6,6 @@ metadata:
   annotations:
     # See https://github.com/moby/buildkit/blob/master/docs/rootless.md#about---oci-worker-no-process-sandbox for more information
     container.apparmor.security.beta.kubernetes.io/step-build-and-push: unconfined
-    # The usage of seccomp annotation will be deprecate in k8s v1.22.0, see
-    # https://kubernetes.io/docs/tutorials/clusters/seccomp/#create-a-pod-with-a-seccomp-profile-for-syscall-auditing for more information
-    container.seccomp.security.alpha.kubernetes.io/step-build-and-push: unconfined
 spec:
   parameters:
   - name: build-args
@@ -37,6 +34,8 @@ spec:
           add:
             - SETGID
             - SETUID
+        seccompProfile:
+          type: Unconfined
       workingDir: $(params.shp-source-root)
       env:
       - name: DOCKER_CONFIG

--- a/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -6,9 +6,6 @@ metadata:
   annotations:
     # See https://github.com/moby/buildkit/blob/master/docs/rootless.md#about---oci-worker-no-process-sandbox for more information
     container.apparmor.security.beta.kubernetes.io/step-build-and-push: unconfined
-    # The usage of seccomp annotation will be deprecate in k8s v1.22.0, see
-    # https://kubernetes.io/docs/tutorials/clusters/seccomp/#create-a-pod-with-a-seccomp-profile-for-syscall-auditing for more information
-    container.seccomp.security.alpha.kubernetes.io/step-build-and-push: unconfined
 spec:
   parameters:
     - name: build-args
@@ -45,6 +42,8 @@ spec:
           add:
             - SETGID
             - SETUID
+        seccompProfile:
+          type: Unconfined
       workingDir: $(params.shp-source-root)
       env:
         - name: DOCKER_CONFIG


### PR DESCRIPTION
# Changes

Since Kubernetes 1.31, seccomp annotations are ignored. Therefore finally moving them to the container security context.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The BuildKit sample build strategy defines the seccomp profile now in the security context instead of the - since k8s 1.31 - unsupported annotation
```
