### PR TITLE
Add Grype as second scan tool for OS vulnerabilities

### DIFF
--- a/.github/workflows/report-release-vulnerabilities.yaml
+++ b/.github/workflows/report-release-vulnerabilities.yaml
@@ -36,6 +36,10 @@ jobs:
         run: curl --location --silent  https://raw.githubusercontent.com/homeport/retry/main/hack/download.sh | bash
       - name: Install semver
         run: go install gitlab.com/usvc/utils/semver/cmd/semver@latest
+      - name: Install Grype
+        run: |
+          TAG_NAME="$(curl -s https://api.github.com/repos/anchore/grype/releases/latest | jq -r '.tag_name')"
+          curl -L -s "https://github.com/anchore/grype/releases/download/${TAG_NAME}/grype_${TAG_NAME/v/}_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/aarch64/arm64/' -e 's/x86_64/amd64/').tar.gz" | tar -xzf - grype
       - name: Install Trivy
         run: make install-trivy
         working-directory: ${{ github.workspace }}/main
@@ -43,7 +47,7 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.repository_owner }}
           TRIVY_PASSWORD: ${{ github.token }}
-        run: retry trivy image --download-db-only
+        run: retry trivy image --download-db-only --disable-telemetry --skip-version-check
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Download latest release


### PR DESCRIPTION
# Changes

Since we updated our base image to UBI 10, our vulnerability scanning is not anymore finding OS vulnerabilities. That is due to https://github.com/aquasecurity/trivy/issues/7452 not being implemented.

I am therefore adding Grype as second scanning tool. I verified that it finds UBI 10 vulnerabilities. Here is a sample output from the vulnerability report that it would have opened as GitHub issue for v0.18.2:

-- 

## ghcr.io/shipwright-io/build/bundle:v0.18.2@sha256:fa71c41c73cf73deb14ef2625e27c874889050396535088d4369e9dff313decc
### OS vulnerabilities (Grype)
| Vulnerability | Package | Severity | Version | Fixed by rebuild |
| -- | -- | -- | -- | -- |
| CVE-2025-9086 | curl | medium | 8.12.1-2.el10 -> 0:8.12.1-2.el10_1.2 | :white_check_mark: |
| CVE-2025-9086 | libcurl-minimal | medium | 8.12.1-2.el10 -> 0:8.12.1-2.el10_1.2 | :white_check_mark: |
| CVE-2025-14104 | libblkid | medium | 2.40.2-13.el10 -> 0:2.40.2-15.el10_1 | :white_check_mark: |
| CVE-2025-14104 | libmount | medium | 2.40.2-13.el10 -> 0:2.40.2-15.el10_1 | :white_check_mark: |
| CVE-2025-14104 | libsmartcols | medium | 2.40.2-13.el10 -> 0:2.40.2-15.el10_1 | :white_check_mark: |
| CVE-2025-14104 | libuuid | medium | 2.40.2-13.el10 -> 0:2.40.2-15.el10_1 | :white_check_mark: |
### OS vulnerabilities (Trivy)
No vulnerabilities found.

-- 

BTW1: in case you noticed it, yes the fix version is here suffixed with `0:`. That is from Grype's output, no idea why they have that prefix:

<img width="926" height="579" alt="grafik" src="https://github.com/user-attachments/assets/04baac05-b55b-4c02-b618-4cc1cb92974b" />

BTW2: we have the same problem with the image scanning that we do for the images that Shipwright Build creates. Back at that time, [we compared Trivy and Grype and chose Trivy because it was faster](https://github.com/shipwright-io/community/blob/main/ships/0033-build-output-vulnerability-scanning.md#performance-comparison-between-trivy-and-grype) (Trivy imo is still faster).

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
We are scanning our images during our regular scans now with Grype in addition to Trivy as Trivy is not yet capable to find vulnerabilities in RedHat UBI 10 which we are using as our base image.
```
