### PR TITLE
feat: Reduce CI Test Matrix Cardinality

### DIFF
--- a/.github/bump-tekton-lts.sh
+++ b/.github/bump-tekton-lts.sh
@@ -62,7 +62,7 @@ go mod vendor
 popd >/dev/null
 
 # Update ci.yml
-sed -i "s/- v.* # RETAIN-COMMENT: TEKTON_NEWEST_LTS/- ${NEW_VERSION} # RETAIN-COMMENT: TEKTON_NEWEST_LTS/" "${BASEDIR}/.github/workflows/ci.yml"
+sed -i "s/tekton: v.* # RETAIN-COMMENT: TEKTON_NEWEST_LTS/tekton: ${NEW_VERSION} # RETAIN-COMMENT: TEKTON_NEWEST_LTS/" "${BASEDIR}/.github/workflows/ci.yml"
 
 # Update Makefile
 sed -i "s/TEKTON_VERSION ?= v.*/TEKTON_VERSION ?= ${NEW_VERSION}/" "${BASEDIR}/Makefile"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,8 @@
+# Primary CI workflow for unit, integration, and e2e tests.
+#
+# Note: The `bump-tekton-lts.sh` script relies on the RETAIN-COMMENT comment being present. Take
+# care to ensure this comment is not removed.
+
 name: Unit, Integration, and E2E Tests
 on:
   pull_request:
@@ -71,14 +76,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes:
-          - v1.30.10
-          - v1.33.0
-        tekton:
-          # oldest LTS that exists at the time of our planned next release
-          - v0.62.9
-          # newest LTS that exists at the time of our planned next release
-          - v1.0.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
+        compat:
+          # oldest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
+          - kubernetes: v1.30.10
+            tekton: v0.62.9
+          # newest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
+          - kubernetes: v1.33.0
+            tekton: v1.0.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
     runs-on: ubuntu-latest
     steps:
@@ -97,12 +101,12 @@ jobs:
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
         with:
-          version: ${{ matrix.kubernetes }}
+          version: ${{ matrix.compat.kubernetes }}
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
           version: v0.27.0
-          node_image: kindest/node:${{ matrix.kubernetes }}
+          node_image: kindest/node:${{ matrix.compat.kubernetes }}
           cluster_name: kind
           wait: 120s
       - name: Verify kind cluster
@@ -126,7 +130,7 @@ jobs:
           fi
       - name: Install Tekton
         env:
-          TEKTON_VERSION: ${{ matrix.tekton }}
+          TEKTON_VERSION: ${{ matrix.compat.tekton }}
         run: |
           make kind-tekton
           if ! kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-controller --timeout=3m; then
@@ -151,14 +155,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes:
-          - v1.30.10
-          - v1.33.0
-        tekton:
-          # oldest LTS that exists at the time of our planned next release
-          - v0.62.9
-          # newest LTS that exists at the time of our planned next release
-          - v1.0.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
+        compat:
+          # oldest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
+          - kubernetes: v1.30.10
+            tekton: v0.62.9
+          # newest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
+          - kubernetes: v1.33.0
+            tekton: v1.0.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
     runs-on: ubuntu-latest-16-cores
     steps:
@@ -173,12 +176,12 @@ jobs:
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
         with:
-          version: ${{ matrix.kubernetes }}
+          version: ${{ matrix.compat.kubernetes }}
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
           version: v0.27.0
-          node_image: kindest/node:${{ matrix.kubernetes }}
+          node_image: kindest/node:${{ matrix.compat.kubernetes }}
           cluster_name: kind
           config: test/kind/config_three_node.yaml
           wait: 120s
@@ -206,7 +209,7 @@ jobs:
           done
       - name: Install Tekton
         env:
-          TEKTON_VERSION: ${{ matrix.tekton }}
+          TEKTON_VERSION: ${{ matrix.compat.tekton }}
         run: |
           make kind-tekton
           if ! kubectl -n tekton-pipelines rollout status deployment tekton-pipelines-controller --timeout=3m; then


### PR DESCRIPTION
# Changes

Replaced separate Kubernetes and Tekton version matrices with a single compatibility matrix in the CI configuration. This change reduces our test matrix from 4 runs to 2 for the integration and e2e test suites, skipping configurations that are less likely to be run by end users.

/kind cleanup

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

