### PR TITLE
remove get,patch of CustomResourceDefinitions.

### DIFF
--- a/deploy/200-role.yaml
+++ b/deploy/200-role.yaml
@@ -82,7 +82,3 @@ rules:
 - apiGroups: ['']
   resources: ['serviceaccounts']
   verbs:     ['get', 'list', 'watch', 'create', 'update', 'delete']
-
-- apiGroups: ['apiextensions.k8s.io']
-  resources: ['customresourcedefinitions', 'customresourcedefinitions/status']
-  verbs:     ['get', 'patch']


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

`hack/storage-version-migration.sh script` is using permissions to patch CustomResourceDefinitions.
The needed permissions were added to the script and then deleted after the script is done executing.


Fixes #1789



# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
