### PR TITLE
Enable readOnlyFs for strategies

### DIFF
--- a/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml
@@ -11,6 +11,17 @@ spec:
       workingDir: $(params.shp-source-root)
       securityContext:
         privileged: true
+        readOnlyRootFilesystem: true
+      volumeMounts:
+        - name: shp-buildah-container-storage
+          mountPath: /var/lib/containers # Read/Write location of container storage
+        - name: shp-tmp
+          mountPath: /shp-tmp
+        - name: shp-run
+          mountPath: /var/run
+      env:
+        - name: TMPDIR
+          value: /shp-tmp
       command:
         - /bin/bash
       args:
@@ -125,21 +136,21 @@ spec:
 
           echo "[INFO] Creating registries config file..."
           if [ "${registriesSearch}" != "" ]; then
-            cat <<EOF >>/tmp/registries.conf
+            cat <<EOF >>/shp-tmp/registries.conf
           [registries.search]
           registries = [${registriesSearch::-2}]
 
           EOF
           fi
           if [ "${registriesInsecure}" != "" ]; then
-            cat <<EOF >>/tmp/registries.conf
+            cat <<EOF >>/shp-tmp/registries.conf
           [registries.insecure]
           registries = [${registriesInsecure::-2}]
 
           EOF
           fi
           if [ "${registriesBlock}" != "" ]; then
-            cat <<EOF >>/tmp/registries.conf
+            cat <<EOF >>/shp-tmp/registries.conf
           [registries.block]
           registries = [${registriesBlock::-2}]
 
@@ -150,7 +161,7 @@ spec:
           echo "[INFO] Building image ${image}"
           buildah --storage-driver=$(params.storage-driver) \
             bud "${budArgs[@]}" \
-            --registries-conf=/tmp/registries.conf \
+            --registries-conf=/shp-tmp/registries.conf \
             --tag="${image}" \
             --file="${dockerfile}" \
             .
@@ -219,6 +230,13 @@ spec:
       description: "Sets the target stage to be built."
       type: string
       default: ""
+  volumes:
+    - name: shp-buildah-container-storage
+      emptyDir: {}
+    - name: shp-tmp
+      emptyDir: {}
+    - name: shp-run
+      emptyDir: {}
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml
@@ -10,9 +10,20 @@ spec:
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
       securityContext:
+        readOnlyRootFilesystem: true
         capabilities:
           add:
           - "SETFCAP"
+      volumeMounts:
+        - name: shp-buildah-container-storage
+          mountPath: /var/lib/containers # Read/Write location of container storage
+        - name: shp-tmp
+          mountPath: /shp-tmp
+        - name: shp-run
+          mountPath: /var/run
+      env:
+        - name: TMPDIR
+          value: /shp-tmp
       command:
         - /bin/bash
       args:
@@ -125,21 +136,21 @@ spec:
 
           echo "[INFO] Creating registries config file..."
           if [ "${registriesSearch}" != "" ]; then
-            cat <<EOF >>/tmp/registries.conf
+            cat <<EOF >>/shp-tmp/registries.conf
           [registries.search]
           registries = [${registriesSearch::-2}]
 
           EOF
           fi
           if [ "${registriesInsecure}" != "" ]; then
-            cat <<EOF >>/tmp/registries.conf
+            cat <<EOF >>/shp-tmp/registries.conf
           [registries.insecure]
           registries = [${registriesInsecure::-2}]
 
           EOF
           fi
           if [ "${registriesBlock}" != "" ]; then
-            cat <<EOF >>/tmp/registries.conf
+            cat <<EOF >>/shp-tmp/registries.conf
           [registries.block]
           registries = [${registriesBlock::-2}]
 
@@ -150,7 +161,7 @@ spec:
           echo "[INFO] Building image ${image}"
           buildah --storage-driver=$(params.storage-driver) \
             bud "${budArgs[@]}" \
-            --registries-conf=/tmp/registries.conf \
+            --registries-conf=/shp-tmp/registries.conf \
             --tag="${image}" \
             --file="${dockerfile}" \
             .
@@ -222,3 +233,10 @@ spec:
   securityContext:
     runAsUser: 0
     runAsGroup: 0
+  volumes:
+    - name: shp-buildah-container-storage
+      emptyDir: {}
+    - name: shp-tmp
+      emptyDir: {}
+    - name: shp-run
+      emptyDir: {}

--- a/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml
@@ -44,8 +44,13 @@ spec:
             - SETUID
         seccompProfile:
           type: Unconfined
+        readOnlyRootFilesystem: true
       workingDir: $(params.shp-source-root)
       env:
+        # This is required to align the temporary directory created by buildkit
+        # with the volume mount for that directory.
+        - name: XDG_RUNTIME_DIR
+          value: /home/user/.local/tmp
         - name: DOCKER_CONFIG
           value: /tekton/home/.docker
         - name: HOME
@@ -67,6 +72,13 @@ spec:
           value: $(params.cache)
         - name: PARAM_TARGET
           value: $(params.target)
+      volumeMounts:
+        - name: buildkitd-1
+          mountPath: /home/user/.local/share/buildkit
+        - name: buildkitd-2
+          mountPath: /home/user/.local/tmp
+        - name: shp-tmp
+          mountPath: /tmp
       command:
         - /bin/ash
       args:
@@ -180,3 +192,10 @@ spec:
   securityContext:
     runAsUser: 1000
     runAsGroup: 1000
+  volumes:
+    - name: shp-tmp
+      emptyDir: {}
+    - name: buildkitd-1
+      emptyDir: {}
+    - name: buildkitd-2
+      emptyDir: {}

--- a/samples/v1beta1/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/v1beta1/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -25,14 +25,23 @@ spec:
       description: "Volume to contain the GOCACHE. Can be set to a persistent volume to optimize compilation performance for rebuilds."
       overridable: true
       emptyDir: {}
+    - name: ko-tmp
+      description: "Volume to contain temporary files for ko binary and other build artifacts."
+      overridable: true
+      emptyDir: {}
   steps:
     - name: build
       image: golang:$(params.go-version)
       imagePullPolicy: Always
       workingDir: $(params.shp-source-root)
+      securityContext:
+        readOnlyRootFilesystem: true
       volumeMounts:
         - mountPath: /gocache
           name: gocache
+          readOnly: false
+        - mountPath: /ko-tmp
+          name: ko-tmp
           readOnly: false
       env:
         - name: DOCKER_CONFIG
@@ -43,6 +52,10 @@ spec:
           value: $(params.go-flags)
         - name: GOCACHE
           value: /gocache
+        - name: GOTMPDIR
+          value: /ko-tmp
+        - name: TMPDIR
+          value: /ko-tmp
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
         - name: PARAM_OUTPUT_DIRECTORY
@@ -80,7 +93,7 @@ spec:
           fi
 
           # Download ko to the temp directory
-          curl -f -s -L "https://github.com/ko-build/ko/releases/download/${KO_VERSION_WITH_V}/ko_${KO_VERSION_WITHOUT_V}_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | tar xzf - -C /tmp ko
+          curl -f -s -L "https://github.com/ko-build/ko/releases/download/${KO_VERSION_WITH_V}/ko_${KO_VERSION_WITHOUT_V}_$(uname)_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | tar xzf - -C /ko-tmp ko
 
           # Determine the platform
           PLATFORM="${PARAM_TARGET_PLATFORM}"
@@ -90,7 +103,7 @@ spec:
 
           # Print version information
           go version
-          echo "ko version $(/tmp/ko version)"
+          echo "ko version $(/ko-tmp/ko version)"
 
           # Allow directory to be owned by other user which is normal for a volume-mounted directory.
           # This allows Go to run git commands to access repository metadata.
@@ -102,7 +115,7 @@ spec:
           export GOROOT="$(go env GOROOT)"
 
           pushd "${PARAM_SOURCE_CONTEXT}" > /dev/null
-            /tmp/ko build "${PARAM_PACKAGE_DIRECTORY}" --oci-layout-path="${PARAM_OUTPUT_DIRECTORY}" --platform="${PLATFORM}" --push=false
+            /ko-tmp/ko build "${PARAM_PACKAGE_DIRECTORY}" --oci-layout-path="${PARAM_OUTPUT_DIRECTORY}" --platform="${PLATFORM}" --push=false
           popd > /dev/null
       resources:
         limits:


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Enable readOnlyFs for strategies and add volumes.



Fixes #1969



# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
Pointed writes to volumes and enabled readOnlyRootFilesystem in buildah,buildkit, and ko strategies.
```

