### PR TITLE
Set GOMODCACHE to writable directory in ko sample build strategy

### DIFF
--- a/samples/v1beta1/buildstrategy/ko/buildstrategy_ko_cr.yaml
+++ b/samples/v1beta1/buildstrategy/ko/buildstrategy_ko_cr.yaml
@@ -51,7 +51,9 @@ spec:
         - name: GOFLAGS
           value: $(params.go-flags)
         - name: GOCACHE
-          value: /gocache
+          value: /gocache/go-build
+        - name: GOMODCACHE
+          value: /gocache/go-mod
         - name: GOTMPDIR
           value: /ko-tmp
         - name: TMPDIR


### PR DESCRIPTION
# Changes

This fixes a problem with certain sources in the ko build strategy after the root file system was made readonly in #2020.

Basically for modules with dependencies but without vendoring, Go downloads the modules to the GOMODCACHE directory which is `/go/pkg/mod` by default. And that directory is not anymore writable.

I re-used the gocache volume as persistence here also makes sense for those that overwrite the volume.

/cc hasanawad94
/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The ko build strategy is fixed for Go modules that have dependencies but no vendoring.
```
