### PR TITLE
[release-0.16] feat: update go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shipwright-io/build
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/docker/cli v28.2.2+incompatible


### PR DESCRIPTION
# Changes

- go 1.23 is EOL, update to 1.24
- 
# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
