### PR TITLE
fix: Update Tekton Manifest URL

### DIFF
--- a/.github/bump-tekton-lts.sh
+++ b/.github/bump-tekton-lts.sh
@@ -72,4 +72,4 @@ sed -i "s/TEKTON_VERSION ?= v.*/TEKTON_VERSION ?= ${NEW_VERSION}/" "${BASEDIR}/M
 sed -i "s/TEKTON_VERSION:-v.*}/TEKTON_VERSION:-${NEW_VERSION}}/" "${BASEDIR}/hack/install-tekton.sh"
 
 # Update README.md
-sed -i "s#https://storage.googleapis.com/tekton-releases/pipeline/previous/v.*/release.yaml#https://storage.googleapis.com/tekton-releases/pipeline/previous/${NEW_VERSION}/release.yaml#" "${BASEDIR}/README.md"
+sed -i "s#https://infra.tekton.dev/tekton-releases/pipeline/previous/v.*/release.yaml#https://infra.tekton.dev/tekton-releases/pipeline/previous/${NEW_VERSION}/release.yaml#" "${BASEDIR}/README.md"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - We also require a Tekton installation (v0.59.+). To install the latest LTS release, run:
 
   ```bash
-  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v1.9.0/release.yaml
+  kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/v1.9.0/release.yaml
   ```
 
   If you are using OpenShift cluster refer [Running on OpenShift](#running-on-openshift) for some more configurations.


### PR DESCRIPTION
# Changes

Tekton migrated its release hosting to `infra.tekton.dev`.

Fixes #2100 

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Update Tekton manifests URL to `infra.tekton.dev`
```

