### PR TITLE
Extract grype into correct directory

### DIFF
--- a/.github/workflows/report-release-vulnerabilities.yaml
+++ b/.github/workflows/report-release-vulnerabilities.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Grype
         run: |
           TAG_NAME="$(curl -s https://api.github.com/repos/anchore/grype/releases/latest | jq -r '.tag_name')"
-          curl -L -s "https://github.com/anchore/grype/releases/download/${TAG_NAME}/grype_${TAG_NAME/v/}_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/aarch64/arm64/' -e 's/x86_64/amd64/').tar.gz" | tar -xzf - grype
+          curl -L -s "https://github.com/anchore/grype/releases/download/${TAG_NAME}/grype_${TAG_NAME/v/}_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/aarch64/arm64/' -e 's/x86_64/amd64/').tar.gz" | sudo tar -xzf - -C /usr/local/bin grype
       - name: Install Trivy
         run: make install-trivy
         working-directory: ${{ github.workspace }}/main


### PR DESCRIPTION
# Changes

Our vulnerability scanning is [failing](https://github.com/shipwright-io/build/actions/runs/22472875838/job/65093648574) because grype is not extracted into the correct directory. Fixing that.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
