### PR TITLE
Only cache pods and taskruns with the buildrun label

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,12 +7,18 @@ package controller
 import (
 	"context"
 
-	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+
 	"github.com/shipwright-io/build/pkg/apis"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/ctxlog"
 	"github.com/shipwright-io/build/pkg/reconciler/build"
@@ -25,6 +31,35 @@ import (
 
 // NewManager add all the controllers to the manager and register the required schemes
 func NewManager(ctx context.Context, config *config.Config, cfg *rest.Config, options manager.Options) (manager.Manager, error) {
+	// Setup a scheme
+	options.Scheme = k8sruntime.NewScheme()
+	if err := corev1.AddToScheme(options.Scheme); err != nil {
+		return nil, err
+	}
+	if err := pipelineapi.AddToScheme(options.Scheme); err != nil {
+		return nil, err
+	}
+	if err := apis.AddToScheme(options.Scheme); err != nil {
+		return nil, err
+	}
+
+	// Configure the cache
+	buildRunLabelExistsSelector, err := labels.Parse(buildv1beta1.LabelBuildRun)
+	if err != nil {
+		return nil, err
+	}
+
+	options.Cache = cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}: {
+				Label: buildRunLabelExistsSelector,
+			},
+			&pipelineapi.TaskRun{}: {
+				Label: buildRunLabelExistsSelector,
+			},
+		},
+	}
+
 	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		return nil, err
@@ -38,15 +73,6 @@ func NewManager(ctx context.Context, config *config.Config, cfg *rest.Config, op
 	}
 
 	ctxlog.Info(ctx, "Registering Components.")
-
-	if err := pipelineapi.AddToScheme(mgr.GetScheme()); err != nil {
-		return nil, err
-	}
-
-	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		return nil, err
-	}
 
 	// Add Reconcilers.
 	if err := build.Add(ctx, config, mgr); err != nil {


### PR DESCRIPTION
# Changes

When we create a TaskRun for a BuildRun, then we always add the `buildrun.shipwright.io/name` label. Tekton also applies this to the pod it creates.

This change configures the cache of our manager to only cache TaskRuns and Pods that have this label. This should bring down the memory usage of our controller a lot, especially when it runs in a cluster that is used for not just Shipwright and has many pods and maybe also taskruns which are not applicable. It may also improve startup time. In my local home cluster, "just" 391 pods and 258 taskruns in total where for each only 25 are BuildRun-related, the memory usage after startup went down from 33 MB to 20 MB.

I had to move up the scheme registration to before initializing the manager to pass it in as the manager needs it for the cache configuration.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Improve resource consumption by only caching shipwright-related taskruns and pods
```
