### PR TITLE
Add link to gopkg.dev to listed Go packages with vulnerabilities

### DIFF
--- a/.github/report-release-vulnerabilities.sh
+++ b/.github/report-release-vulnerabilities.sh
@@ -97,7 +97,7 @@ for image in "${images[@]}"; do
     fi
 
     echo "    [INFO] Found ${id} in ${pkg}. Requires upgrade from ${vulnerableVersion} to ${fixedVersion}.${fixedSentence}"
-    echo "| ${id} | ${pkg} | ${vulnerableVersion} -> ${fixedVersion} | ${fixed} |" >>/tmp/report.md
+    echo "| ${id} | [${pkg}](https://pkg.go.dev/${pkg}) | ${vulnerableVersion} -> ${fixedVersion} | ${fixed} |" >>/tmp/report.md
   done <<<"$(jq --raw-output 'select(.finding != null and .finding.fixed_version != null) | [ .finding.osv, .finding.trace[0].module, .finding.trace[0].version, .finding.fixed_version ] | @tsv' <<<"${goVulns}" | sort -u)"
 
   if [ "${goVulnsFound}" == "false" ]; then


### PR DESCRIPTION
# Changes

When looking at issues such as #1810, when I see Go vulnerabilities and Dependabot suddenly has not yet opened a PR, then I open it myself. When doing so, I prefer to check if the fixed version is actually also the latest version or if there is already something newer, and if so go to latest. To check what the latest version is I usually go to pkg.go.dev. Hereby making the package name a link so that this can be done faster.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
