### PR TITLE
Tolerate crane export creating tarballs with and without leading slash in the entry names

### DIFF
--- a/.github/download-latest-release.sh
+++ b/.github/download-latest-release.sh
@@ -22,7 +22,10 @@ echo "release-yaml=/tmp/release.yaml" >>"${GITHUB_OUTPUT}"
 # look at the first image, download the entrypoint to determine the Go version
 image="$(grep ghcr.io /tmp/release.yaml | sed -E 's/(image|value)://' | tr -d ' ' | head -n 1)"
 entrypoint="$(crane config "${image}" | jq -r '.config.Entrypoint[0]')"
-crane export "${image}" - | tar -xf - -C /tmp "${entrypoint:1}"
+crane export "${image}" /tmp/image.tar
+if ! tar -xf /tmp/image.tar -C /tmp "${entrypoint:1}"; then
+  tar -xf /tmp/image.tar -C /tmp "${entrypoint}"
+fi
 goVersion="$(go version "/tmp${entrypoint}" | sed "s#/tmp${entrypoint}: go##")"
 goVersion="${goVersion:0:4}"
 echo "[INFO] Go version is ${goVersion}"

--- a/.github/report-release-vulnerabilities.sh
+++ b/.github/report-release-vulnerabilities.sh
@@ -23,7 +23,7 @@ for image in "${images[@]}"; do
   binaryName="$(basename "${entrypoint}")"
   echo "  [INFO] Rebuilding github.com/shipwright-io/build/cmd/${binaryName}"
   pushd "${REPOSITORY}" >/dev/null
-    KO_DOCKER_REPO=dummy/image ko build "github.com/shipwright-io/build/cmd/${binaryName}" --bare --platform linux/amd64 --push=false --sbom none --tarball /tmp/image.tar
+    KO_DOCKER_REPO=dummy/image ko build "github.com/shipwright-io/build/cmd/${binaryName}" --bare --platform linux/amd64 --push=false --sbom none --tarball /tmp/new-image.tar
   popd >/dev/null
 
   # OS vulnerabilities (Grype)
@@ -31,7 +31,7 @@ for image in "${images[@]}"; do
   echo "### OS vulnerabilities (Grype)" >>/tmp/report.md
   osVulnsGrype="$(grype --output json --only-fixed --quiet "${image}")"
   osVulnsGrypeFound=false
-  osVulnsGrypeLatest="$(grype --output json --only-fixed --quiet /tmp/image.tar)"
+  osVulnsGrypeLatest="$(grype --output json --only-fixed --quiet /tmp/new-image.tar)"
   while read -r id pkg severity vulnerableVersion fixedVersion; do
     if [ "${id}" == "" ]; then
       continue
@@ -70,7 +70,7 @@ for image in "${images[@]}"; do
   echo "### OS vulnerabilities (Trivy)" >>/tmp/report.md
   osVulnsTrivy="$(trivy image --disable-telemetry --skip-version-check --format json --ignore-unfixed --no-progress --pkg-types os --scanners vuln --skip-db-update --timeout 10m "${image}")"
   osVulnsTrivyFound=false
-  osVulnsTrivyLatest="$(trivy image --disable-telemetry --skip-version-check --format json --ignore-unfixed --input /tmp/image.tar --no-progress --pkg-types os --scanners vuln --skip-db-update --timeout 10m)"
+  osVulnsTrivyLatest="$(trivy image --disable-telemetry --skip-version-check --format json --ignore-unfixed --input /tmp/new-image.tar --no-progress --pkg-types os --scanners vuln --skip-db-update --timeout 10m)"
   while read -r id pkg severity vulnerableVersion fixedVersion; do
     if [ "${id}" == "" ]; then
       continue
@@ -107,12 +107,18 @@ for image in "${images[@]}"; do
   # Go vulnerabilities
   echo "  [INFO] Checking for Go vulnerabilities"
   echo "### Go vulnerabilities" >>/tmp/report.md
-  crane export "${image}" - | tar -xf - -C /tmp "${entrypoint:1}"
+  crane export "${image}" /tmp/old-image-export.tar
+  if ! tar -xf /tmp/old-image-export.tar -C /tmp "${entrypoint:1}"; then
+    tar -xf /tmp/old-image-export.tar -C /tmp "${entrypoint}"
+  fi
   goVulns="$(govulncheck -format json -mode binary "/tmp${entrypoint}")"
   goVulnsFound=false
-  cat /tmp/image.tar | crane export - - | tar -xf - -C /tmp "${entrypoint:1}"
+  crane export - /tmp/new-image-export.tar </tmp/new-image.tar
+  if ! tar -xf /tmp/new-image-export.tar -C /tmp "${entrypoint:1}"; then
+    tar -xf /tmp/new-image-export.tar -C /tmp "${entrypoint}"
+  fi
   goVulnsLatest="$(govulncheck -format json -mode binary "/tmp${entrypoint}")"
-  rm -f /tmp/image.tar "/tmp${entrypoint}"
+  rm -f /tmp/new-image.tar /tmp/new-image-export.tar /tmp/old-image-export.tar "/tmp${entrypoint}"
   while read -r id pkg vulnerableVersion fixedVersion; do
     if [ "${id}" == "" ]; then
       continue


### PR DESCRIPTION
# Changes

The most recent crane version seemingly re-introduced the leading slash in the tarball entry names of a `crane export` output. That caused our vulnerability reporting to be broken (https://github.com/shipwright-io/build/actions/workflows/report-release-vulnerabilities.yaml).

Changing our logic now to something that can handle both, then they can do what they want.

I ran that in https://github.com/shipwright-io/build/actions/runs/24553685715 which worked.

# Type of PR

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
