### PR TITLE
Correct expected value for source.type

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -138,7 +138,7 @@ The `Build` definition supports the following fields:
 
 A `Build` resource can specify a source type, such as a Git repository or an OCI artifact, together with other parameters like:
 
-- `source.type` - Specify the type of the data-source. Currently, the supported types are "Git", "OCIArtifact", and "Local".
+- `source.type` - Specify the type of the data-source. Currently, the supported types are "Git", "OCI", and "Local".
 - `source.git.url` - Specify the source location using a Git repository.
 - `source.git.cloneSecret` - For private repositories or registries, the name references a secret in the namespace that contains the SSH private key or Docker access credentials, respectively.
 - `source.git.revision` - A specific revision to select from the source repository, this can be a commit, tag or branch name. If not defined, it will fall back to the Git repository default branch.

--- a/pkg/validate/sources.go
+++ b/pkg/validate/sources.go
@@ -35,15 +35,15 @@ func (s *SourceRef) validateSourceEntry(source *build.Source) error {
 	}
 
 	switch source.Type {
-	case "Git":
+	case build.GitType:
 		if source.Git == nil || source.OCIArtifact != nil || source.Local != nil {
 			return fmt.Errorf("type does not match the source")
 		}
-	case "OCI":
+	case build.OCIArtifactType:
 		if source.OCIArtifact == nil || source.Git != nil || source.Local != nil {
 			return fmt.Errorf("type does not match the source")
 		}
-	case "Local":
+	case build.LocalType:
 		if source.Local == nil || source.OCIArtifact != nil || source.Git != nil {
 			return fmt.Errorf("type does not match the source")
 		}

--- a/pkg/validate/sources_test.go
+++ b/pkg/validate/sources_test.go
@@ -26,7 +26,7 @@ var _ = Describe("SourcesRef", func() {
 			srcRef := validate.NewSourceRef(&build.Build{
 				Spec: build.BuildSpec{
 					Source: &build.Source{
-						Type: "Git",
+						Type: build.GitType,
 						Git:  &build.Git{},
 					},
 				},
@@ -51,7 +51,7 @@ var _ = Describe("SourcesRef", func() {
 			srcRef := validate.NewSourceRef(&build.Build{
 				Spec: build.BuildSpec{
 					Source: &build.Source{
-						Type: "OCI",
+						Type: build.OCIArtifactType,
 						Git:  &build.Git{},
 					},
 				},


### PR DESCRIPTION
# Changes

While reviewing #1846, I noticed that the value we use for `.spec.source.type` is just [`OCI`](https://github.com/shipwright-io/build/blob/v0.15.0/pkg/apis/build/v1beta1/source.go#L24). I always assumed it is `OCIArtifact` - and that's also what the documentation had.

And while looking around in that context, I noticed that the validation code did not use the constants defined in the API package.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
