### PR TITLE
Add volume for home directory to the build pod

### DIFF
--- a/pkg/reconciler/buildrun/resources/image_processing.go
+++ b/pkg/reconciler/buildrun/resources/image_processing.go
@@ -217,7 +217,7 @@ func SetupImageProcessing(taskRun *pipelineapi.TaskRun, cfg *config.Config, crea
 			Value: "/trivy-cache-data",
 		})
 		// add the writeable volumes
-		sources.AppendWriteableVolumes(taskRun.Spec.TaskSpec, &imageProcessingStep)
+		sources.SetupHomeAndTmpVolumes(taskRun.Spec.TaskSpec, &imageProcessingStep)
 		// append the mutate step
 		taskRun.Spec.TaskSpec.Steps = append(taskRun.Spec.TaskSpec.Steps, imageProcessingStep)
 	}

--- a/pkg/reconciler/buildrun/resources/sources/bundle.go
+++ b/pkg/reconciler/buildrun/resources/sources/bundle.go
@@ -66,7 +66,7 @@ func AppendBundleStep(cfg *config.Config, taskSpec *pipelineapi.TaskSpec, oci *b
 	if oci.Prune != nil && *oci.Prune == build.PruneAfterPull {
 		bundleStep.Args = append(bundleStep.Args, "--prune")
 	}
-
+	SetupHomeAndTmpVolumes(taskSpec, &bundleStep)
 	taskSpec.Steps = append(taskSpec.Steps, bundleStep)
 }
 

--- a/pkg/reconciler/buildrun/resources/sources/git.go
+++ b/pkg/reconciler/buildrun/resources/sources/git.go
@@ -115,6 +115,7 @@ func AppendGitStep(
 		)
 	}
 
+	SetupHomeAndTmpVolumes(taskSpec, &gitStep)
 	// append the git step
 	taskSpec.Steps = append(taskSpec.Steps, gitStep)
 }

--- a/pkg/reconciler/buildrun/resources/sources/git_test.go
+++ b/pkg/reconciler/buildrun/resources/sources/git_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Git", func() {
 		})
 
 		It("adds a volume for the secret", func() {
-			Expect(len(taskSpec.Volumes)).To(Equal(1))
+			Expect(len(taskSpec.Volumes)).To(Equal(3))
 			Expect(taskSpec.Volumes[0].Name).To(Equal("shp-a-secret"))
 			Expect(taskSpec.Volumes[0].VolumeSource.Secret).NotTo(BeNil())
 			Expect(taskSpec.Volumes[0].VolumeSource.Secret.SecretName).To(Equal("a.secret"))
@@ -100,7 +100,7 @@ var _ = Describe("Git", func() {
 				"--result-file-source-timestamp", "$(results.shp-source-default-source-timestamp.path)",
 				"--secret-path", "/workspace/shp-source-secret",
 			}))
-			Expect(len(taskSpec.Steps[0].VolumeMounts)).To(Equal(1))
+			Expect(len(taskSpec.Steps[0].VolumeMounts)).To(Equal(3))
 			Expect(taskSpec.Steps[0].VolumeMounts[0].Name).To(Equal("shp-a-secret"))
 			Expect(taskSpec.Steps[0].VolumeMounts[0].MountPath).To(Equal("/workspace/shp-source-secret"))
 			Expect(taskSpec.Steps[0].VolumeMounts[0].ReadOnly).To(BeTrue())
@@ -188,7 +188,7 @@ var _ = Describe("Git", func() {
 				Revision:    ptr.To(revision),
 				CloneSecret: ptr.To("another.secret"),
 			}, "default")
-		
+
 			Expect(len(taskSpec.Steps)).To(Equal(1))
 			Expect(taskSpec.Steps[0].Args).To(ContainElements(
 				"--url", "https://github.com/shipwright-io/another-repo",

--- a/pkg/reconciler/buildrun/resources/sources/local_copy.go
+++ b/pkg/reconciler/buildrun/resources/sources/local_copy.go
@@ -35,5 +35,6 @@ func AppendLocalCopyStep(cfg *config.Config, taskSpec *pipelineapi.TaskSpec, tim
 	if timeout != nil {
 		step.Args = append(step.Args, fmt.Sprintf("--timeout=%s", timeout.Duration.String()))
 	}
+	SetupHomeAndTmpVolumes(taskSpec, &step)
 	taskSpec.Steps = append(taskSpec.Steps, step)
 }


### PR DESCRIPTION
Each container gets its own isolated emptyDir volume mounted at "/shp-writeable-home", to remove writes to the container's rootfs. Should be isolated volumes since when step 1 runs as user A but step 2 as user B, there will permission issues if this directory is shared. For Git SSH, it would actually mean that we put a private key on disk which is then unnecessarily visible

# Changes

- Added logic creating and mounting a volume to be used as a home directory for the build containers.
- Mounted a volume and set `HOME` env value for `source`,`build`, `image-processing` containers.


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Mounting a volume to be used as a home directory for `source`,`build`, `image-processing` containers.
```
