### PR TITLE
Environment variable to enable using PipelineRun instead of TaskRun

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ const (
 	controllerBuildRunMaxConcurrentReconciles             = "BUILDRUN_MAX_CONCURRENT_RECONCILES"
 	controllerBuildStrategyMaxConcurrentReconciles        = "BUILDSTRATEGY_MAX_CONCURRENT_RECONCILES"
 	controllerClusterBuildStrategyMaxConcurrentReconciles = "CLUSTERBUILDSTRATEGY_MAX_CONCURRENT_RECONCILES"
+	controllerBuildrunPipelinerunExecutorEnvVar           = "BUILDRUN_PIPELINERUN_EXECUTOR" // not used yet. Relevant to pr #1924
 
 	// environment variables for the kube API
 	kubeAPIBurst = "KUBE_API_BURST"
@@ -107,6 +108,7 @@ type Config struct {
 	KubeAPIOptions                   KubeAPIOptions
 	GitRewriteRule                   bool
 	VulnerabilityCountLimit          int
+	BuildrunPipelinerunExecutor      bool
 }
 
 // PrometheusConfig contains the specific configuration for the
@@ -163,7 +165,7 @@ func NewDefaultConfig() *Config {
 		TerminationLogPath:            terminationLogPathDefault,
 		GitRewriteRule:                false,
 		VulnerabilityCountLimit:       50,
-
+		BuildrunPipelinerunExecutor:   false,
 		GitContainerTemplate: Step{
 			Image: gitDefaultImage,
 			Command: []string{
@@ -453,6 +455,9 @@ func (c *Config) SetConfigFromEnv() error {
 
 	if terminationLogPath := os.Getenv(terminationLogPathEnvVar); terminationLogPath != "" {
 		c.TerminationLogPath = terminationLogPath
+	}
+	if usePipelinerun := os.Getenv(controllerBuildrunPipelinerunExecutorEnvVar); usePipelinerun != "" {
+		c.BuildrunPipelinerunExecutor = strings.ToLower(usePipelinerun) == "true"
 	}
 
 	return nil


### PR DESCRIPTION
This is relevant to the refactor Shipwright's build logic to execute builds in a Tekton PipelineRun, and let cluster admins switch between the object type Shipwright creates to run the build. 
This is a prerequisite to fanning out parallel multi-arch builds.

Relevant to https://github.com/shipwright-io/build/pull/1924 and #1968 
# Changes

Added environment variable value that will later determine whether the BuildRun controller creates TaskRuns or PipelineRuns.

- By default, the controller will create TaskRuns, maintaining the current behavior.
- When the new variable is set to true, the controller will create PipelineRuns.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
```release-note
NONE
```
