### PR TITLE
WIP: Refactor TaskRuns out of BuildRun Controller

### DIFF
--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -51,6 +51,7 @@ type ReconcileBuildRun struct {
 	client                client.Client
 	scheme                *runtime.Scheme
 	setOwnerReferenceFunc setOwnerReferenceFunc
+	taskRunnerFactory     ImageBuildRunnerFactory
 }
 
 // NewReconciler returns a new reconcile.Reconciler
@@ -60,6 +61,7 @@ func NewReconciler(c *config.Config, mgr manager.Manager, ownerRef setOwnerRefer
 		client:                mgr.GetClient(),
 		scheme:                mgr.GetScheme(),
 		setOwnerReferenceFunc: ownerRef,
+		taskRunnerFactory:     &TektonTaskRunImageBuildRunnerFactory{},
 	}
 }
 
@@ -81,8 +83,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 	// so we can no longer assume that a build run event will not come in after the build run has a task run ref in its status
 	buildRun = &buildv1beta1.BuildRun{}
 	getBuildRunErr := r.GetBuildRunObject(ctx, request.Name, request.Namespace, buildRun)
-	lastTaskRun := &pipelineapi.TaskRun{}
-	getTaskRunErr := r.client.Get(ctx, types.NamespacedName{Name: request.Name, Namespace: request.Namespace}, lastTaskRun)
+	lastTaskRun, getTaskRunErr := r.taskRunnerFactory.GetImageBuildRunner(ctx, r.client, types.NamespacedName{Name: request.Name, Namespace: request.Namespace})
 
 	if getBuildRunErr != nil && getTaskRunErr != nil {
 		if !apierrors.IsNotFound(getBuildRunErr) {
@@ -125,7 +126,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 
 	// if this is a build run event after we've set the task run ref, get the task run using the task run name stored in the build run
 	if getBuildRunErr == nil && apierrors.IsNotFound(getTaskRunErr) && buildRun.Status.TaskRunName != nil {
-		getTaskRunErr = r.client.Get(ctx, types.NamespacedName{Name: *buildRun.Status.TaskRunName, Namespace: request.Namespace}, lastTaskRun)
+		lastTaskRun, getTaskRunErr = r.taskRunnerFactory.GetImageBuildRunner(ctx, r.client, types.NamespacedName{Name: *buildRun.Status.TaskRunName, Namespace: request.Namespace})
 	}
 
 	// for existing TaskRuns update the BuildRun Status, if there is no TaskRun, then create one
@@ -389,12 +390,15 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 			return reconcile.Result{}, getBuildRunErr
 		} else if apierrors.IsNotFound(getBuildRunErr) {
 			// this is a TR event, try getting the br from the label on the tr
-			err := r.GetBuildRunObject(ctx, lastTaskRun.Labels[buildv1beta1.LabelBuildRun], request.Namespace, buildRun)
-			if err != nil && !apierrors.IsNotFound(err) {
-				return reconcile.Result{}, err
-			}
-			if err != nil && apierrors.IsNotFound(err) {
-				return reconcile.Result{}, nil
+			labels := lastTaskRun.GetLabels()
+			if labels != nil {
+				err := r.GetBuildRunObject(ctx, labels[buildv1beta1.LabelBuildRun], request.Namespace, buildRun)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return reconcile.Result{}, err
+				}
+				if err != nil && apierrors.IsNotFound(err) {
+					return reconcile.Result{}, nil
+				}
 			}
 		}
 
@@ -402,7 +406,10 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 			ctxlog.Info(ctx, "buildRun marked for cancellation, patching task run", namespace, request.Namespace, name, request.Name)
 			// patch tekton taskrun a la tkn to start tekton's cancelling logic
 			trueParam := true
-			if err := r.patchTaskRun(ctx, lastTaskRun, "replace", "/spec/status", pipelineapi.TaskRunSpecStatusCancelled, metav1.PatchOptions{Force: &trueParam}); err != nil {
+			// For now, we patch the TaskRun directly.
+			// TODO: We should use the ImageBuildRunnerFactory to patch the TaskRun.
+			taskRunObj := lastTaskRun.GetObject().(*pipelineapi.TaskRun)
+			if err := r.patchTaskRun(ctx, taskRunObj, "replace", "/spec/status", pipelineapi.TaskRunSpecStatusCancelled, metav1.PatchOptions{Force: &trueParam}); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
@@ -416,18 +423,22 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 			return reconcile.Result{}, nil
 		}
 
-		if len(lastTaskRun.Status.Results) > 0 {
+		taskRunResults := lastTaskRun.GetResults()
+		if len(taskRunResults) > 0 {
 			ctxlog.Info(ctx, "surfacing taskRun results to BuildRun status", namespace, request.Namespace, name, request.Name)
-			resources.UpdateBuildRunUsingTaskResults(ctx, buildRun, lastTaskRun.Status.Results, request)
+			resources.UpdateBuildRunUsingTaskResults(ctx, buildRun, taskRunResults, request)
 		}
 
-		trCondition := lastTaskRun.Status.GetCondition(apis.ConditionSucceeded)
+		trCondition := lastTaskRun.GetCondition(apis.ConditionSucceeded)
 		if trCondition != nil {
-			if err := resources.UpdateBuildRunUsingTaskRunCondition(ctx, r.client, buildRun, lastTaskRun, trCondition); err != nil {
+			// For now, pass the underlying TaskRun object to maintain compatibility
+			// TODO: Update resources functions to work with interface
+			taskRunObj := lastTaskRun.GetObject().(*pipelineapi.TaskRun)
+			if err := resources.UpdateBuildRunUsingTaskRunCondition(ctx, r.client, buildRun, taskRunObj, trCondition); err != nil {
 				return reconcile.Result{}, err
 			}
 
-			resources.UpdateBuildRunUsingTaskFailures(ctx, r.client, buildRun, lastTaskRun)
+			resources.UpdateBuildRunUsingTaskFailures(ctx, r.client, buildRun, taskRunObj)
 			taskRunStatus := trCondition.Status
 
 			// check if we should delete the generated service account by checking the build run spec and that the task run is complete
@@ -438,10 +449,12 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				}
 			}
 
-			buildRun.Status.TaskRunName = &lastTaskRun.Name
+			taskRunName := lastTaskRun.GetName()
+			buildRun.Status.TaskRunName = &taskRunName
 
-			if buildRun.Status.StartTime == nil && lastTaskRun.Status.StartTime != nil {
-				buildRun.Status.StartTime = lastTaskRun.Status.StartTime
+			taskRunStartTime := lastTaskRun.GetStartTime()
+			if buildRun.Status.StartTime == nil && taskRunStartTime != nil {
+				buildRun.Status.StartTime = taskRunStartTime
 
 				// Report the buildrun established duration (time between the creation of the buildrun and the start of the buildrun)
 				buildmetrics.BuildRunEstablishObserve(
@@ -453,8 +466,8 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				)
 			}
 
-			if lastTaskRun.Status.CompletionTime != nil && buildRun.Status.CompletionTime == nil {
-				buildRun.Status.CompletionTime = lastTaskRun.Status.CompletionTime
+			if lastTaskRun.GetCompletionTime() != nil && buildRun.Status.CompletionTime == nil {
+				buildRun.Status.CompletionTime = lastTaskRun.GetCompletionTime()
 
 				// buildrun completion duration (total time between the creation of the buildrun and the buildrun completion)
 				buildmetrics.BuildRunCompletionObserve(
@@ -467,7 +480,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 
 				// Look for the pod created by the taskrun
 				var pod = &corev1.Pod{}
-				if err := r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: lastTaskRun.Status.PodName}, pod); err == nil {
+				if err := r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: lastTaskRun.GetPodName()}, pod); err == nil {
 					if len(pod.Status.InitContainerStatuses) > 0 {
 
 						lastInitPodIdx := len(pod.Status.InitContainerStatuses) - 1
@@ -491,7 +504,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 						buildRun.Namespace,
 						buildRun.Spec.BuildName(),
 						buildRun.Name,
-						pod.CreationTimestamp.Time.Sub(lastTaskRun.CreationTimestamp.Time),
+						pod.CreationTimestamp.Time.Sub(lastTaskRun.GetCreationTimestamp().Time),
 					)
 				}
 			}

--- a/pkg/reconciler/buildrun/imagebuildrunner.go
+++ b/pkg/reconciler/buildrun/imagebuildrunner.go
@@ -1,0 +1,188 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package buildrun
+
+import (
+	"context"
+	"fmt"
+
+	pipelineapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"knative.dev/pkg/apis"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+	"github.com/shipwright-io/build/pkg/config"
+	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
+)
+
+// ImageBuildRunner defines an interface for building a container image.
+type ImageBuildRunner interface {
+	// GetName returns the name of the build runner.
+	GetName() string
+	// GetLabels returns the labels of the build runner.
+	GetLabels() map[string]string
+	// GetCreationTimestamp returns the creation timestamp of the build runner.
+	GetCreationTimestamp() metav1.Time
+	// GetResults returns the results of the build runner.
+	GetResults() []pipelineapi.TaskRunResult
+	// GetCondition returns the condition of the build runner.
+	GetCondition(conditionType apis.ConditionType) *apis.Condition
+	// GetStartTime returns the start time of the build runner.
+	GetStartTime() *metav1.Time
+	// GetCompletionTime returns the completion time of the build runner.
+	GetCompletionTime() *metav1.Time
+	// GetPodName returns the pod name of the build runner.
+	GetPodName() string
+	// IsCancelled returns true if the build runner is cancelled.
+	IsCancelled() bool
+	// GetObject returns the underlying client.Object for owner reference operations.
+	GetObject() client.Object
+}
+
+// ImageBuildRunnerFactory defines methods for creating and manipulating ImageBuildRunners.
+type ImageBuildRunnerFactory interface {
+	// NewImageBuildRunner creates a new empty ImageBuildRunner.
+	NewImageBuildRunner() ImageBuildRunner
+
+	// CreateImageBuildRunner creates an ImageBuildRunner instance from build configuration. It does not create the ImageBuildRunner in the API server.
+	CreateImageBuildRunner(ctx context.Context, cfg *config.Config, serviceAccount *corev1.ServiceAccount, strategy buildv1beta1.BuilderStrategy, build *buildv1beta1.Build, buildRun *buildv1beta1.BuildRun, scheme *runtime.Scheme, setOwnerRef setOwnerReferenceFunc) (ImageBuildRunner, error)
+
+	// GetImageBuildRunner retrieves an ImageBuildRunner from the API server.
+	GetImageBuildRunner(ctx context.Context, client client.Client, namespacedName types.NamespacedName) (ImageBuildRunner, error)
+
+	// CreateImageBuildRunnerInCluster creates the ImageBuildRunner in the API server.
+	CreateImageBuildRunnerInCluster(ctx context.Context, client client.Client, taskRunner ImageBuildRunner) error
+}
+
+// TektonTaskRunWrapper wraps pipelineapi.TaskRun to implement the ImageBuildRunner interface.
+type TektonTaskRunWrapper struct {
+	TaskRun *pipelineapi.TaskRun
+}
+
+// GetName returns the name of the TaskRun
+func (t *TektonTaskRunWrapper) GetName() string {
+	if t.TaskRun == nil {
+		return ""
+	}
+	return t.TaskRun.Name
+}
+
+// GetLabels returns the labels of the TaskRun
+func (t *TektonTaskRunWrapper) GetLabels() map[string]string {
+	if t.TaskRun == nil {
+		return nil
+	}
+	return t.TaskRun.Labels
+}
+
+// GetCreationTimestamp returns the creation timestamp of the TaskRun
+func (t *TektonTaskRunWrapper) GetCreationTimestamp() metav1.Time {
+	if t.TaskRun == nil {
+		return metav1.Time{}
+	}
+	return t.TaskRun.CreationTimestamp
+}
+
+// GetResults returns the TaskRun results
+func (t *TektonTaskRunWrapper) GetResults() []pipelineapi.TaskRunResult {
+	if t.TaskRun == nil {
+		return nil
+	}
+	return t.TaskRun.Status.Results
+}
+
+// GetCondition returns the condition with the specified type
+func (t *TektonTaskRunWrapper) GetCondition(conditionType apis.ConditionType) *apis.Condition {
+	if t.TaskRun == nil {
+		return nil
+	}
+	return t.TaskRun.Status.GetCondition(conditionType)
+}
+
+// GetStartTime returns the start time of the TaskRun
+func (t *TektonTaskRunWrapper) GetStartTime() *metav1.Time {
+	if t.TaskRun == nil {
+		return nil
+	}
+	return t.TaskRun.Status.StartTime
+}
+
+// GetCompletionTime returns the completion time of the TaskRun
+func (t *TektonTaskRunWrapper) GetCompletionTime() *metav1.Time {
+	if t.TaskRun == nil {
+		return nil
+	}
+	return t.TaskRun.Status.CompletionTime
+}
+
+// GetPodName returns the pod name of the TaskRun
+func (t *TektonTaskRunWrapper) GetPodName() string {
+	if t.TaskRun == nil {
+		return ""
+	}
+	return t.TaskRun.Status.PodName
+}
+
+// IsCancelled returns true if the TaskRun is cancelled
+func (t *TektonTaskRunWrapper) IsCancelled() bool {
+	if t.TaskRun == nil {
+		return false
+	}
+	return t.TaskRun.IsCancelled()
+}
+
+// GetObject returns the underlying client.Object for owner reference operations
+func (t *TektonTaskRunWrapper) GetObject() client.Object {
+	return t.TaskRun
+}
+
+// TektonTaskRunImageBuildRunnerFactory implements ImageBuildRunnerFactory for Tekton TaskRuns
+type TektonTaskRunImageBuildRunnerFactory struct{}
+
+// NewImageBuildRunner creates a new empty TaskRunner
+func (f *TektonTaskRunImageBuildRunnerFactory) NewImageBuildRunner() ImageBuildRunner {
+	return &TektonTaskRunWrapper{
+		TaskRun: &pipelineapi.TaskRun{},
+	}
+}
+
+// CreateImageBuildRunner creates an ImageBuildRunner instance from build configuration. It does not create the ImageBuildRunner in the API server.
+func (f *TektonTaskRunImageBuildRunnerFactory) CreateImageBuildRunner(ctx context.Context, cfg *config.Config, serviceAccount *corev1.ServiceAccount, strategy buildv1beta1.BuilderStrategy, build *buildv1beta1.Build, buildRun *buildv1beta1.BuildRun, scheme *runtime.Scheme, setOwnerRef setOwnerReferenceFunc) (ImageBuildRunner, error) {
+	generatedTaskRun, err := resources.GenerateTaskRun(cfg, build, buildRun, serviceAccount.Name, strategy)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set OwnerReference for BuildRun and TaskRun
+	if err := setOwnerRef(buildRun, generatedTaskRun, scheme); err != nil {
+		return nil, err
+	}
+
+	return &TektonTaskRunWrapper{TaskRun: generatedTaskRun}, nil
+}
+
+// GetImageBuildRunner retrieves an ImageBuildRunner from the API server.
+func (f *TektonTaskRunImageBuildRunnerFactory) GetImageBuildRunner(ctx context.Context, client client.Client, namespacedName types.NamespacedName) (ImageBuildRunner, error) {
+	taskRun := &pipelineapi.TaskRun{}
+	err := client.Get(ctx, namespacedName, taskRun)
+	if err != nil {
+		return nil, err
+	}
+	return &TektonTaskRunWrapper{TaskRun: taskRun}, nil
+}
+
+// CreateImageBuildRunnerInCluster creates an ImageBuildRunner in the API server.
+func (f *TektonTaskRunImageBuildRunnerFactory) CreateImageBuildRunnerInCluster(ctx context.Context, client client.Client, taskRunner ImageBuildRunner) error {
+	wrapper, ok := taskRunner.(*TektonTaskRunWrapper)
+	if !ok {
+		return fmt.Errorf("unsupported TaskRunner type")
+	}
+	return client.Create(ctx, wrapper.TaskRun)
+}


### PR DESCRIPTION
# Changes

Initial effort to abstract concrete usage of Tekton TaskRuns out of the BuildRun controller. This includes the creation of new a new interface (ImageBuildRunner), factories for converting TaskRuns to ImageBuildRunners, and updates to controller code.

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
