### PR TITLE
Refactor[Tests]: Use ginkgo labels to differentiate PipelinRun tests from TaskRun tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           make test-integration
       - name: Test-PipelineRun
         run: |
-          BUILDRUN_EXECUTOR=PipelineRun ginkgo --focus-file="buildruns_to_pipelineruns_test.go" -v test/integration/...
+          BUILDRUN_EXECUTOR=PipelineRun ginkgo --label-filter="PipelineRun" -v test/integration/...
 
   e2e:
     strategy:
@@ -269,7 +269,7 @@ jobs:
           TEST_E2E_SERVICEACCOUNT_NAME=pipeline \
           TEST_E2E_TIMEOUT_MULTIPLIER=${TEST_E2E_TIMEOUT_MULTIPLIER} \
           TEST_E2E_VERIFY_TEKTONOBJECTS=true \
-          ginkgo --focus="PipelineRun E2E Tests" --procs 8 --timeout=1h --vv test/e2e/v1beta1/
+          ginkgo --label-filter="PipelineRun" --procs 8 --timeout=1h --vv test/e2e/v1beta1/
       - name: Build controller logs
         if: ${{ failure() }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ test-integration: install-apis ginkgo
 		--randomize-all \
 		--randomize-suites \
 		--fail-on-pending \
-		--skip-file=buildruns_to_pipelineruns_test.go \
+		--label-filter="!PipelineRun" \
 		-trace \
 		test/integration/...
 
@@ -227,7 +227,7 @@ test-e2e-plain: ginkgo
 	TEST_E2E_SERVICEACCOUNT_NAME=${TEST_E2E_SERVICEACCOUNT_NAME} \
 	TEST_E2E_TIMEOUT_MULTIPLIER=${TEST_E2E_TIMEOUT_MULTIPLIER} \
 	TEST_E2E_VERIFY_TEKTONOBJECTS=${TEST_E2E_VERIFY_TEKTONOBJECTS} \
-	$(GINKGO) --skip-file=e2e_pipelinerun_test.go ${TEST_E2E_FLAGS} test/e2e/
+	$(GINKGO) --label-filter="!PipelineRun" ${TEST_E2E_FLAGS} test/e2e/
 
 .PHONY: test-e2e-kind-with-prereq-install
 test-e2e-kind-with-prereq-install: ginkgo install-controller-kind install-strategies test-e2e-plain

--- a/test/integration/buildruns_to_pipelineruns_test.go
+++ b/test/integration/buildruns_to_pipelineruns_test.go
@@ -15,7 +15,7 @@ import (
 	test "github.com/shipwright-io/build/test/v1beta1_samples"
 )
 
-var _ = Describe("Integration tests BuildRuns and PipelineRuns", func() {
+var _ = Describe("Integration tests BuildRuns and PipelineRuns", Label("PipelineRun"), func() {
 	var (
 		cbsObject      *v1beta1.ClusterBuildStrategy
 		buildObject    *v1beta1.Build


### PR DESCRIPTION

## Changes
- added ginkgo labels `PipelinRun` for PipelineRun tests
- updated makefile and CI to utilize labels for filtering 

This enables new PipelineRun tests can be written in any other file rather than one single file. 

Fixes #2017

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

---

# Release Notes

```release-note
Added gingkgo labels support to differentiate PipelineRun and TaskRun tests 
```
