### PR TITLE
feat: add insecure registries configuration for buildpacks buildstrategy

### DIFF
--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -18,7 +18,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   buildSteps:
     - name: build-and-push

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -17,6 +17,9 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   buildSteps:
     - name: build-and-push
       image: heroku/builder:22
@@ -27,6 +30,8 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -45,26 +45,33 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
-            while [[ $# -gt 0 ]]; do
-              arg="$1"
-              shift
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
 
-              if [ "${arg}" == "--insecure-registries" ]; then
-                inInsecureRegistries=true
-              elif [ "${inInsecureRegistries}" == "true" ]; then
-                insecureRegistries="${insecureRegistries}${arg},"
-              else
-                echo "Invalid usage"
-                exit 1
-              fi
-            done
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
           fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
           fi
 
           set -euo pipefail
@@ -119,16 +126,16 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
-      - --
-      - --insecure-registries
-      - $(params.insecure-registries[*])
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -35,6 +35,8 @@ spec:
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
@@ -43,19 +45,21 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          while [[ $# -gt 0 ]]; do
-            arg="$1"
-            shift
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            while [[ $# -gt 0 ]]; do
+              arg="$1"
+              shift
 
-            if [ "${arg}" == "--insecure-registries" ]; then
-              inInsecureRegistries=true
-            elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
-            else
-              echo "Invalid usage"
-              exit 1
-            fi
-          done
+              if [ "${arg}" == "--insecure-registries" ]; then
+                inInsecureRegistries=true
+              elif [ "${inInsecureRegistries}" == "true" ]; then
+                insecureRegistries="${insecureRegistries}${arg},"
+              else
+                echo "Invalid usage"
+                exit 1
+              fi
+            done
+          fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -18,8 +18,9 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   buildSteps:
     - name: build-and-push
       image: heroku/builder:22
@@ -30,8 +31,6 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
@@ -41,6 +40,29 @@ spec:
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -100,6 +122,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      - --
+      - --insecure-registries
+      - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -18,7 +18,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   buildSteps:
     - name: build-and-push

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -17,6 +17,9 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   buildSteps:
     - name: build-and-push
       image: heroku/builder:22
@@ -27,6 +30,8 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -45,26 +45,33 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
-            while [[ $# -gt 0 ]]; do
-              arg="$1"
-              shift
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
 
-              if [ "${arg}" == "--insecure-registries" ]; then
-                inInsecureRegistries=true
-              elif [ "${inInsecureRegistries}" == "true" ]; then
-                insecureRegistries="${insecureRegistries}${arg},"
-              else
-                echo "Invalid usage"
-                exit 1
-              fi
-            done
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
           fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
           fi
 
           set -euo pipefail
@@ -103,7 +110,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"
@@ -119,16 +126,16 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
-      - --
-      - --insecure-registries
-      - $(params.insecure-registries[*])
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -35,6 +35,8 @@ spec:
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
@@ -43,19 +45,21 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          while [[ $# -gt 0 ]]; do
-            arg="$1"
-            shift
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            while [[ $# -gt 0 ]]; do
+              arg="$1"
+              shift
 
-            if [ "${arg}" == "--insecure-registries" ]; then
-              inInsecureRegistries=true
-            elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
-            else
-              echo "Invalid usage"
-              exit 1
-            fi
-          done
+              if [ "${arg}" == "--insecure-registries" ]; then
+                inInsecureRegistries=true
+              elif [ "${inInsecureRegistries}" == "true" ]; then
+                insecureRegistries="${insecureRegistries}${arg},"
+              else
+                echo "Invalid usage"
+                exit 1
+              fi
+            done
+          fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -18,8 +18,9 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   buildSteps:
     - name: build-and-push
       image: heroku/builder:22
@@ -30,8 +31,6 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
@@ -41,6 +40,29 @@ spec:
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -100,6 +122,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      - --
+      - --insecure-registries
+      - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -11,12 +11,17 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -12,7 +12,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   buildSteps:
     - name: build-and-push

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -18,7 +18,7 @@ spec:
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
-      env: 
+      env:
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT
@@ -35,26 +35,33 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
-            while [[ $# -gt 0 ]]; do
-              arg="$1"
-              shift
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
 
-              if [ "${arg}" == "--insecure-registries" ]; then
-                inInsecureRegistries=true
-              elif [ "${inInsecureRegistries}" == "true" ]; then
-                insecureRegistries="${insecureRegistries}${arg},"
-              else
-                echo "Invalid usage"
-                exit 1
-              fi
-            done
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
           fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
           fi
 
           set -euo pipefail
@@ -93,7 +100,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"
@@ -109,16 +116,16 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
-      - --
-      - --insecure-registries
-      - $(params.insecure-registries[*])
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -12,16 +12,15 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
@@ -31,6 +30,29 @@ spec:
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -90,6 +112,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      - --
+      - --insecure-registries
+      - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -25,6 +25,8 @@ spec:
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
@@ -33,19 +35,21 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          while [[ $# -gt 0 ]]; do
-            arg="$1"
-            shift
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            while [[ $# -gt 0 ]]; do
+              arg="$1"
+              shift
 
-            if [ "${arg}" == "--insecure-registries" ]; then
-              inInsecureRegistries=true
-            elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
-            else
-              echo "Invalid usage"
-              exit 1
-            fi
-          done
+              if [ "${arg}" == "--insecure-registries" ]; then
+                inInsecureRegistries=true
+              elif [ "${inInsecureRegistries}" == "true" ]; then
+                insecureRegistries="${insecureRegistries}${arg},"
+              else
+                echo "Invalid usage"
+                exit 1
+              fi
+            done
+          fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -11,12 +11,17 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -12,7 +12,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   buildSteps:
     - name: build-and-push

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -18,7 +18,7 @@ spec:
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
-      env: 
+      env:
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
         - name: PARAM_SOURCE_CONTEXT
@@ -35,26 +35,33 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
-            while [[ $# -gt 0 ]]; do
-              arg="$1"
-              shift
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
 
-              if [ "${arg}" == "--insecure-registries" ]; then
-                inInsecureRegistries=true
-              elif [ "${inInsecureRegistries}" == "true" ]; then
-                insecureRegistries="${insecureRegistries}${arg},"
-              else
-                echo "Invalid usage"
-                exit 1
-              fi
-            done
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
           fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
           fi
 
           set -euo pipefail
@@ -93,7 +100,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"
@@ -109,16 +116,16 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
-      - --
-      - --insecure-registries
-      - $(params.insecure-registries[*])
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -12,16 +12,15 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   buildSteps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
@@ -31,6 +30,29 @@ spec:
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES=$insecureRegistries
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -90,6 +112,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+      - --
+      - --insecure-registries
+      - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -25,6 +25,8 @@ spec:
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
@@ -33,19 +35,21 @@ spec:
           insecureRegistries=""
           inInsecureRegistries=false
 
-          while [[ $# -gt 0 ]]; do
-            arg="$1"
-            shift
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            while [[ $# -gt 0 ]]; do
+              arg="$1"
+              shift
 
-            if [ "${arg}" == "--insecure-registries" ]; then
-              inInsecureRegistries=true
-            elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
-            else
-              echo "Invalid usage"
-              exit 1
-            fi
-          done
+              if [ "${arg}" == "--insecure-registries" ]; then
+                inInsecureRegistries=true
+              elif [ "${inInsecureRegistries}" == "true" ]; then
+                insecureRegistries="${insecureRegistries}${arg},"
+              else
+                echo "Invalid usage"
+                exit 1
+              fi
+            done
+          fi
 
           if [[ ! -z "$insecureRegistries" ]]; then
             echo "> Using insecure registries: $insecureRegistries"

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -17,6 +17,9 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   steps:
     - name: build-and-push
       image: heroku/builder:22
@@ -27,6 +30,8 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -18,7 +18,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   steps:
     - name: build-and-push

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -18,8 +18,9 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   steps:
     - name: build-and-push
       image: heroku/builder:22
@@ -30,17 +31,49 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
+          fi
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -93,13 +126,16 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -17,6 +17,9 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   steps:
     - name: build-and-push
       image: heroku/builder:22
@@ -27,6 +30,8 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -16,7 +16,7 @@ spec:
       default: "x86_64"
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -18,7 +18,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   steps:
     - name: build-and-push

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -18,8 +18,9 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   steps:
     - name: build-and-push
       image: heroku/builder:22
@@ -30,17 +31,49 @@ spec:
           value: $(params.system-architecture)
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
+          fi
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -77,7 +110,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"
@@ -93,13 +126,16 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -11,12 +11,17 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   steps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -12,7 +12,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   steps:
     - name: build-and-push

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -12,25 +12,58 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   steps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
-      env: 
+      env:
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
+          fi
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -67,7 +100,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"
@@ -83,13 +116,16 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -11,12 +11,17 @@ spec:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
+    - name: insecure-registries
+      description: Registries to consider insecure (http or self-signed certificate).
+      default: ""
   steps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
+        - name: CNB_INSECURE_REGISTRIES
+          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -10,7 +10,7 @@ spec:
   parameters:
     - name: platform-api-version
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
-      default: "0.12"
+      default: "0.13"
     - name: insecure-registries
       description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -12,7 +12,7 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.12"
     - name: insecure-registries
-      description: Registries to consider insecure (http or self-signed certificate).
+      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
       default: ""
   steps:
     - name: build-and-push

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -12,25 +12,58 @@ spec:
       description: The referenced version is the minimum version that all relevant buildpack implementations support.
       default: "0.13"
     - name: insecure-registries
-      description: Comma separated list of registries to consider insecure (http or self-signed certificate).
-      default: ""
+      description: List of registries to consider insecure (http or self-signed certificate).
+      type: array
+      defaults: []
   steps:
     - name: build-and-push
       image: docker.io/paketobuildpacks/builder-jammy-full:latest
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)
-        - name: CNB_INSECURE_REGISTRIES
-          value: $(params.insecure-registries)
         - name: PARAM_SOURCE_CONTEXT
           value: $(params.shp-source-context)
         - name: PARAM_OUTPUT_IMAGE
           value: $(params.shp-output-image)
+        - name: PARAM_OUTPUT_INSECURE
+          value: $(params.shp-output-insecure)
       command:
         - /bin/bash
       args:
         - -c
         - |
+          insecureRegistries=""
+          inInsecureRegistries=false
+
+          while [[ $# -gt 0 ]]; do
+            arg="$1"
+            shift
+
+            if [ "${arg}" == "--insecure-registries" ]; then
+              inInsecureRegistries=true
+            elif [ "${inInsecureRegistries}" == "true" ]; then
+              insecureRegistries="${insecureRegistries}${arg},"
+            else
+              echo "Invalid usage"
+              exit 1
+            fi
+          done
+
+          if [[ "${PARAM_OUTPUT_INSECURE}" == "true" ]]; then
+            outputImageHost="${PARAM_OUTPUT_IMAGE%%/*}"
+            if [[ "${outputImageHost}" == "${PARAM_OUTPUT_IMAGE}" || ( "${outputImageHost}" != *.* && "${outputImageHost}" != *:* && "${outputImageHost}" != "localhost" ) ]]; then
+              echo "> Output image '${PARAM_OUTPUT_IMAGE}' has no explicit registry host; not adding to insecure registries."
+            else
+              insecureRegistries="${insecureRegistries}${outputImageHost},"
+            fi
+          fi
+
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
+
           set -euo pipefail
 
           echo "> Processing environment variables..."
@@ -90,6 +123,9 @@ spec:
 
           # Store the image digest
           grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+        - --
+        - --insecure-registries
+        - $(params.insecure-registries[*])
       volumeMounts:
         - mountPath: /platform/env
           name: platform-env


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here. Ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR adds the insecure registries configuration option for buildpacks buildstrategy.

This is similar to what the buildah and source-to-image BuildStragegy provide and will allow people using local registries or registries behind self-signed certificate to use buildpacks to build their image.

# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Not a secure solution but partly related to #1835 while waiting for [SHIP-0042](https://github.com/shipwright-io/community/pull/281) implementation.

# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug
/kind feature
/kind cleanup
/kind documentation

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

/kind feature

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Kind label has been set
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!-- Describe any user-facing changes here, or mark as NONE.

Examples of user-facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

If this PR requires additional action from users switching to the new release,
include the string "action required" (case insensitive) in the release note.

If there are no user-facing changes, write NONE below. -->

```release-note
The buildpacks sample build strategies now allow the configuration of insecure registries in a fashion similar to buildah and source-to-image.
```
