### PR TITLE
Add daily upstream sync workflow for main branch

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,52 @@
+name: Sync from upstream
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # daily at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/shipwright-io/build.git
+          git fetch upstream main
+
+      - name: Merge upstream changes
+        run: |
+          UPSTREAM_SHA=$(git rev-parse upstream/main)
+          LOCAL_SHA=$(git rev-parse HEAD)
+
+          if [ "$UPSTREAM_SHA" = "$LOCAL_SHA" ]; then
+            echo "Already up to date with upstream ($LOCAL_SHA)"
+            exit 0
+          fi
+
+          echo "Syncing main: $LOCAL_SHA -> $UPSTREAM_SHA"
+
+          if ! git merge upstream/main --no-edit; then
+            echo "::error::Merge conflict syncing 'main' from upstream."
+            echo "::error::Upstream SHA: $UPSTREAM_SHA | Mirror SHA: $LOCAL_SHA"
+            echo "::error::Manual resolution required."
+            git merge --abort
+            exit 1
+          fi
+
+      - name: Push to mirror
+        run: git push origin main


### PR DESCRIPTION
Adds a GitHub Actions workflow that syncs the mirror's main branch from upstream shipwright-io/build daily at 06:00 UTC, with manual workflow_dispatch support. On merge conflict the job fails and notifies repo watchers.

Assisted by: Cursor