### PR TITLE
chore(ci): update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,7 @@ jobs:
           export TEST_NAMESPACE=shp-e2e
           export TEST_IMAGE_REPO=registry.registry.svc.cluster.local:32222/shipwright-io/build-e2e
           export TEST_IMAGE_REPO_INSECURE=true
+          export TEST_E2E_FLAGS="-r --procs 8 --randomize-all --timeout=1h --trace --vv"
           export TEST_E2E_TIMEOUT_MULTIPLIER=2
           make test-e2e
       - name: Build controller logs


### PR DESCRIPTION
# Changes

CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.

/kind chore

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
