### PR TITLE
[release-v0.18] Update github.com/go-git/go-git/v5 from v5.16.3 to v5.16.5 to address GO-2026-4473

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/docker/cli v29.0.2+incompatible
-	github.com/go-git/go-git/v5 v5.16.3
+	github.com/go-git/go-git/v5 v5.16.5
 	github.com/go-logr/logr v1.4.3
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-containerregistry v0.20.6

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UN
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.16.3 h1:Z8BtvxZ09bYm/yYNgPKCzgWtaRqDTgIKRgIRHBfU6Z8=
-github.com/go-git/go-git/v5 v5.16.3/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
+github.com/go-git/go-git/v5 v5.16.5 h1:mdkuqblwr57kVfXri5TTH+nMFLNUxIj9Z7F5ykFbw5s=
+github.com/go-git/go-git/v5 v5.16.5/go.mod h1:QOMLpNf1qxuSY4StA/ArOdfFR2TrKEjJiye2kel2m+M=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/vendor/github.com/go-git/go-git/v5/plumbing/format/objfile/reader.go
+++ b/vendor/github.com/go-git/go-git/v5/plumbing/format/objfile/reader.go
@@ -30,7 +30,7 @@ type Reader struct {
 func NewReader(r io.Reader) (*Reader, error) {
 	zlib, err := sync.GetZlibReader(r)
 	if err != nil {
-		return nil, packfile.ErrZLib.AddDetails(err.Error())
+		return nil, packfile.ErrZLib.AddDetails("%s", err.Error())
 	}
 
 	return &Reader{

--- a/vendor/github.com/go-git/go-git/v5/plumbing/protocol/packp/advrefs_decode.go
+++ b/vendor/github.com/go-git/go-git/v5/plumbing/protocol/packp/advrefs_decode.go
@@ -262,9 +262,8 @@ func decodeShallow(p *advRefsDecoder) decoderStateFn {
 	p.line = bytes.TrimPrefix(p.line, shallow)
 
 	if len(p.line) != hashSize {
-		p.error(fmt.Sprintf(
-			"malformed shallow hash: wrong length, expected 40 bytes, read %d bytes",
-			len(p.line)))
+		p.error("malformed shallow hash: wrong length, expected 40 bytes, read %d bytes",
+			len(p.line))
 		return nil
 	}
 

--- a/vendor/github.com/go-git/go-git/v5/plumbing/protocol/packp/updreq_encode.go
+++ b/vendor/github.com/go-git/go-git/v5/plumbing/protocol/packp/updreq_encode.go
@@ -62,7 +62,7 @@ func (req *ReferenceUpdateRequest) encodeCommands(e *pktline.Encoder,
 	}
 
 	for _, cmd := range cmds[1:] {
-		if err := e.Encodef(formatCommand(cmd)); err != nil {
+		if err := e.Encodef("%s", formatCommand(cmd)); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/go-git/go-git/v5/worktree.go
+++ b/vendor/github.com/go-git/go-git/v5/worktree.go
@@ -310,13 +310,20 @@ func (w *Worktree) ResetSparsely(opts *ResetOptions, dirs []string) error {
 		return err
 	}
 
+	var removedFiles []string
 	if opts.Mode == MixedReset || opts.Mode == MergeReset || opts.Mode == HardReset {
-		if err := w.resetIndex(t, dirs, opts.Files); err != nil {
+		if removedFiles, err = w.resetIndex(t, dirs, opts.Files); err != nil {
 			return err
 		}
 	}
 
-	if opts.Mode == MergeReset || opts.Mode == HardReset {
+	if opts.Mode == MergeReset && len(removedFiles) > 0 {
+		if err := w.resetWorktree(t, removedFiles); err != nil {
+			return err
+		}
+	}
+
+	if opts.Mode == HardReset {
 		if err := w.resetWorktree(t, opts.Files); err != nil {
 			return err
 		}
@@ -365,23 +372,24 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	return w.ResetSparsely(opts, nil)
 }
 
-func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) error {
+func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) ([]string, error) {
 	idx, err := w.r.Storer.Index()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	b := newIndexBuilder(idx)
 
 	changes, err := w.diffTreeWithStaging(t, true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	var removedFiles []string
 	for _, ch := range changes {
 		a, err := ch.Action()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		var name string
@@ -392,7 +400,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) err
 			name = ch.To.String()
 			e, err = t.FindEntry(name)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		case merkletrie.Delete:
 			name = ch.From.String()
@@ -406,6 +414,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) err
 		}
 
 		b.Remove(name)
+		removedFiles = append(removedFiles, name)
 		if e == nil {
 			continue
 		}
@@ -424,7 +433,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) err
 		idx.SkipUnless(dirs)
 	}
 
-	return w.r.Storer.SetIndex(idx)
+	return removedFiles, w.r.Storer.SetIndex(idx)
 }
 
 func inFiles(files []string, v string) bool {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -141,8 +141,8 @@ github.com/go-git/go-billy/v5/helper/polyfill
 github.com/go-git/go-billy/v5/memfs
 github.com/go-git/go-billy/v5/osfs
 github.com/go-git/go-billy/v5/util
-# github.com/go-git/go-git/v5 v5.16.3
-## explicit; go 1.23.0
+# github.com/go-git/go-git/v5 v5.16.5
+## explicit; go 1.24.0
 github.com/go-git/go-git/v5
 github.com/go-git/go-git/v5/config
 github.com/go-git/go-git/v5/internal/path_util


### PR DESCRIPTION
# Changes

Part of #2110

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Update github.com/go-git/go-git/v5 from v5.16.3 to v5.16.5 to address GO-2026-4473
```
