### PR TITLE
Tweak `check-latest-images.yaml` to use authenticated call

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Check and modify ${{ matrix.image }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE: ${{ matrix.image }}
           LATEST_RELEASE_URL: ${{ matrix.latest-release-url }}
         run: |


### PR DESCRIPTION
# Changes

Fix `validate` call to fail if no args are given.

Add check to verify that the release isn't `null`.

Add conditional authenticated call to GitHub API.

Fix indentation in script to match common style.

"Fixes" #1942


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
