### PR TITLE
Remove `""` from required fields

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -2433,7 +2433,6 @@ spec:
                           - volumePath
                           type: object
                       required:
-                      - ""
                       - name
                       type: object
                     type: array
@@ -4566,7 +4565,6 @@ spec:
                       - volumePath
                       type: object
                   required:
-                  - ""
                   - name
                   type: object
                 type: array
@@ -6927,7 +6925,6 @@ spec:
                           - volumePath
                           type: object
                       required:
-                      - ""
                       - name
                       type: object
                     type: array
@@ -9499,7 +9496,6 @@ spec:
                               - volumePath
                               type: object
                           required:
-                          - ""
                           - name
                           type: object
                         type: array
@@ -11694,7 +11690,6 @@ spec:
                       - volumePath
                       type: object
                   required:
-                  - ""
                   - name
                   type: object
                 type: array
@@ -14063,7 +14058,6 @@ spec:
                           - volumePath
                           type: object
                       required:
-                      - ""
                       - name
                       type: object
                     type: array

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -2406,7 +2406,6 @@ spec:
                       - volumePath
                       type: object
                   required:
-                  - ""
                   - name
                   type: object
                 type: array
@@ -4831,7 +4830,6 @@ spec:
                       - volumePath
                       type: object
                   required:
-                  - ""
                   - name
                   type: object
                 type: array

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -205,7 +205,7 @@ type BuildVolume struct {
 	Description *string `json:"description,omitempty"`
 
 	// Represents the source of a volume to mount
-	// +required
+	// +optional
 	corev1.VolumeSource `json:",inline"`
 }
 

--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -205,7 +205,7 @@ type BuildVolume struct {
 	Name string `json:"name"`
 
 	// Represents the source of a volume to mount
-	// +required
+	// +optional
 	corev1.VolumeSource `json:",inline"`
 }
 


### PR DESCRIPTION
# Changes



Seems v0.16 of added ""  as a required value by mistake to some objects in the buildrun and build crd. This wasnt in v0.15 which created volume creating issues.

Fixes: #1947 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
