### PR TITLE
Correct comment

### DIFF
--- a/docs/buildstrategies.md
+++ b/docs/buildstrategies.md
@@ -495,7 +495,7 @@ spec:
               # using head because the data could be multiline
               id="$(echo "${a}" | head -1 | sed 's/=.*//')"
 
-              # This is hacky, we remove the suffix ${id}= from all lines of the data.
+              # This is hacky, we remove the prefix ${id}= from all lines of the data.
               # If the data would be multiple lines and a line would start with ${id}=
               # then we would remove it. We could force users to give us the secret
               # base64 encoded. But ultimately, the best solution might be if the user

--- a/samples/v1alpha1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -132,7 +132,7 @@ spec:
               # using head because the data could be multiline
               id="$(echo "${a}" | head -1 | sed 's/=.*//')"
 
-              # This is hacky, we remove the suffix ${id}= from all lines of the data.
+              # This is hacky, we remove the prefix ${id}= from all lines of the data.
               # If the data would be multiple lines and a line would start with ${id}=
               # then we would remove it. We could force users to give us the secret
               # base64 encoded. But ultimately, the best solution might be if the user

--- a/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -145,7 +145,7 @@ spec:
               # using head because the data could be multiline
               id="$(echo "${a}" | head -1 | sed 's/=.*//')"
 
-              # This is hacky, we remove the suffix ${id}= from all lines of the data.
+              # This is hacky, we remove the prefix ${id}= from all lines of the data.
               # If the data would be multiple lines and a line would start with ${id}=
               # then we would remove it. We could force users to give us the secret
               # base64 encoded. But ultimately, the best solution might be if the user


### PR DESCRIPTION
# Changes

Stumbled over that comment while checking something. The following `sed` command is for sure removing a prefix and not a suffix.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
