### PR TITLE
Add dorzel to OWNERS as Reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,7 @@ approvers:
 reviewers:
 - adambkaplan
 - apoorvajagtap
+- dorzel
 - qu1queee
 - SaschaSchwarze0
 - HeavyWombat


### PR DESCRIPTION
# Changes

Promote Dylan Orzel (@dorzel) to `reviewer` in the shipwright-io/build repo, in recognition of his contributions related to scheduling builds on Kubernetes clusters. Many of these implement the API-level features described in SHIP-0039 [1].

Thank you Dylan for your efforts!

[1] https://github.com/shipwright-io/community/blob/main/ships/0039-build-scheduler-opts.md

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```