### PR TITLE
Updates Multi-Arch resources to be ClusterScoped

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -116,9 +116,8 @@ coordinate with the orchestrator pod.
 
 When all the builds are completed, the orchestrator pod will compose a manifest-list image and push it to the target registry.
 
-The service account that runs the strategy must be bound to a role able to `create`, `list`, `get` and `watch` 
-`batch/v1` `jobs` and `core/v1` `pods` resources. 
-The role also needs to allow the `create` verb for the `pods/exec` resource.
+The service account that runs the strategy must be bound to a ClusterRole able to `create`, `list`, `get` and `watch` `batch/v1` `jobs` and `core/v1` `pods` resources. 
+The ClusteRole also needs to allow the `create` verb for the `pods/exec` resource.
 Finally, when running in OKD or OpenShift clusters, the service account must be able to use the 
 `privileged` SecurityContextConstraint.
 

--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -127,13 +127,26 @@ To install the cluster-scoped strategy, use:
 
 ```sh
 kubectl apply -f samples/v1beta1/buildstrategy/multiarch-native-buildah/buildstrategy_multiarch_native_buildah_cr.yaml
+kubectl apply -f samples/v1beta1/buildstrategy/multiarch-native-buildah/clusterrole_multiarch_native_buildah_cr.yaml
 ```
 
 For each namespace where you want to use the strategy, you also need to apply the RBAC rules that allow the service
 account to run the strategy. If the service account is named `pipeline` (default), you can use:
 
 ```sh
-kubectl apply -n <namespace> -f  samples/v1beta1/buildstrategy/multiarch-native-buildah/
+kubectl apply -n <namespace> -f samples/v1beta1/buildstrategy/multiarch-native-buildah/rolebinding_multiarch_native_buildah_cr.yaml
+```
+
+_note_: If `pipeline` service account isn't available in your environment (most likely when using a kind cluster), replace the subjects[0].name to `default`.
+
+```sh
+sed 's/name: pipeline/name: default/' samples/v1beta1/buildstrategy/multiarch-native-buildah/rolebinding_multiarch_native_buildah_cr.yaml| kubectl apply -f -
+```
+
+If you are on OKD platform, apply the following RBAC to use the 
+`privileged` SecurityContextConstraint:
+```sh
+kubectl apply -f samples/v1beta1/buildstrategy/multiarch-native-buildah/rolebinding_multiarch_native_buildah_scc_okd_cr.yaml
 ```
 
 ### Parameters

--- a/samples/v1beta1/buildstrategy/multiarch-native-buildah/clusterrole_multiarch_native_buildah_cr.yaml
+++ b/samples/v1beta1/buildstrategy/multiarch-native-buildah/clusterrole_multiarch_native_buildah_cr.yaml
@@ -1,4 +1,4 @@
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multiarch-native-buildah-pipeline

--- a/samples/v1beta1/buildstrategy/multiarch-native-buildah/rolebinding_multiarch_native_buildah_cr.yaml
+++ b/samples/v1beta1/buildstrategy/multiarch-native-buildah/rolebinding_multiarch_native_buildah_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: multiarch-native-buildah-pipeline
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: multiarch-native-buildah-pipeline
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
# Changes
This PR includes following changes:
- Replaces the Role references to ClusterRole references. Updates the doc to create the roleBindings accordingly.
- In kind cluster, there doesn't seem to have `pipeline` SA in all the namesapces, so, another commit makes SERVICE_ACCOUNT configurable while applying the roleBinding.

Fixes #1756 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```