### PR TITLE
doc: Improve godoc for Source Code Spec

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -7450,12 +7450,13 @@ spec:
                           artifact
                         properties:
                           contextDir:
-                            description: ContextDir is a path to subfolder in the
-                              repo. Optional.
+                            description: |-
+                              ContextDir is a path to a subdirectory within the source code that should be used as the
+                              build root directory. Optional.
                             type: string
                           git:
-                            description: Git contains the details for the source of
-                              type Git
+                            description: Git contains the details for obtaining source
+                              code from a git repository.
                             properties:
                               cloneSecret:
                                 description: |-
@@ -7477,28 +7478,33 @@ spec:
                             - url
                             type: object
                           local:
-                            description: Local contains the details for the source
-                              of type Local
+                            description: |-
+                              Local contains the details for obtaining source code that is streamed in from a remote
+                              machine's local directory.
                             properties:
                               name:
                                 description: Name of the local step
                                 type: string
                               timeout:
-                                description: Timeout how long the BuildSource execution
-                                  must take.
+                                description: |-
+                                  Timeout is the maximum duration the build should wait for source code to be streamed in from
+                                  a remote machine's local directory.
                                 type: string
                             type: object
                           ociArtifact:
-                            description: OCIArtifact contains the details for the
-                              source of type OCIArtifact
+                            description: |-
+                              OCIArtifact contains the details for obtaining source code from a container image, also
+                              known as an OCI artifact.
                             properties:
                               image:
-                                description: Image reference, i.e. quay.io/org/image:tag
+                                description: |-
+                                  Image is a reference to a container image to be pulled from a container registry.
+                                  For example, quay.io/org/image:tag
                                 type: string
                               prune:
                                 description: |-
-                                  Prune specifies whether the image is suppose to be deleted. Allowed
-                                  values are 'Never' (no deletion) and `AfterPull` (removal after the
+                                  Prune specifies whether the image containing the source code should be deleted.
+                                  Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the
                                   image was successfully pulled from the registry).
 
 
@@ -7507,14 +7513,15 @@ spec:
                               pullSecret:
                                 description: |-
                                   PullSecret references a Secret that contains credentials to access
-                                  the repository.
+                                  the container image.
                                 type: string
                             required:
                             - image
                             type: object
                           type:
-                            description: Type is the BuildSource qualifier, the type
-                              of the source.
+                            description: |-
+                              Type is the type of source code used as input for the build. Allowed values are
+                              `Git`, `OCI`, and `Local`.
                             type: string
                         required:
                         - type
@@ -9769,8 +9776,9 @@ spec:
                 type: string
               source:
                 description: |-
-                  Source refers to the location where the source code is,
-                  this could only be a local source
+                  Source overrides where the source code is obtained for the BuildRun. This can only be used
+                  to obtain source code from a remote machine's local directory, instead of the value defined
+                  in the build.
                 properties:
                   local:
                     description: Local contains the details for the source of type
@@ -9780,14 +9788,15 @@ spec:
                         description: Name of the local step
                         type: string
                       timeout:
-                        description: Timeout how long the BuildSource execution must
-                          take.
+                        description: |-
+                          Timeout is the maximum duration the build should wait for source code to be streamed in from
+                          a remote machine's local directory.
                         type: string
                     type: object
                   type:
                     description: |-
                       Type is the BuildRunSource qualifier, the type of the source.
-                      Only Local is supported.
+                      Only `Local` is supported.
                     type: string
                 required:
                 - type
@@ -11960,12 +11969,13 @@ spec:
                       artifact
                     properties:
                       contextDir:
-                        description: ContextDir is a path to subfolder in the repo.
-                          Optional.
+                        description: |-
+                          ContextDir is a path to a subdirectory within the source code that should be used as the
+                          build root directory. Optional.
                         type: string
                       git:
-                        description: Git contains the details for the source of type
-                          Git
+                        description: Git contains the details for obtaining source
+                          code from a git repository.
                         properties:
                           cloneSecret:
                             description: |-
@@ -11987,28 +11997,33 @@ spec:
                         - url
                         type: object
                       local:
-                        description: Local contains the details for the source of
-                          type Local
+                        description: |-
+                          Local contains the details for obtaining source code that is streamed in from a remote
+                          machine's local directory.
                         properties:
                           name:
                             description: Name of the local step
                             type: string
                           timeout:
-                            description: Timeout how long the BuildSource execution
-                              must take.
+                            description: |-
+                              Timeout is the maximum duration the build should wait for source code to be streamed in from
+                              a remote machine's local directory.
                             type: string
                         type: object
                       ociArtifact:
-                        description: OCIArtifact contains the details for the source
-                          of type OCIArtifact
+                        description: |-
+                          OCIArtifact contains the details for obtaining source code from a container image, also
+                          known as an OCI artifact.
                         properties:
                           image:
-                            description: Image reference, i.e. quay.io/org/image:tag
+                            description: |-
+                              Image is a reference to a container image to be pulled from a container registry.
+                              For example, quay.io/org/image:tag
                             type: string
                           prune:
                             description: |-
-                              Prune specifies whether the image is suppose to be deleted. Allowed
-                              values are 'Never' (no deletion) and `AfterPull` (removal after the
+                              Prune specifies whether the image containing the source code should be deleted.
+                              Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the
                               image was successfully pulled from the registry).
 
 
@@ -12017,14 +12032,15 @@ spec:
                           pullSecret:
                             description: |-
                               PullSecret references a Secret that contains credentials to access
-                              the repository.
+                              the container image.
                             type: string
                         required:
                         - image
                         type: object
                       type:
-                        description: Type is the BuildSource qualifier, the type of
-                          the source.
+                        description: |-
+                          Type is the type of source code used as input for the build. Allowed values are
+                          `Git`, `OCI`, and `Local`.
                         type: string
                     required:
                     - type

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -2829,10 +2829,13 @@ spec:
                   artifact
                 properties:
                   contextDir:
-                    description: ContextDir is a path to subfolder in the repo. Optional.
+                    description: |-
+                      ContextDir is a path to a subdirectory within the source code that should be used as the
+                      build root directory. Optional.
                     type: string
                   git:
-                    description: Git contains the details for the source of type Git
+                    description: Git contains the details for obtaining source code
+                      from a git repository.
                     properties:
                       cloneSecret:
                         description: |-
@@ -2854,28 +2857,33 @@ spec:
                     - url
                     type: object
                   local:
-                    description: Local contains the details for the source of type
-                      Local
+                    description: |-
+                      Local contains the details for obtaining source code that is streamed in from a remote
+                      machine's local directory.
                     properties:
                       name:
                         description: Name of the local step
                         type: string
                       timeout:
-                        description: Timeout how long the BuildSource execution must
-                          take.
+                        description: |-
+                          Timeout is the maximum duration the build should wait for source code to be streamed in from
+                          a remote machine's local directory.
                         type: string
                     type: object
                   ociArtifact:
-                    description: OCIArtifact contains the details for the source of
-                      type OCIArtifact
+                    description: |-
+                      OCIArtifact contains the details for obtaining source code from a container image, also
+                      known as an OCI artifact.
                     properties:
                       image:
-                        description: Image reference, i.e. quay.io/org/image:tag
+                        description: |-
+                          Image is a reference to a container image to be pulled from a container registry.
+                          For example, quay.io/org/image:tag
                         type: string
                       prune:
                         description: |-
-                          Prune specifies whether the image is suppose to be deleted. Allowed
-                          values are 'Never' (no deletion) and `AfterPull` (removal after the
+                          Prune specifies whether the image containing the source code should be deleted.
+                          Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the
                           image was successfully pulled from the registry).
 
 
@@ -2884,14 +2892,15 @@ spec:
                       pullSecret:
                         description: |-
                           PullSecret references a Secret that contains credentials to access
-                          the repository.
+                          the container image.
                         type: string
                     required:
                     - image
                     type: object
                   type:
-                    description: Type is the BuildSource qualifier, the type of the
-                      source.
+                    description: |-
+                      Type is the type of source code used as input for the build. Allowed values are
+                      `Git`, `OCI`, and `Local`.
                     type: string
                 required:
                 - type

--- a/pkg/apis/build/v1beta1/buildrun_types.go
+++ b/pkg/apis/build/v1beta1/buildrun_types.go
@@ -59,8 +59,9 @@ type BuildRunSpec struct {
 	//
 	Build ReferencedBuild `json:"build"`
 
-	// Source refers to the location where the source code is,
-	// this could only be a local source
+	// Source overrides where the source code is obtained for the BuildRun. This can only be used
+	// to obtain source code from a remote machine's local directory, instead of the value defined
+	// in the build.
 	//
 	// +optional
 	Source *BuildRunSource `json:"source,omitempty"`

--- a/pkg/apis/build/v1beta1/source.go
+++ b/pkg/apis/build/v1beta1/source.go
@@ -20,7 +20,7 @@ const LocalType BuildSourceType = "Local"
 // a public or private repository
 const GitType BuildSourceType = "Git"
 
-// OCIArtifactType represents a source code bundle container image to pull. This is where the source code resides.
+// OCIArtifactType represents a build whose source code is in a "scratch" container image, also known as an OCI artifact.
 const OCIArtifactType BuildSourceType = "OCI"
 
 const (
@@ -31,8 +31,11 @@ const (
 	PruneAfterPull PruneOption = "AfterPull"
 )
 
+// Local describes how to obtain source code streamed in from a remote machine's local directory.
+// Local source code can be streamed into a build using the shp command line.
 type Local struct {
-	// Timeout how long the BuildSource execution must take.
+	// Timeout is the maximum duration the build should wait for source code to be streamed in from
+	// a remote machine's local directory.
 	//
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
@@ -41,7 +44,7 @@ type Local struct {
 	Name string `json:"name,omitempty"`
 }
 
-// Git describes the git repository to pull
+// Git describes how to obtain source code from a git repository.
 type Git struct {
 	// URL describes the URL of the Git repository.
 	URL string `json:"url"`
@@ -61,13 +64,15 @@ type Git struct {
 	CloneSecret *string `json:"cloneSecret,omitempty"`
 }
 
-// OCIArtifact describes the source code bundle container to pull
+// OCIArtifact describes how to obtain source code from a container image, also known as an OCI
+// artifact.
 type OCIArtifact struct {
-	// Image reference, i.e. quay.io/org/image:tag
+	// Image is a reference to a container image to be pulled from a container registry.
+	// For example, quay.io/org/image:tag
 	Image string `json:"image"`
 
-	// Prune specifies whether the image is suppose to be deleted. Allowed
-	// values are 'Never' (no deletion) and `AfterPull` (removal after the
+	// Prune specifies whether the image containing the source code should be deleted.
+	// Allowed values are 'Never' (no deletion) and `AfterPull` (removal after the
 	// image was successfully pulled from the registry).
 	//
 	// If not defined, it defaults to 'Never'.
@@ -76,42 +81,47 @@ type OCIArtifact struct {
 	Prune *PruneOption `json:"prune,omitempty"`
 
 	// PullSecret references a Secret that contains credentials to access
-	// the repository.
+	// the container image.
 	//
 	// +optional
 	PullSecret *string `json:"pullSecret,omitempty"`
 }
 
-// Source describes the build source type to fetch.
+// Source describes the source code to fetch for the build.
 type Source struct {
-	// Type is the BuildSource qualifier, the type of the source.
+	// Type is the type of source code used as input for the build. Allowed values are
+	// `Git`, `OCI`, and `Local`.
 	Type BuildSourceType `json:"type"`
 
-	// ContextDir is a path to subfolder in the repo. Optional.
+	// ContextDir is a path to a subdirectory within the source code that should be used as the
+	// build root directory. Optional.
 	//
 	// +optional
 	ContextDir *string `json:"contextDir,omitempty"`
 
-	// OCIArtifact contains the details for the source of type OCIArtifact
+	// OCIArtifact contains the details for obtaining source code from a container image, also
+	// known as an OCI artifact.
 	//
 	// +optional
 	OCIArtifact *OCIArtifact `json:"ociArtifact,omitempty"`
 
-	// Git contains the details for the source of type Git
+	// Git contains the details for obtaining source code from a git repository.
 	//
 	// +optional
 	Git *Git `json:"git,omitempty"`
 
-	// Local contains the details for the source of type Local
+	// Local contains the details for obtaining source code that is streamed in from a remote
+	// machine's local directory.
 	//
 	// +optional
 	Local *Local `json:"local,omitempty"`
 }
 
-// BuildRunSource describes the local source to use
+// BuildRunSource describes the source to use in a BuildRun, overriding the value of the parent
+// Build object.
 type BuildRunSource struct {
 	// Type is the BuildRunSource qualifier, the type of the source.
-	// Only Local is supported.
+	// Only `Local` is supported.
 	//
 	Type BuildSourceType `json:"type"`
 


### PR DESCRIPTION
# Changes

Adding clearer descriptions of the source code spec options for `Build` and `BuildRun` objects. This is particularly relevant for the `OCIArtifact` source type, which extracts the contents of a "scratch" container image to a local directory.

These updated godoc comments should then get synced to the docs repository and published at https://shipwright.io/docs/ref/api/build/.

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
