### PR TITLE
Run 'make generate' when updating Tekton

### DIFF
--- a/.github/bump-tekton-lts.sh
+++ b/.github/bump-tekton-lts.sh
@@ -62,6 +62,9 @@ go mod vendor
 go get toolchain@none
 popd >/dev/null
 
+# As above changes may have changed the Kubernetes libraries, run code generation
+make -C "${BASEDIR}" generate
+
 # Update ci.yml
 sed -i "s/tekton: v.* # RETAIN-COMMENT: TEKTON_NEWEST_LTS/tekton: ${NEW_VERSION} # RETAIN-COMMENT: TEKTON_NEWEST_LTS/" "${BASEDIR}/.github/workflows/ci.yml"
 

--- a/.github/workflows/update-tekton-version.yaml
+++ b/.github/workflows/update-tekton-version.yaml
@@ -1,6 +1,6 @@
 ---
 # This workflow updates the Tekton version insight Shipwright Build to the latest LTS.
-# As part of that it uses a Personal Access Token that is stored as secret in shipwrigh-io/build
+# As part of that it uses a Personal Access Token that is stored as secret in shipwright-io/build
 # using the name SHIPWRIGHT_BUILD_WRITE_WORKFLOWS. The token expires every 90 days. Instructions
 # to renew it can be found in the "HOW TO update SHIPWRIGHT_BUILD_WRITE_WORKFLOWS" note in the
 # 1Password store that Shipwright Administrators have access to.
@@ -18,21 +18,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          path: go/src/github.com/shipwright-io/build
           token: ${{ secrets.SHIPWRIGHT_BUILD_WRITE_WORKFLOWS }}
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: '1.25.x'
           cache: true
+          cache-dependency-path: ./go/src/github.com/shipwright-io/build
           check-latest: true
+      - name: Install Counterfeiter
+        working-directory: go/src/github.com/shipwright-io/build
+        run: make install-counterfeiter
+      - name: Install Spruce
+        working-directory: go/src/github.com/shipwright-io/build
+        run: make install-spruce
 
       - name: Update Tekton version
         id: update-tekton
+        working-directory: go/src/github.com/shipwright-io/build
+        env:
+          GOPATH: ${{ github.workspace }}/go
         run: ./.github/bump-tekton-lts.sh --output "${GITHUB_OUTPUT}"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:
+          path: go/src/github.com/shipwright-io/build
           token: ${{ secrets.SHIPWRIGHT_BUILD_WRITE_WORKFLOWS }}
 
           commit-message: Bump Tekton Pipeline from ${{ steps.update-tekton.outputs.OLD_VERSION }} to ${{ steps.update-tekton.outputs.NEW_VERSION }}


### PR DESCRIPTION
# Changes

PR https://github.com/shipwright-io/build/pull/2178 fails in the verify step because the go.mod bump of Tekton causes Kubernetes libraries to be updated which requires generated code to be updated.

Therefore adding necessary tool installations and a run of `make generate` to the logic.

Tested in https://github.com/shipwright-io/build/actions/runs/25361069435.

# Type of PR

/kind failing-test

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
