### PR TITLE
add securityContext of ReadOnlyRootFilesystem to steps

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,8 +187,9 @@ func NewDefaultConfig() *Config {
 						"ALL",
 					},
 				},
-				RunAsUser:  nonRoot,
-				RunAsGroup: nonRoot,
+				RunAsUser:              nonRoot,
+				RunAsGroup:             nonRoot,
+				ReadOnlyRootFilesystem: ptr.To(true),
 			},
 		},
 
@@ -215,8 +216,9 @@ func NewDefaultConfig() *Config {
 						"ALL",
 					},
 				},
-				RunAsUser:  nonRoot,
-				RunAsGroup: nonRoot,
+				RunAsUser:              nonRoot,
+				RunAsGroup:             nonRoot,
+				ReadOnlyRootFilesystem: ptr.To(true),
 			},
 		},
 
@@ -249,6 +251,7 @@ func NewDefaultConfig() *Config {
 						"ALL",
 					},
 				},
+				ReadOnlyRootFilesystem: ptr.To(true),
 			},
 		},
 
@@ -274,8 +277,9 @@ func NewDefaultConfig() *Config {
 						"ALL",
 					},
 				},
-				RunAsUser:  nonRoot,
-				RunAsGroup: nonRoot,
+				RunAsUser:              nonRoot,
+				RunAsGroup:             nonRoot,
+				ReadOnlyRootFilesystem: ptr.To(true),
 			},
 		},
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -142,8 +142,9 @@ var _ = Describe("Config", func() {
 								"ALL",
 							},
 						},
-						RunAsUser:  nonRoot,
-						RunAsGroup: nonRoot,
+						RunAsUser:              nonRoot,
+						RunAsGroup:             nonRoot,
+						ReadOnlyRootFilesystem: ptr.To(true),
 					},
 				}))
 			})
@@ -243,8 +244,9 @@ var _ = Describe("Config", func() {
 								"ALL",
 							},
 						},
-						RunAsUser:  nonRoot,
-						RunAsGroup: nonRoot,
+						RunAsUser:              nonRoot,
+						RunAsGroup:             nonRoot,
+						ReadOnlyRootFilesystem: ptr.To(true),
 					},
 				}))
 			})


### PR DESCRIPTION
# Changes

Explicitly set readOnlyRootFilesystem to true for taskruns according to security best practice.

# Submitter Checklist

- [ X ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
