### PR TITLE
Exclude RoleBinding from sample-strategies.yaml

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,6 +35,6 @@ KO_DOCKER_REPO="${IMAGE_HOST}/${IMAGE_NAMESPACE}" GOFLAGS="${GO_FLAGS} -tags=ppr
 
 # Bundle the sample cluster build strategies, remove namespace strategies first
 echo "[INFO] Bundling sample build strategies"
-find samples/v1beta1/buildstrategy -type f -print0 | xargs -0 grep -l "kind: BuildStrategy" | xargs rm -f
+find samples/v1beta1/buildstrategy -type f -print0 | xargs -0 grep -l -e "kind: BuildStrategy" -e "kind: RoleBinding" | xargs rm -f
 KO_DOCKER_REPO=dummy ko resolve --recursive --filename samples/v1beta1/buildstrategy/ > sample-strategies.yaml
 git restore samples/v1beta1/buildstrategy


### PR DESCRIPTION
# Changes

For the multiarch buildstrategy, https://github.com/shipwright-io/build/tree/main/samples/v1beta1/buildstrategy/multiarch-native-buildah, we are delivering also a ClusterRole and RoleBindings so that the running build has the necessary permissions to manage Jobs and Pods in the cluster.

As described in https://github.com/shipwright-io/build/blob/main/docs/buildstrategies.md#installing-multi-arch-native-buildah-strategy, the RoleBinding must be installed in the namespace(s) where the build strategy will be used. As we cannot know which namespaces those are, we should not include this file in our sample-strategies.yaml.

This PR excludes it like we already also exclude our sample namespaces build strategies.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The role bindings related to the multiarch-native-buildah cluster build strategy sample are now not anymore included in our sample-strategies.yaml file. You must manually apply them to the namespaces where you plan to use this strategy.
```
