### PR TITLE
feat: Update controller image to ubi10

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,7 +1,7 @@
-defaultBaseImage: registry.access.redhat.com/ubi9/ubi-minimal
+defaultBaseImage: registry.access.redhat.com/ubi10/ubi-minimal
 
 baseImageOverrides:
-  github.com/shipwright-io/build/cmd/bundle: ghcr.io/shipwright-io/base-base:latest
-  github.com/shipwright-io/build/cmd/git: ghcr.io/shipwright-io/base-git:latest
-  github.com/shipwright-io/build/cmd/image-processing: ghcr.io/shipwright-io/base-image-processing:latest
-  github.com/shipwright-io/build/cmd/waiter: ghcr.io/shipwright-io/base-waiter:latest
+  github.com/shipwright-io/build/cmd/bundle: ghcr.io/shipwright-io/base-base:ubi10
+  github.com/shipwright-io/build/cmd/git: ghcr.io/shipwright-io/base-git:ubi10
+  github.com/shipwright-io/build/cmd/image-processing: ghcr.io/shipwright-io/base-image-processing:ubi10
+  github.com/shipwright-io/build/cmd/waiter: ghcr.io/shipwright-io/base-waiter:ubi10


### PR DESCRIPTION
# Changes

 [`.ko.yaml`](diffhunk://#diff-a4f2ae2e878c4ea5e68c38199b536fac0de1b097db8c23a887d0d0fb65028a7bL1-R7): Changed `defaultBaseImage` from `ubi9/ubi-minimal` to `ubi10/ubi-minimal`, and updated `baseImageOverrides` to use `ubi10` tags for all components (`bundle`, `git`, `image-processing`, and `waiter`).

Fixes #1903 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has beenThis pull request updates the `.ko.yaml` file to use a newer base image (`ubi10`) and adjusts the image overrides accordingly to ensure compatibility.

# Release Notes

```release-note
All Shipwright container images are now built with Redhat Universal Base Image 10 as a base, was version 9 before
```
