### PR TITLE
Fix shebang position in install-spruce.sh

### DIFF
--- a/hack/install-spruce.sh
+++ b/hack/install-spruce.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
+
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-
-#!/bin/bash
 
 set -euo pipefail
 


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->
Move shebang to line 1 in `hack/install-spruce.sh`. The shebang was placed after the copyright header, causing the script to run with `/bin/sh` instead of `/bin/bash`, which fails on `set -o pipefail`.

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
