### PR TITLE
Add volume for trivy

### DIFF
--- a/pkg/reconciler/buildrun/resources/sources/utils.go
+++ b/pkg/reconciler/buildrun/resources/sources/utils.go
@@ -5,6 +5,7 @@
 package sources
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"regexp"
 	"strings"
@@ -86,4 +87,101 @@ func FindResultValue(results []pipelineapi.TaskRunResult, sourceName, resultName
 	}
 
 	return ""
+}
+
+// AppendWriteableVolumes configures writable volumes for a specific step in a Tekton Task.
+// It ensures that these volumes are not shared with other steps in the same pod.
+func AppendWriteableVolumes(
+	taskSpec *pipelineapi.TaskSpec,
+	targetStep *pipelineapi.Step,
+) {
+	// Define a custom, isolated path for temporary files and mount it.
+	tmpDir := "/shp-tmp"
+	addStepEmptyDirVolume(
+		taskSpec,
+		targetStep,
+		generateVolumeName("shp-tmp-", targetStep.Name),
+		tmpDir,
+	)
+	// Point the TMPDIR environment variable to the custom path.
+	setEnvVar(targetStep, "TMPDIR", tmpDir)
+}
+
+// generateVolumeName creates a unique, DNS-1123 compliant volume name for a step.
+// The function ensures uniqueness by appending a SHA256 hash of the original step name.
+func generateVolumeName(prefix, stepName string) string {
+	// Create the full name first, then sanitize it
+	name := fmt.Sprintf("%s%s", prefix, stepName)
+
+	// Convert to lowercase and remove forbidden characters
+	sanitizedName := strings.ToLower(dnsLabel1123Forbidden.ReplaceAllString(name, "-"))
+
+	// Remove both leading and trailing hyphens
+	sanitizedName = strings.Trim(sanitizedName, "-")
+
+	// Generate a short hash of the original stepName for uniqueness
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(stepName)))[:8]
+
+	// Ensure maximum length, leaving space for the hash
+	maxLength := 63 - len(hash) - 1 // -1 for the hyphen separator
+	if len(sanitizedName) > maxLength {
+		sanitizedName = sanitizedName[:maxLength]
+	}
+
+	// Combine sanitized name with hash
+	result := fmt.Sprintf("%s-%s", sanitizedName, hash)
+
+	return result
+}
+
+// addStepEmptyDirVolume creates a unique EmptyDir volume for a specific step and mounts it at the given path.
+func addStepEmptyDirVolume(taskSpec *pipelineapi.TaskSpec, step *pipelineapi.Step, volumeName, mountPath string) {
+	ensureVolume(taskSpec, corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+
+	ensureVolumeMount(step, corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: mountPath,
+	})
+}
+
+// setEnvVar sets or overrides an environment variable in a Step.
+func setEnvVar(step *pipelineapi.Step, name, value string) {
+	for i, env := range step.Env {
+		if env.Name == name {
+			// Override existing variable
+			step.Env[i].Value = value
+			return
+		}
+	}
+
+	// Append new variable if it does not exist
+	step.Env = append(step.Env, corev1.EnvVar{
+		Name:  name,
+		Value: value,
+	})
+}
+
+// ensureVolume adds a volume to the TaskSpec if a volume with the same name does not already exist.
+func ensureVolume(taskSpec *pipelineapi.TaskSpec, volume corev1.Volume) {
+	for _, v := range taskSpec.Volumes {
+		if v.Name == volume.Name {
+			return
+		}
+	}
+	taskSpec.Volumes = append(taskSpec.Volumes, volume)
+}
+
+// ensureVolumeMount adds a VolumeMount to a Step if a mount with the same name does not already exist.
+func ensureVolumeMount(step *pipelineapi.Step, mount corev1.VolumeMount) {
+	for _, m := range step.VolumeMounts {
+		if m.Name == mount.Name {
+			return
+		}
+	}
+	step.VolumeMounts = append(step.VolumeMounts, mount)
 }

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -122,7 +122,7 @@ var _ = Describe("GenerateTaskrun", func() {
 			})
 
 			It("should ensure top level volumes are populated", func() {
-				Expect(len(got.Volumes)).To(Equal(1))
+				Expect(len(got.Volumes)).To(Equal(3))
 			})
 
 			It("should contain the shipwright system parameters", func() {


### PR DESCRIPTION
Breaking the changes of https://github.com/shipwright-io/build/pull/1885 into smaller prs to make review easier in the effort of better security practices for the containers that are used for the build process. 
# Changes

Added env variables for trivy to configure writing to volumes instead of the root filesystem.
Added a utility function `AppendWriteableVolumes` to be used for appending volumes to steps.

Volumes introduced to trivy:
- volume for trivy cache
- volume for tmp data

Set env variables:
- TRIVY_CACHE_DIR
- TMPDIR

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
Added volumes and config for trivy to enable its cache and tmp data to be on a volume instead of root filesystem.
```