### PR TITLE
Add runtimeClassName field to Build and BuildRun APIs

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -7472,6 +7472,10 @@ spec:
                             format: duration
                             type: string
                         type: object
+                      runtimeClassName:
+                        description: RuntimeClassName specifies the RuntimeClass to
+                          be used to run the Pod
+                        type: string
                       schedulerName:
                         description: SchedulerName specifies the scheduler to be used
                           to dispatch the Pod
@@ -9826,6 +9830,10 @@ spec:
                     format: duration
                     type: string
                 type: object
+              runtimeClassName:
+                description: RuntimeClassName specifies the RuntimeClass to be used
+                  to run the Pod
+                type: string
               schedulerName:
                 description: SchedulerName specifies the scheduler to be used to dispatch
                   the Pod
@@ -12044,6 +12052,10 @@ spec:
                         format: duration
                         type: string
                     type: object
+                  runtimeClassName:
+                    description: RuntimeClassName specifies the RuntimeClass to be
+                      used to run the Pod
+                    type: string
                   schedulerName:
                     description: SchedulerName specifies the scheduler to be used
                       to dispatch the Pod

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -2823,6 +2823,10 @@ spec:
                     format: duration
                     type: string
                 type: object
+              runtimeClassName:
+                description: RuntimeClassName specifies the RuntimeClass to be used
+                  to run the Pod
+                type: string
               schedulerName:
                 description: SchedulerName specifies the scheduler to be used to dispatch
                   the Pod

--- a/docs/build.md
+++ b/docs/build.md
@@ -42,6 +42,7 @@ A `Build` resource allows the user to define:
 - nodeSelector
 - tolerations
 - schedulerName
+- runtimeClassName
 
 A `Build` is available within a namespace.
 
@@ -98,7 +99,8 @@ To prevent users from triggering `BuildRun`s (_execution of a Build_) that will 
 | OutputTimestampNotValid                         | The output timestamp value is not valid.                                                                                                                                                                     |
 | NodeSelectorNotValid                            | The specified nodeSelector is not valid. |
 | TolerationNotValid                              | The specified tolerations are not valid. |
-| SchedulerNameNotValid                              | The specified schedulerName is not valid. |
+| SchedulerNameNotValid                           | The specified schedulerName is not valid. |
+| RuntimeClassNameNotValid                        | The specified runtimeClassName is not valid. |
 
 ## Configuring a Build
 
@@ -133,6 +135,7 @@ The `Build` definition supports the following fields:
   - `spec.nodeSelector` - Specifies a selector which must match a node's labels for the build pod to be scheduled on that node. If nodeSelectors are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.tolerations` - Specifies the tolerations for the build pod. Only `key`, `value`, and `operator` are supported. Only `NoSchedule` taint `effect` is supported. If tolerations are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.schedulerName` - Specifies the scheduler name for the build pod. If schedulerName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
+  - `spec.runtimeClassName` - Specifies the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) to be used for the build pod. If runtimeClassName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
 
 ### Defining the Source
 

--- a/docs/buildrun.md
+++ b/docs/buildrun.md
@@ -78,8 +78,9 @@ The `BuildRun` definition supports the following fields:
   - `spec.nodeSelector` - Specifies a selector which must match a node's labels for the build pod to be scheduled on that node. If nodeSelectors are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.tolerations` - Specifies the tolerations for the build pod. Only `key`, `value`, and `operator` are supported. Only `NoSchedule` taint `effect` is supported. If tolerations are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.schedulerName` - Specifies the scheduler name for the build pod. If schedulerName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
+  - `spec.runtimeClassName` - Specifies the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) to be used for the build pod. If runtimeClassName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
 
-**Note**: The `spec.build.name` and `spec.build.spec` are mutually exclusive. Furthermore, the overrides for `timeout`, `paramValues`, `output`, and `env` can only be combined with `spec.build.name`, but **not** with `spec.build.spec`.
+**Note**: The `spec.build.name` and `spec.build.spec` are mutually exclusive. Furthermore, the overrides for `timeout`, `paramValues`, `output`, `env`, `nodeSelector`, `tolerations`, `schedulerName`, and `runtimeClassName` can only be combined with `spec.build.name`, but **not** with `spec.build.spec`.
 
 ### Defining the Build Reference
 

--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -82,6 +82,8 @@ const (
 	TolerationNotValid BuildReason = "TolerationNotValid"
 	// SchedulerNameNotValid indicates that the Scheduler name is not valid
 	SchedulerNameNotValid BuildReason = "SchedulerNameNotValid"
+	// RuntimeClassNameNotValid indicates that the RuntimeClassName is not valid
+	RuntimeClassNameNotValid BuildReason = "RuntimeClassNameNotValid"
 	// AllValidationsSucceeded indicates a Build was successfully validated
 	AllValidationsSucceeded = "all validations succeeded"
 )
@@ -196,6 +198,10 @@ type BuildSpec struct {
 	// SchedulerName specifies the scheduler to be used to dispatch the Pod
 	// +optional
 	SchedulerName *string `json:"schedulerName,omitempty"`
+
+	// RuntimeClassName specifies the RuntimeClass to be used to run the Pod
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
 }
 
 // BuildVolume is a volume that will be mounted in build pod during build step

--- a/pkg/apis/build/v1beta1/buildrun_types.go
+++ b/pkg/apis/build/v1beta1/buildrun_types.go
@@ -126,6 +126,10 @@ type BuildRunSpec struct {
 	// SchedulerName specifies the scheduler to be used to dispatch the Pod
 	// +optional
 	SchedulerName *string `json:"schedulerName,omitempty"`
+
+	// RuntimeClassName specifies the RuntimeClass to be used to run the Pod
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
 }
 
 // BuildRunRequestedState defines the buildrun state the user can provide to override whatever is the current state.

--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -36,6 +36,7 @@ var validationTypes = [...]string{
 	validate.NodeSelector,
 	validate.Tolerations,
 	validate.SchedulerName,
+	validate.RuntimeClassName,
 }
 
 // ReconcileBuild reconciles a Build object

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -317,6 +317,15 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				return reconcile.Result{}, nil
 			}
 
+			// Validate the runtimeClassName
+			valid, reason, message = validate.BuildRunRuntimeClassName(buildRun.Spec.RuntimeClassName)
+			if !valid {
+				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
+					return reconcile.Result{}, err
+				}
+				return reconcile.Result{}, nil
+			}
+
 			// Create the ImageBuildRunner (TaskRun or PipelineRun)
 			imageBuildRunner, err := r.taskRunnerFactory.CreateImageBuildRunner(ctx, r.client, r.config, svcAccount, strategy, build, buildRun, r.scheme, r.setOwnerReferenceFunc)
 			if err != nil {

--- a/pkg/reconciler/buildrun/resources/taskrun_test.go
+++ b/pkg/reconciler/buildrun/resources/taskrun_test.go
@@ -374,6 +374,47 @@ var _ = Describe("TaskRun Unit Tests", func() {
 			})
 		})
 
+		Context("with runtimeClassName", func() {
+			It("should use BuildRun runtimeClassName when specified", func() {
+				runtimeClassName := "kata-containers"
+				buildRun.Spec.RuntimeClassName = &runtimeClassName
+
+				taskRun, err := resources.GenerateTaskRun(cfg, build, buildRun, serviceAccountName, buildStrategy)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(taskRun.Spec.PodTemplate).ToNot(BeNil())
+				Expect(taskRun.Spec.PodTemplate.RuntimeClassName).ToNot(BeNil())
+				Expect(*taskRun.Spec.PodTemplate.RuntimeClassName).To(Equal(runtimeClassName))
+			})
+
+			It("should use Build runtimeClassName when BuildRun runtimeClassName is not specified", func() {
+				runtimeClassName := "gvisor"
+				build.Spec.RuntimeClassName = &runtimeClassName
+
+				taskRun, err := resources.GenerateTaskRun(cfg, build, buildRun, serviceAccountName, buildStrategy)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(taskRun.Spec.PodTemplate).ToNot(BeNil())
+				Expect(taskRun.Spec.PodTemplate.RuntimeClassName).ToNot(BeNil())
+				Expect(*taskRun.Spec.PodTemplate.RuntimeClassName).To(Equal(runtimeClassName))
+			})
+
+			It("should prefer BuildRun runtimeClassName over Build runtimeClassName", func() {
+				buildRuntimeClassName := "gvisor"
+				buildRunRuntimeClassName := "kata-containers"
+
+				build.Spec.RuntimeClassName = &buildRuntimeClassName
+				buildRun.Spec.RuntimeClassName = &buildRunRuntimeClassName
+
+				taskRun, err := resources.GenerateTaskRun(cfg, build, buildRun, serviceAccountName, buildStrategy)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(taskRun.Spec.PodTemplate).ToNot(BeNil())
+				Expect(taskRun.Spec.PodTemplate.RuntimeClassName).ToNot(BeNil())
+				Expect(*taskRun.Spec.PodTemplate.RuntimeClassName).To(Equal(buildRunRuntimeClassName))
+			})
+		})
+
 		Context("with output image configuration", func() {
 			It("should use BuildRun output image when specified", func() {
 				buildRun.Spec.Output = &buildv1beta1.Image{

--- a/pkg/validate/runtime_class_name.go
+++ b/pkg/validate/runtime_class_name.go
@@ -1,0 +1,47 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/ptr"
+
+	build "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+)
+
+// RuntimeClassNameRef contains all required fields
+// to validate a RuntimeClassName
+type RuntimeClassNameRef struct {
+	Build *build.Build // build instance for analysis
+}
+
+func NewRuntimeClassName(build *build.Build) *RuntimeClassNameRef {
+	return &RuntimeClassNameRef{build}
+}
+
+// ValidatePath implements BuildPath interface and validates
+// that RuntimeClassName values are valid
+func (b *RuntimeClassNameRef) ValidatePath(_ context.Context) error {
+	ok, reason, msg := BuildRunRuntimeClassName(b.Build.Spec.RuntimeClassName)
+	if !ok {
+		b.Build.Status.Reason = ptr.To(build.BuildReason(reason))
+		b.Build.Status.Message = ptr.To(msg)
+	}
+	return nil
+}
+
+// BuildRunRuntimeClassName is used to validate the runtimeClassName in the BuildRun object
+func BuildRunRuntimeClassName(runtimeClassName *string) (bool, string, string) {
+	if runtimeClassName != nil {
+		if errs := validation.IsDNS1123Subdomain(*runtimeClassName); len(errs) > 0 {
+			return false, string(build.RuntimeClassNameNotValid), fmt.Sprintf("RuntimeClassName not valid: %v", strings.Join(errs, ", "))
+		}
+	}
+	return true, "", ""
+}

--- a/pkg/validate/runtime_class_name_test.go
+++ b/pkg/validate/runtime_class_name_test.go
@@ -1,0 +1,81 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+	"github.com/shipwright-io/build/pkg/validate"
+)
+
+var _ = Describe("ValidateRuntimeClassName", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+	})
+
+	var validate = func(build *Build) {
+		GinkgoHelper()
+
+		var validator = &validate.RuntimeClassNameRef{Build: build}
+		Expect(validator.ValidatePath(ctx)).To(Succeed())
+	}
+
+	var sampleBuild = func(runtimeClassName string) *Build {
+		return &Build{
+			ObjectMeta: corev1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: BuildSpec{
+				RuntimeClassName: &runtimeClassName,
+			},
+		}
+	}
+
+	Context("when runtimeClassName is specified", func() {
+		It("should fail an empty name", func() {
+			build := sampleBuild("")
+			validate(build)
+			Expect(*build.Status.Reason).To(Equal(RuntimeClassNameNotValid))
+			Expect(*build.Status.Message).To(ContainSubstring("RuntimeClassName not valid"))
+		})
+
+		It("should fail an invalid name with uppercase", func() {
+			build := sampleBuild("InvalidName")
+			validate(build)
+			Expect(*build.Status.Reason).To(Equal(RuntimeClassNameNotValid))
+			Expect(*build.Status.Message).To(ContainSubstring("RuntimeClassName not valid"))
+		})
+
+		It("should fail an invalid name with special characters", func() {
+			build := sampleBuild("invalid_name!")
+			validate(build)
+			Expect(*build.Status.Reason).To(Equal(RuntimeClassNameNotValid))
+			Expect(*build.Status.Message).To(ContainSubstring("RuntimeClassName not valid"))
+		})
+
+		It("should pass a valid name", func() {
+			build := sampleBuild("kata-containers")
+			validate(build)
+			Expect(build.Status.Reason).To(BeNil())
+			Expect(build.Status.Message).To(BeNil())
+		})
+
+		It("should pass a valid name with dots", func() {
+			build := sampleBuild("gvisor.runsc")
+			validate(build)
+			Expect(build.Status.Reason).To(BeNil())
+			Expect(build.Status.Message).To(BeNil())
+		})
+	})
+})

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -41,6 +41,8 @@ const (
 	Tolerations = "tolerations"
 	// SchedulerName for validating `spec.schedulerName` entry
 	SchedulerName = "schedulername"
+	// RuntimeClassName for validating `spec.runtimeClassName` entry
+	RuntimeClassName = "runtimeclassname"
 )
 
 const (
@@ -87,6 +89,8 @@ func NewValidation(
 		return &TolerationsRef{Build: build}, nil
 	case SchedulerName:
 		return &SchedulerNameRef{Build: build}, nil
+	case RuntimeClassName:
+		return &RuntimeClassNameRef{Build: build}, nil
 	default:
 		return nil, fmt.Errorf("unknown validation type")
 	}
@@ -155,6 +159,11 @@ func BuildRunFields(buildRun *build.BuildRun) (string, string) {
 		if buildRun.Spec.SchedulerName != nil {
 			return resources.BuildRunBuildFieldOverrideForbidden,
 				"cannot use 'schedulerName' override and 'buildSpec' simultaneously"
+		}
+
+		if buildRun.Spec.RuntimeClassName != nil {
+			return resources.BuildRunBuildFieldOverrideForbidden,
+				"cannot use 'runtimeClassName' override and 'buildSpec' simultaneously"
 		}
 	}
 

--- a/test/v1beta1_samples/build_samples.go
+++ b/test/v1beta1_samples/build_samples.go
@@ -594,6 +594,19 @@ spec:
   schedulerName: "build-test-schedulername"
 `
 
+// MinimalBuildWithRuntimeClassName defines a simple
+// Build with a strategy, output, and a RuntimeClassName specified
+const MinimalBuildWithRuntimeClassName = `
+apiVersion: shipwright.io/v1beta1
+kind: Build
+spec:
+  strategy:
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/example/buildpacks-app
+  runtimeClassName: "kata-containers"
+`
+
 // BuildWithUndefinedParameter defines a param that was not declared under the
 // strategy parameters
 const BuildWithUndefinedParam = `

--- a/test/v1beta1_samples/buildrun_samples.go
+++ b/test/v1beta1_samples/buildrun_samples.go
@@ -313,6 +313,32 @@ spec:
   schedulerName: "buildrun-test-schedulername"
 `
 
+// MinimalBuildRunWithRuntimeClassName defines a minimal BuildRun
+// with a reference to a not existing Build,
+// and a RuntimeClassName specified
+const MinimalBuildRunWithRuntimeClassName = `
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+spec:
+  build:
+    name: foobar
+  runtimeClassName: "kata-containers"
+`
+
+// MinimalBuildRunWithRuntimeClassNameOverride defines a minimal BuildRun
+// with a build spec defined and a runtimeClassName overriding the build spec
+const MinimalBuildRunWithRuntimeClassNameOverride = `
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+spec:
+  build:
+    spec:
+      strategy:
+        kind: ClusterBuildStrategy
+        name: buildah
+  runtimeClassName: "kata-containers"
+`
+
 // MinimalBuildRunWithVulnerabilityScan defines a BuildRun with
 // an override for the Build Output
 const MinimalBuildRunWithVulnerabilityScan = `


### PR DESCRIPTION
# Changes
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #2074

-->

This PR adds support for `runtimeClassName` field in Build and BuildRun APIs, allowing builds to run with alternative container runtimes.

Fixes #2074

/kind feature
# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
You can now specify a `runtimeClassName` on a Build and BuildRun to use alternative container runtimes.
```
