### PR TITLE
add labels to isolate features in e2e tests

### DIFF
--- a/test/e2e/v1alpha1/e2e_bundle_test.go
+++ b/test/e2e/v1alpha1/e2e_bundle_test.go
@@ -23,7 +23,7 @@ import (
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 )
 
-var _ = Describe("Test local source code (bundle) functionality", func() {
+var _ = Describe("Test local source code (bundle) functionality", Label("LocalSource", "CORE"), func() {
 
 	insecure := false
 	value, found := os.LookupEnv(EnvVarImageRepoInsecure)
@@ -73,7 +73,7 @@ var _ = Describe("Test local source code (bundle) functionality", func() {
 			)
 		})
 
-		It("should work with Kaniko build strategy", func() {
+		It("should work with Kaniko build strategy", Label("Kaniko"),func() {
 			build, err = NewBuildPrototype().
 				ClusterBuildStrategy("kaniko").
 				Name(testID).
@@ -99,7 +99,7 @@ var _ = Describe("Test local source code (bundle) functionality", func() {
 			testBuild.ValidateImageDigest(buildRun)
 		})
 
-		It("should work with Buildpacks build strategy", func() {
+		It("should work with Buildpacks build strategy", Label("Buildpacks"),func() {
 			build, err = NewBuildPrototype().
 				ClusterBuildStrategy("buildpacks-v3").
 				Name(testID).
@@ -124,7 +124,7 @@ var _ = Describe("Test local source code (bundle) functionality", func() {
 			testBuild.ValidateImageDigest(buildRun)
 		})
 
-		It("should work with Buildah build strategy", func() {
+		It("should work with Buildah build strategy", Label("Buildah"),func() {
 			buildPrototype := NewBuildPrototype().
 				ClusterBuildStrategy("buildah-shipwright-managed-push").
 				Name(testID).

--- a/test/e2e/v1alpha1/e2e_image_mutate_test.go
+++ b/test/e2e/v1alpha1/e2e_image_mutate_test.go
@@ -66,7 +66,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when a Buildah build with label and annotation is defined", func() {
+	Context("when a Buildah build with label and annotation is defined", Label("ImageMutation", "Buildah", "CORE"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("buildah-mutate")
 
@@ -95,7 +95,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("mutate image timestamp", func() {
+	Context("mutate image timestamp", Label("ImageMutation", "CORE"), func() {
 		var outputImage name.Reference
 
 		var insecure = func() bool {
@@ -119,7 +119,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		Context("when using BuildKit based Dockerfile build", func() {
+		Context("when using BuildKit based Dockerfile build", Label("BuildKit"), func() {
 			var sampleBuildRun = func(outputTimestamp string) *buildv1alpha1.BuildRun {
 				return NewBuildRunPrototype().
 					Namespace(testBuild.Namespace).
@@ -165,7 +165,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when using Buildpacks build", func() {
+		Context("when using Buildpacks build", Label("Buildpacks"), func() {
 			var sampleBuildRun = func(outputTimestamp string) *buildv1alpha1.BuildRun {
 				return NewBuildRunPrototype().
 					Namespace(testBuild.Namespace).
@@ -211,7 +211,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("edge cases", func() {
+		Context("edge cases", Label("FailureCase"), func() {
 			It("should fail run a build run when source timestamp is used with an empty source", func() {
 				buildRun = NewBuildRunPrototype().
 					Namespace(testBuild.Namespace).

--- a/test/e2e/v1alpha1/e2e_local_source_upload_test.go
+++ b/test/e2e/v1alpha1/e2e_local_source_upload_test.go
@@ -35,7 +35,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when LocalCopy BuildSource is defined", func() {
+	Context("when LocalCopy BuildSource is defined", Label("LocalSource", "FailureCase"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("local-copy")
 			build = createBuild(

--- a/test/e2e/v1alpha1/e2e_one_off_builds_test.go
+++ b/test/e2e/v1alpha1/e2e_one_off_builds_test.go
@@ -16,7 +16,7 @@ import (
 	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
 )
 
-var _ = Describe("Using One-Off Builds", func() {
+var _ = Describe("Using One-Off Builds", Label("OneOffBuild"),  func() {
 
 	insecure := false
 	value, found := os.LookupEnv(EnvVarImageRepoInsecure)
@@ -61,7 +61,7 @@ var _ = Describe("Using One-Off Builds", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should build an image using Buildpacks and a Git source", func() {
+		It("should build an image using Buildpacks and a Git source", Label("Buildpacks", "GitSource"), func() {
 			buildRun, err = NewBuildRunPrototype().
 				Namespace(testBuild.Namespace).
 				Name(testID).
@@ -80,7 +80,7 @@ var _ = Describe("Using One-Off Builds", func() {
 			validateBuildRunToSucceed(testBuild, buildRun)
 		})
 
-		It("should build an image using Buildah and a Git source", func() {
+		It("should build an image using Buildah and a Git source", Label("Buildah", "GitSource"), func() {
 			buildRun, err = NewBuildRunPrototype().
 				Namespace(testBuild.Namespace).
 				Name(testID).
@@ -101,7 +101,7 @@ var _ = Describe("Using One-Off Builds", func() {
 			validateBuildRunToSucceed(testBuild, buildRun)
 		})
 
-		It("should build an image using Buildpacks and a bundle source", func() {
+		It("should build an image using Buildpacks and a bundle source", Label("Buildpacks", "LocalSource"), func() {
 			buildRun, err = NewBuildRunPrototype().
 				Namespace(testBuild.Namespace).
 				Name(testID).

--- a/test/e2e/v1alpha1/e2e_params_test.go
+++ b/test/e2e/v1alpha1/e2e_params_test.go
@@ -60,7 +60,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when using a cluster build strategy is used that uses a lot parameters", func() {
+	Context("when using a cluster build strategy is used that uses a lot parameters", Label("Params"), func() {
 		BeforeEach(func() {
 			buildStrategy, err = testBuild.Catalog.LoadBuildStrategyFromBytes([]byte(test.BuildStrategyWithParameterVerification))
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/v1alpha1/e2e_rbac_test.go
+++ b/test/e2e/v1alpha1/e2e_rbac_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("User RBAC for Shipwright", func() {
+var _ = Describe("User RBAC for Shipwright", Label("RBAC"), func() {
 
 	var ctx context.Context
 

--- a/test/e2e/v1alpha1/e2e_test.go
+++ b/test/e2e/v1alpha1/e2e_test.go
@@ -46,7 +46,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when a Buildah build is defined that is using shipwright-managed push", func() {
+	Context("when a Buildah build is defined that is using shipwright-managed push", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah")
@@ -70,7 +70,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildah build is defined that is using strategy-managed push", func() {
+	Context("when a Buildah build is defined that is using strategy-managed push", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah")
@@ -94,7 +94,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildah build with a contextDir and a custom Dockerfile name is defined", func() {
+	Context("when a Buildah build with a contextDir and a custom Dockerfile name is defined", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah-custom-context-dockerfile")
@@ -117,7 +117,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a heroku Buildpacks build is defined using a cluster strategy", func() {
+	Context("when a heroku Buildpacks build is defined using a cluster strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-heroku")
@@ -139,7 +139,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a heroku Buildpacks build is defined using a namespaced strategy", func() {
+	Context("when a heroku Buildpacks build is defined using a namespaced strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-heroku-namespaced")
@@ -166,7 +166,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined using a cluster strategy", func() {
+	Context("when a Buildpacks v3 build is defined using a cluster strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3")
@@ -189,7 +189,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined using a namespaced strategy", func() {
+	Context("when a Buildpacks v3 build is defined using a namespaced strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-namespaced")
@@ -215,7 +215,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a php runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a php runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-php")
@@ -237,7 +237,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a ruby runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a ruby runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-ruby")
@@ -259,7 +259,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a golang runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a golang runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-golang")
@@ -281,7 +281,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a golang runtime with `BP_GO_TARGETS` env", func() {
+	Context("when a Buildpacks v3 build is defined for a golang runtime with `BP_GO_TARGETS` env", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-golang")
 
@@ -302,7 +302,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a build uses the build-run-deletion annotation", func() {
+	Context("when a build uses the build-run-deletion annotation", Label("BuildRunDeletion"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-golang")
@@ -339,7 +339,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a java runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a java runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-java")
@@ -361,7 +361,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Kaniko build is defined to use public GitHub", func() {
+	Context("when a Kaniko build is defined to use public GitHub", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("kaniko")
@@ -384,7 +384,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Kaniko build with a Dockerfile that requires advanced permissions is defined", func() {
+	Context("when a Kaniko build with a Dockerfile that requires advanced permissions is defined", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("kaniko-advanced-dockerfile")
@@ -406,7 +406,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Kaniko build with a contextDir and a custom Dockerfile name is defined", func() {
+	Context("when a Kaniko build with a contextDir and a custom Dockerfile name is defined", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("kaniko-custom-context-dockerfile")
@@ -428,7 +428,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildkit build with a contextDir and a path to a Dockerfile is defined", func() {
+	Context("when a Buildkit build with a contextDir and a path to a Dockerfile is defined", Label("BuildKit", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildkit-custom-context")
@@ -460,7 +460,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a s2i build is defined", func() {
+	Context("when a s2i build is defined", Label("s2i", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("s2i")
@@ -483,7 +483,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a private source repository is used", func() {
+	Context("when a private source repository is used", Label("privaterepo"), func() {
 
 		BeforeEach(func() {
 			if os.Getenv(EnvVarEnablePrivateRepos) != "true" {
@@ -491,7 +491,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			}
 		})
 
-		Context("when a Buildah build is defined to use a private GitHub repository", func() {
+		Context("when a Buildah build is defined to use a private GitHub repository", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-github-buildah")
@@ -513,7 +513,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a Buildah build is defined to use a private GitLab repository", func() {
+		Context("when a Buildah build is defined to use a private GitLab repository", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-gitlab-buildah")
@@ -535,7 +535,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a Kaniko build is defined to use a private GitHub repository", func() {
+		Context("when a Kaniko build is defined to use a private GitHub repository", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-github-kaniko")
@@ -557,7 +557,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a Kaniko build is defined to use a private GitLab repository", func() {
+		Context("when a Kaniko build is defined to use a private GitLab repository", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-gitlab-kaniko")
@@ -579,7 +579,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a s2i build is defined to use a private GitHub repository", func() {
+		Context("when a s2i build is defined to use a private GitHub repository", Label("s2i", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-github-s2i")
@@ -602,7 +602,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a s2i build uses a non-existent git repository as source", func() {
+	Context("when a s2i build uses a non-existent git repository as source", Label("s2i", "FailureCase"), func() {
 		It("fails because of prompted authentication which surfaces the to the BuildRun", func() {
 			testID = generateTestID("s2i-failing")
 

--- a/test/e2e/v1beta1/e2e_image_mutate_test.go
+++ b/test/e2e/v1beta1/e2e_image_mutate_test.go
@@ -66,7 +66,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when a Buildah build with label and annotation is defined", func() {
+	Context("when a Buildah build with label and annotation is defined", Label("ImageMutation", "Buildah", "CORE"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("buildah-mutate")
 
@@ -95,7 +95,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("mutate image timestamp", func() {
+	Context("mutate image timestamp", Label("ImageMutation", "CORE"), func() {
 		var outputImage name.Reference
 
 		var insecure = func() bool {
@@ -119,7 +119,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		Context("when using BuildKit based Dockerfile build", func() {
+		Context("when using BuildKit based Dockerfile build", Label("BuildKit"), func() {
 			var sampleBuildRun = func(outputTimestamp string) *buildv1beta1.BuildRun {
 				return NewBuildRunPrototype().
 					Namespace(testBuild.Namespace).
@@ -165,7 +165,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when using Buildpacks build", func() {
+		Context("when using Buildpacks build", Label("Buildpacks"), func() {
 			var sampleBuildRun = func(outputTimestamp string) *buildv1beta1.BuildRun {
 				return NewBuildRunPrototype().
 					Namespace(testBuild.Namespace).
@@ -211,7 +211,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("edge cases", func() {
+		Context("edge cases", Label("FailureCase"), func() {
 			It("should fail run a build run when source timestamp is used with an empty source", func() {
 				buildRun = NewBuildRunPrototype().
 					Namespace(testBuild.Namespace).

--- a/test/e2e/v1beta1/e2e_local_source_upload_test.go
+++ b/test/e2e/v1beta1/e2e_local_source_upload_test.go
@@ -35,7 +35,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when LocalCopy BuildSource is defined", func() {
+	Context("when LocalCopy BuildSource is defined", Label("LocalSource", "FailureCase"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("local-copy")
 			build = createBuild(

--- a/test/e2e/v1beta1/e2e_ociartifact_test.go
+++ b/test/e2e/v1beta1/e2e_ociartifact_test.go
@@ -23,7 +23,7 @@ import (
 	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
-var _ = Describe("Test local source code (bundle) functionality", func() {
+var _ = Describe("Test local source code (bundle) functionality", Label("OCIArtifactSource"), func() {
 
 	insecure := false
 	value, found := os.LookupEnv(EnvVarImageRepoInsecure)
@@ -59,7 +59,7 @@ var _ = Describe("Test local source code (bundle) functionality", func() {
 		}
 	})
 
-	Context("when using local source code bundle images as input", func() {
+	Context("when using local source code bundle images as input", Label("LocalSource", "CORE"), func() {
 		var inputImage, outputImage string
 
 		BeforeEach(func() {
@@ -73,7 +73,7 @@ var _ = Describe("Test local source code (bundle) functionality", func() {
 			)
 		})
 
-		It("should work with Kaniko build strategy", func() {
+		It("should work with Kaniko build strategy", Label("Kaniko"), func() {
 			build, err = NewBuildPrototype().
 				ClusterBuildStrategy("kaniko").
 				Name(testID).
@@ -99,7 +99,7 @@ var _ = Describe("Test local source code (bundle) functionality", func() {
 			testBuild.ValidateImageDigest(buildRun)
 		})
 
-		It("should work with Buildpacks build strategy", func() {
+		It("should work with Buildpacks build strategy", Label("Buildpacks"), func() {
 			build, err = NewBuildPrototype().
 				ClusterBuildStrategy("buildpacks-v3").
 				Name(testID).
@@ -124,7 +124,7 @@ var _ = Describe("Test local source code (bundle) functionality", func() {
 			testBuild.ValidateImageDigest(buildRun)
 		})
 
-		It("should work with Buildah build strategy", func() {
+		It("should work with Buildah build strategy", Label("Buildah"), func() {
 			buildPrototype := NewBuildPrototype().
 				ClusterBuildStrategy("buildah-shipwright-managed-push").
 				Name(testID).

--- a/test/e2e/v1beta1/e2e_one_off_builds_test.go
+++ b/test/e2e/v1beta1/e2e_one_off_builds_test.go
@@ -16,7 +16,7 @@ import (
 	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
-var _ = Describe("Using One-Off Builds", func() {
+var _ = Describe("Using One-Off Builds", Label("OneOffBuild"), func() {
 
 	insecure := false
 	value, found := os.LookupEnv(EnvVarImageRepoInsecure)
@@ -61,7 +61,7 @@ var _ = Describe("Using One-Off Builds", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should build an image using Buildpacks and a Git source", func() {
+		It("should build an image using Buildpacks and a Git source", Label("Buildpacks", "GitSource"), func() {
 			buildRun, err = NewBuildRunPrototype().
 				Namespace(testBuild.Namespace).
 				Name(testID).
@@ -80,7 +80,7 @@ var _ = Describe("Using One-Off Builds", func() {
 			validateBuildRunToSucceed(testBuild, buildRun)
 		})
 
-		It("should build an image using Buildah and a Git source", func() {
+		It("should build an image using Buildah and a Git source", Label("Buildah", "GitSource"), func() {
 			buildRun, err = NewBuildRunPrototype().
 				Namespace(testBuild.Namespace).
 				Name(testID).
@@ -101,7 +101,7 @@ var _ = Describe("Using One-Off Builds", func() {
 			validateBuildRunToSucceed(testBuild, buildRun)
 		})
 
-		It("should build an image using Buildpacks and a ociArtifact source", func() {
+		It("should build an image using Buildpacks and a ociArtifact source", Label("Buildpacks", "OCIArtifactSource"), func() {
 			buildRun, err = NewBuildRunPrototype().
 				Namespace(testBuild.Namespace).
 				Name(testID).

--- a/test/e2e/v1beta1/e2e_params_test.go
+++ b/test/e2e/v1beta1/e2e_params_test.go
@@ -60,7 +60,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when using a cluster build strategy is used that uses a lot parameters", func() {
+	Context("when using a cluster build strategy is used that uses a lot parameters", Label("Params"), func() {
 		BeforeEach(func() {
 			buildStrategy, err = testBuild.Catalog.LoadBuildStrategyFromBytes([]byte(test.BuildStrategyWithParameterVerification))
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/v1beta1/e2e_rbac_test.go
+++ b/test/e2e/v1beta1/e2e_rbac_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("User RBAC for Shipwright", func() {
+var _ = Describe("User RBAC for Shipwright", Label("RBAC"), func() {
 
 	var ctx context.Context
 

--- a/test/e2e/v1beta1/e2e_test.go
+++ b/test/e2e/v1beta1/e2e_test.go
@@ -48,7 +48,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		}
 	})
 
-	Context("when a Buildah build is defined that is using shipwright-managed push", func() {
+	Context("when a Buildah build is defined that is using shipwright-managed push", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah")
@@ -72,7 +72,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildah build is defined that is using strategy-managed push", func() {
+	Context("when a Buildah build is defined that is using strategy-managed push", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah")
@@ -96,7 +96,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildah build with a contextDir and a custom Dockerfile name is defined", func() {
+	Context("when a Buildah build with a contextDir and a custom Dockerfile name is defined", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah-custom-context-dockerfile")
@@ -119,7 +119,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a BuildAh build runs with a custom target stage", func() {
+	Context("when a Buildah build runs with a custom target stage", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah-custom-target-stage")
@@ -141,7 +141,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a heroku Buildpacks build is defined using a cluster strategy", func() {
+	Context("when a heroku Buildpacks build is defined using a cluster strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-heroku")
@@ -163,7 +163,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a heroku Buildpacks build is defined using a namespaced strategy", func() {
+	Context("when a heroku Buildpacks build is defined using a namespaced strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-heroku-namespaced")
 
@@ -189,7 +189,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined using a cluster strategy", func() {
+	Context("when a Buildpacks v3 build is defined using a cluster strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3")
@@ -212,7 +212,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined using a namespaced strategy", func() {
+	Context("when a Buildpacks v3 build is defined using a namespaced strategy", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-namespaced")
@@ -238,7 +238,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a php runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a php runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-php")
@@ -260,7 +260,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a ruby runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a ruby runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-ruby")
@@ -282,7 +282,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a golang runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a golang runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-golang")
@@ -304,7 +304,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a golang runtime with `BP_GO_TARGETS` env", func() {
+	Context("when a Buildpacks v3 build is defined for a golang runtime with `BP_GO_TARGETS` env", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-golang")
 
@@ -325,7 +325,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a build uses the build-run-deletion annotation", func() {
+	Context("when a build uses the build-run-deletion annotation", Label("BuildRunDeletion"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-golang")
@@ -362,7 +362,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildpacks v3 build is defined for a java runtime", func() {
+	Context("when a Buildpacks v3 build is defined for a java runtime", Label("Buildpacks", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildpacks-v3-java")
@@ -384,7 +384,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Kaniko build is defined to use public GitHub", func() {
+	Context("when a Kaniko build is defined to use public GitHub", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("kaniko")
@@ -407,7 +407,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Kaniko build with a Dockerfile that requires advanced permissions is defined", func() {
+	Context("when a Kaniko build with a Dockerfile that requires advanced permissions is defined", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("kaniko-advanced-dockerfile")
@@ -429,7 +429,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Kaniko build with a contextDir and a custom Dockerfile name is defined", func() {
+	Context("when a Kaniko build with a contextDir and a custom Dockerfile name is defined", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("kaniko-custom-context-dockerfile")
@@ -451,7 +451,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Kaniko build runs with a custom target stage", func() {
+	Context("when a Kaniko build runs with a custom target stage", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("kaniko-custom-target-stage")
@@ -473,7 +473,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Buildkit build with a contextDir and a path to a Dockerfile is defined", func() {
+	Context("when a Buildkit build with a contextDir and a path to a Dockerfile is defined", Label("BuildKit", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildkit-custom-context")
@@ -505,7 +505,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a BuildKit build runs with a custom target stage", func() {
+	Context("when a BuildKit build runs with a custom target stage", Label("BuildKit", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildkit-custom-target-stage")
@@ -527,7 +527,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a Multiarch Native Buildah build is defined", func() {
+	Context("when a Multiarch Native Buildah build is defined", Label("Buildah", "MultiArch", "CORE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("buildah-multi-arch-native")
@@ -546,7 +546,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			buildRun = validateBuildRunToSucceed(testBuild, buildRun)
 		})
 	})
-	Context("when a s2i build is defined", func() {
+	Context("when a s2i build is defined", Label("s2i", "CORE", "SAMPLE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("s2i")
@@ -569,7 +569,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a private source repository is used", func() {
+	Context("when a private source repository is used", Label("privaterepo"), func() {
 
 		BeforeEach(func() {
 			if os.Getenv(EnvVarEnablePrivateRepos) != "true" {
@@ -577,7 +577,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			}
 		})
 
-		Context("when a Buildah build is defined to use a private GitHub repository", func() {
+		Context("when a Buildah build is defined to use a private GitHub repository", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-github-buildah")
@@ -599,7 +599,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a Buildah build is defined to use a private GitLab repository", func() {
+		Context("when a Buildah build is defined to use a private GitLab repository", Label("Buildah", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-gitlab-buildah")
@@ -621,7 +621,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a Kaniko build is defined to use a private GitHub repository", func() {
+		Context("when a Kaniko build is defined to use a private GitHub repository", Label("Kaniko", "CORE", "SAMPLE"),func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-github-kaniko")
@@ -643,7 +643,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a Kaniko build is defined to use a private GitLab repository", func() {
+		Context("when a Kaniko build is defined to use a private GitLab repository", Label("Kaniko", "CORE", "SAMPLE"), func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-gitlab-kaniko")
@@ -665,7 +665,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 			})
 		})
 
-		Context("when a s2i build is defined to use a private GitHub repository", func() {
+		Context("when a s2i build is defined to use a private GitHub repository", Label("s2i", "CORE", "SAMPLE"),func() {
 
 			BeforeEach(func() {
 				testID = generateTestID("private-github-s2i")
@@ -688,7 +688,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when a s2i build uses a non-existent git repository as source", func() {
+	Context("when a s2i build uses a non-existent git repository as source", Label("s2i", "FailureCase"), func() {
 		It("fails because of prompted authentication which surfaces the to the BuildRun", func() {
 			testID = generateTestID("s2i-failing")
 
@@ -709,7 +709,7 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		})
 	})
 
-	Context("when tolerations are specified", Serial, func() {
+	Context("when tolerations are specified", Serial, Label("Tolerations"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("tolerations")

--- a/test/e2e/v1beta1/e2e_vulnerability_scanning_test.go
+++ b/test/e2e/v1beta1/e2e_vulnerability_scanning_test.go
@@ -18,7 +18,7 @@ import (
 	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
-var _ = Describe("Vulnerability Scanning", func() {
+var _ = Describe("Vulnerability Scanning", Label("VulnerabilityScanning"),func() {
 	var testID string
 	var err error
 	var buildRun *buildapi.BuildRun
@@ -29,7 +29,7 @@ var _ = Describe("Vulnerability Scanning", func() {
 		testBuild.DeleteBR(buildRun.Name)
 	})
 
-	Context("Scanning for vulnerabilities in container images", func() {
+	Context("Scanning for vulnerabilities in container images", Label("FailureCase"),func() {
 		var outputImage string
 		BeforeEach(func() {
 			testID = generateTestID("vuln")


### PR DESCRIPTION
# Changes

Added Ginkgo labels to isolate features in e2e tests
*   The tests labeled `CORE` cover a wide range of functionalities, including different build strategies (Buildah, Kaniko, etc.), source types (Git, local bundle), image mutation, and interactions with repository types.

*  The tests labeled `SAMPLE` cover the samples (illustrative manifest files (YAML) designed to help users understand how to define `Build`, `BuildRun`, `BuildStrategy`, resources) we have in the /samples directory 

Fixes #1451 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
