### PR TITLE
Update k8s and tekton in test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,10 @@ jobs:
       matrix:
         compat:
           # oldest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
-          - kubernetes: v1.31.9
-            tekton: v0.65.7
+          - kubernetes: v1.32.8
+            tekton: v0.68.1
           # newest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
-          - kubernetes: v1.33.1
+          - kubernetes: v1.34.0
             tekton: v1.6.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
     runs-on: ubuntu-latest
@@ -105,7 +105,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.29.0
+          version: v0.30.0
           node_image: kindest/node:${{ matrix.compat.kubernetes }}
           cluster_name: kind
           wait: 120s
@@ -160,10 +160,10 @@ jobs:
       matrix:
         compat:
           # oldest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
-          - kubernetes: v1.31.9
-            tekton: v0.65.7
+          - kubernetes: v1.32.8
+            tekton: v0.68.1
           # newest supported Kubernetes and Tekton LTS that exists at the time of our planned next release
-          - kubernetes: v1.33.1
+          - kubernetes: v1.34.0
             tekton: v1.6.0 # RETAIN-COMMENT: TEKTON_NEWEST_LTS
       max-parallel: 4
     runs-on: oracle-vm-16cpu-64gb-x86-64
@@ -183,7 +183,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.29.0
+          version: v0.30.0
           node_image: kindest/node:${{ matrix.compat.kubernetes }}
           cluster_name: kind
           config: test/kind/config_three_node.yaml

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ To find out more on what's the best strategy or what else can Shipwright do for 
 
 | Dependency                           | Supported versions           |
 |--------------------------------------|------------------------------|
-| [Kubernetes](https://kubernetes.io/) | v1.31.\*, v1.32.\*, v1.33.\* |
-| [Tekton](https://tekton.dev)         | v0.65.\*, v0.68.\*, v1.0.\*, v1.3.\* |
+| [Kubernetes](https://kubernetes.io/) | v1.32.\*, v1.33.\*, v1.34.\*|
+| [Tekton](https://tekton.dev)         | v0.68.\*, v1.0.\*, v1.3.\*, v1.6.\*|
 
 ### Platform support
 


### PR DESCRIPTION
# Changes

Tekton v0.65 is not anymore supported.
Update to latest k8s version v1.34.

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Action Required: The minimum supported Tekton version is now v0.68, the minimum supported Kubernetes version is now v1.32, the maximum supported Kubernetes version is now v1.34
```
