### PR TITLE
Initializing shallow cloning logic and CRD change

### DIFF
--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -494,6 +494,13 @@ spec:
                   url:
                     description: URL describes the URL of the Git repository.
                     type: string
+                  depth:
+                    description: |-
+                      The depth of the git clone. If not specified the default value is 1, 
+                      a shallow git clone will be performed. Values greater than 1 will 
+                      create a clone with the specified depth.
+                    type: integer
+                    minimum: 1
                 type: object
               sources:
                 description: |-
@@ -2837,6 +2844,13 @@ spec:
                     description: Git contains the details for obtaining source code
                       from a git repository.
                     properties:
+                      depth:
+                        description: |-
+                          The depth of the git clone. If not specified the default value is 1, 
+                          a shallow git clone will be performed. Values greater than 1 will 
+                          create a clone with the specified depth.
+                        type: integer
+                        minimum: 1
                       cloneSecret:
                         description: |-
                           CloneSecret references a Secret that contains credentials to access

--- a/docs/build.md
+++ b/docs/build.md
@@ -142,6 +142,7 @@ A `Build` resource can specify a source type, such as a Git repository or an OCI
 - `source.git.url` - Specify the source location using a Git repository.
 - `source.git.cloneSecret` - For private repositories or registries, the name references a secret in the namespace that contains the SSH private key or Docker access credentials, respectively.
 - `source.git.revision` - A specific revision to select from the source repository, this can be a commit, tag or branch name. If not defined, it will fall back to the Git repository default branch.
+- `source.git.depth` - The depth of the clone. If not specified the value defaults to 1 and a shallow clone is performed. Values greater than 1 will create a clone with the specified depth.
 - `source.contextDir` - For repositories where the source code is not located at the root folder, you can specify this path here.
 
 By default, the Build controller does not validate that the Git repository exists. If the validation is desired, users can explicitly define the `build.shipwright.io/verify.repository` annotation with `true`. For example:

--- a/pkg/apis/build/v1beta1/source.go
+++ b/pkg/apis/build/v1beta1/source.go
@@ -62,6 +62,13 @@ type Git struct {
 	//
 	// +optional
 	CloneSecret *string `json:"cloneSecret,omitempty"`
+
+	// Depth specifies the depth of the shallow clone.
+	// If not specified the default is set to 1.
+	// Values greater than 1 will create a clone with the specified depth.
+	//
+	// +optional
+	Depth *int `json:"depth,omitempty"`
 }
 
 // OCIArtifact describes how to obtain source code from a container image, also known as an OCI

--- a/pkg/reconciler/buildrun/resources/sources/git.go
+++ b/pkg/reconciler/buildrun/resources/sources/git.go
@@ -79,6 +79,15 @@ func AppendGitStep(
 		)
 	}
 
+	// Check if shallow clone is requested
+	if source.Depth != nil && *source.Depth > 0 {
+		gitStep.Args = append(
+			gitStep.Args,
+			"--depth",
+			fmt.Sprintf("%d", *source.Depth),
+		)
+	}
+
 	// If configure, use Git URL rewrite flag
 	if cfg.GitRewriteRule {
 		gitStep.Args = append(gitStep.Args, "--git-url-rewrite")

--- a/samples/v1beta1/buildstrategy/buildah/buildah.yaml
+++ b/samples/v1beta1/buildstrategy/buildah/buildah.yaml
@@ -1,0 +1,231 @@
+---
+apiVersion: shipwright.io/v1beta1
+kind: ClusterBuildStrategy
+metadata:
+  name: buildah
+spec:
+  steps:
+    - name: build-and-push
+      image: quay.io/containers/buildah:v1.39.3
+      imagePullPolicy: Always
+      workingDir: $(params.shp-source-root)
+      securityContext:
+        capabilities:
+          add:
+          - "SETFCAP"
+      command:
+        - /bin/bash
+      args:
+        - -c
+        - |
+          set -euo pipefail
+
+          # Parse parameters
+          context=
+          dockerfile=
+          image=
+          budArgs=()
+          inBuildArgs=false
+          registriesBlock=""
+          inRegistriesBlock=false
+          registriesInsecure=""
+          inRegistriesInsecure=false
+          registriesSearch=""
+          inRegistriesSearch=false
+          tlsVerify=true
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--context" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              context="$1"
+              shift
+            elif [ "${arg}" == "--dockerfile" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              dockerfile="$1"
+              shift
+            elif [ "${arg}" == "--image" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              image="$1"
+              shift
+            elif [ "${arg}" == "--target" ]; then
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+              if [ "$1" != "" ]; then
+                budArgs+=(--target "$1")
+              fi
+              shift
+            elif [ "${arg}" == "--build-args" ]; then
+              inBuildArgs=true
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+            elif [ "${arg}" == "--registries-block" ]; then
+              inRegistriesBlock=true
+              inBuildArgs=false
+              inRegistriesInsecure=false
+              inRegistriesSearch=false
+            elif [ "${arg}" == "--registries-insecure" ]; then
+              inRegistriesInsecure=true
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesSearch=false
+            elif [ "${arg}" == "--registries-search" ]; then
+              inRegistriesSearch=true
+              inBuildArgs=false
+              inRegistriesBlock=false
+              inRegistriesInsecure=false
+            elif [ "${inBuildArgs}" == "true" ]; then
+              budArgs+=("--build-arg" "${arg}")
+            elif [ "${inRegistriesBlock}" == "true" ]; then
+              registriesBlock="${registriesBlock}'${arg}', "
+            elif [ "${inRegistriesInsecure}" == "true" ]; then
+              registriesInsecure="${registriesInsecure}'${arg}', "
+
+              # This assumes that the image is passed before the insecure registries which is fair in this context
+              if [[ ${image} == ${arg}/* ]]; then
+                tlsVerify=false
+              fi
+            elif [ "${inRegistriesSearch}" == "true" ]; then
+              registriesSearch="${registriesSearch}'${arg}', "
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          # Verify the existence of the context directory
+          if [ ! -d "${context}" ]; then
+            echo -e "The context directory '${context}' does not exist."
+            echo -n "ContextDirNotFound" > '$(results.shp-error-reason.path)'
+            echo -n "The context directory '${context}' does not exist." > '$(results.shp-error-message.path)'
+            exit 1
+          fi
+          cd "${context}"
+
+          # Verify the existence of the Dockerfile
+          if [ ! -f "${dockerfile}" ]; then
+            echo -e "The Dockerfile '${dockerfile}' does not exist."
+            echo -n "DockerfileNotFound" > '$(results.shp-error-reason.path)'
+            echo -n "The Dockerfile '${dockerfile}' does not exist." > '$(results.shp-error-message.path)'
+            exit 1
+          fi
+
+          echo "[INFO] Creating registries config file..."
+          if [ "${registriesSearch}" != "" ]; then
+            cat <<EOF >>/tmp/registries.conf
+          [registries.search]
+          registries = [${registriesSearch::-2}]
+
+          EOF
+          fi
+          if [ "${registriesInsecure}" != "" ]; then
+            cat <<EOF >>/tmp/registries.conf
+          [registries.insecure]
+          registries = [${registriesInsecure::-2}]
+
+          EOF
+          fi
+          if [ "${registriesBlock}" != "" ]; then
+            cat <<EOF >>/tmp/registries.conf
+          [registries.block]
+          registries = [${registriesBlock::-2}]
+
+          EOF
+          fi
+
+          # Building the image
+          echo "[INFO] Building image ${image}"
+          buildah --storage-driver=$(params.storage-driver) \
+            bud "${budArgs[@]}" \
+            --registries-conf=/tmp/registries.conf \
+            --tag="${image}" \
+            --file="${dockerfile}" \
+            .
+
+          # Push the image
+          echo "[INFO] Pushing image ${image}"
+          buildah --storage-driver=$(params.storage-driver) push \
+            --digestfile='$(results.shp-image-digest.path)' \
+            --tls-verify="${tlsVerify}" \
+            "${image}" \
+            "docker://${image}"
+        # That's the separator between the shell script and its args
+        - --
+        - --context
+        - $(params.shp-source-context)
+        - --dockerfile
+        - $(params.dockerfile)
+        - --image
+        - $(params.shp-output-image)
+        - --build-args
+        - $(params.build-args[*])
+        - --registries-block
+        - $(params.registries-block[*])
+        - --registries-insecure
+        - $(params.registries-insecure[*])
+        - --registries-search
+        - $(params.registries-search[*])
+        - --target
+        - $(params.target)
+      volumeMounts:
+        - mountPath: /etc/pki/entitlement
+          name: etc-pki-entitlement
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: 250m
+          memory: 65Mi
+  parameters:
+    - name: build-args
+      description: "The values for the args in the Dockerfile. Values must be in the format KEY=VALUE."
+      type: array
+      defaults: []
+    - name: registries-block
+      description: The registries that need to block pull access.
+      type: array
+      defaults: []
+    - name: registries-insecure
+      description: The fully-qualified name of insecure registries. An insecure registry is one that does not have a valid SSL certificate or only supports HTTP.
+      type: array
+      defaults: []
+    - name: registries-search
+      description: The registries for searching short name images such as `golang:latest`.
+      type: array
+      defaults:
+        - registry.redhat.io
+        - quay.io
+    - name: dockerfile
+      description: The path to the Dockerfile to be used for building the image.
+      type: string
+      default: "Dockerfile"
+    - name: storage-driver
+      description: "The storage driver to use, such as 'overlay' or 'vfs'"
+      type: string
+      default: "vfs"
+      # For details see the "--storage-driver" section of https://github.com/containers/buildah/blob/main/docs/buildah.1.md#options
+    - name: target
+      description: "Sets the target stage to be built."
+      type: string
+      default: ""
+  volumes:
+    - name: etc-pki-entitlement
+      emptyDir: {}
+      overridable: true
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0

--- a/test/data/v1beta1/build_buildah_cr_git_depth.yaml
+++ b/test/data/v1beta1/build_buildah_cr_git_depth.yaml
@@ -1,0 +1,19 @@
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildah-golang-build-depth
+spec:
+  source:
+    type: Git
+    git: 
+      url: https://github.com/ayushsatyam146/buildah-sample-go
+      depth: 3
+    contextDir: docker-build
+  strategy:
+    name: buildah
+    kind: ClusterBuildStrategy
+  paramValues:
+  - name: dockerfile
+    value: Dockerfile
+  output:
+    image: ttl.sh/buildah-example-sample-go-app:6h

--- a/test/data/v1beta1/buildrun_buildah_cr_git_depth.yaml
+++ b/test/data/v1beta1/buildrun_buildah_cr_git_depth.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+metadata:
+  name: buildah-golang-buildrun
+spec:
+  build:
+    name: buildah-golang-build-depth
+  serviceAccount: ".generate"

--- a/test/e2e/v1beta1/e2e_git_test.go
+++ b/test/e2e/v1beta1/e2e_git_test.go
@@ -1,0 +1,64 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+)
+
+var _ = Describe("For a Kubernetes cluster with Tekton and build installed", func() {
+	var (
+		testID string
+		err    error
+
+		build    *buildv1beta1.Build
+		buildRun *buildv1beta1.BuildRun
+	)
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			printTestFailureDebugInfo(testBuild, testBuild.Namespace, testID)
+
+		} else if buildRun != nil {
+			validateServiceAccountDeletion(buildRun, testBuild.Namespace)
+		}
+
+		if buildRun != nil {
+			testBuild.DeleteBR(buildRun.Name)
+			buildRun = nil
+		}
+
+		if build != nil {
+			testBuild.DeleteBuild(build.Name)
+			build = nil
+		}
+	})
+
+	Context("when a Buildah build with git depth is defined", func() {
+		BeforeEach(func() {
+			testID = generateTestID("git-depth")
+
+			// create the build definition
+			build = createBuild(
+				testBuild,
+				testID,
+				"test/data/v1beta1/build_buildah_cr_git_depth.yaml",
+			)
+		})
+
+		It("successfully runs a build with limited git history", func() {
+			buildRun, err = buildRunTestData(testBuild.Namespace, testID, "test/data/v1beta1/buildrun_buildah_cr_git_depth.yaml")
+			Expect(err).ToNot(HaveOccurred(), "Error retrieving buildrun test data")
+			appendRegistryInsecureParamValue(build, buildRun)
+
+			buildRun = validateBuildRunToSucceed(testBuild, buildRun)
+			validateBuildRunResultsFromGitSource(buildRun)
+			testBuild.ValidateImageDigest(buildRun)
+		})
+	})
+})


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
The `source.git.depth` is added in the Builds CRD and the Builds API. This field now specifies the depth of the Git history cloning. If not specified the value defaults to 1 and a shallow clone is performed. Values greater than 1 will create a clone with the specified depth.

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
