### PR TITLE
Run trivy with --disable-telemetry and --skip-version-check

### DIFF
--- a/pkg/image/vulnerability_scan.go
+++ b/pkg/image/vulnerability_scan.go
@@ -30,7 +30,7 @@ type TrivyResult struct {
 
 func RunVulnerabilityScan(ctx context.Context, imagePath string, settings buildapi.VulnerabilityScanOptions, auth *authn.AuthConfig, insecure bool, imageInDir bool, vulnCountLimit int) ([]buildapi.Vulnerability, error) {
 
-	trivyArgs := []string{"image", "--quiet", "--format", "json"}
+	trivyArgs := []string{"image", "--quiet", "--disable-telemetry", "--skip-version-check", "--format", "json"}
 	if imageInDir {
 		trivyArgs = append(trivyArgs, "--input", imagePath)
 	} else {


### PR DESCRIPTION
# Changes

Adding two flags to omit Trivy talking unnecessarily with the internet.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The image processing step now runs Trivy vulnerability scans with disabled telemetry
```
