### PR TITLE
Improve build metrics with new counters, gauges, and labels

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,17 +10,24 @@ The Build component exposes several metrics to help you monitor the health and b
 
 Following build metrics are exposed on port `8383`.
 
-| Name                                                 | Type      | Description                                       | Labels                                                                                                                                                                           | Status       |
-|:-----------------------------------------------------|:----------|:--------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------|
-| `build_builds_registered_total`                      | Counter   | Number of total registered Builds.                | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup>                                          | experimental |
-| `build_buildruns_completed_total`                    | Counter   | Number of total completed BuildRuns.              | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_establish_duration_seconds`          | Histogram | BuildRun establish duration in seconds.           | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_completion_duration_seconds`         | Histogram | BuildRun completion duration in seconds.          | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_rampup_duration_seconds`             | Histogram | BuildRun ramp-up duration in seconds              | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_rampup_duration_seconds`     | Histogram | BuildRun taskrun ramp-up duration in seconds.     | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| Name                                                 | Type      | Description                                                          | Labels                          | Status       |
+|:-----------------------------------------------------|:----------|:---------------------------------------------------------------------|:--------------------------------|:-------------|
+| `build_builds_registered_total`                      | Counter   | Number of total registered Builds (both successful and failed).      | `buildstrategy` `namespace` `build` `strategy_kind` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_result_total`                        | Counter   | Number of total completed BuildRuns by result.                       | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` `result` <sup>1</sup> | experimental |
+| `build_buildrun_failure_reason_total`                | Counter   | Number of total failed BuildRuns by failure reason.                  | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> `reason` <sup>2</sup> | experimental |
+| `build_buildruns_active`                             | Gauge     | Number of currently running BuildRuns.                               | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildstrategy_count`                          | Gauge     | Number of BuildStrategy and ClusterBuildStrategy objects.            | `strategy_kind` <sup>3</sup>    | experimental |
+| `build_buildrun_establish_duration_seconds`          | Histogram | BuildRun establish duration in seconds.                              | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_completion_duration_seconds`         | Histogram | BuildRun completion duration in seconds.                             | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_rampup_duration_seconds`             | Histogram | BuildRun ramp-up duration in seconds                                 | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_rampup_duration_seconds`     | Histogram | BuildRun taskrun ramp-up duration in seconds.                        | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds.                    | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
 
 <sup>1</sup> Labels for metric are disabled by default. See [Configuration of metric labels](#configuration-of-metric-labels) to enable them.
+
+<sup>2</sup> The `reason` label on `build_buildrun_failure_reason_total` is always present (not opt-in) because it is the defining dimension of this metric. Values are a bounded set of failure reasons such as `StepOutOfMemory`, `PodEvicted`, `BuildRunTimeout`, `BuildRunCanceled`, etc.
+
+<sup>3</sup> The `strategy_kind` label on `build_buildstrategy_count` is always present (not opt-in). Values are `BuildStrategy` or `ClusterBuildStrategy`.
 
 ## Configuration of histogram buckets
 
@@ -55,10 +62,14 @@ When you deploy the build controller in a Kubernetes cluster, you need to extend
 
 As the amount of buckets and labels has a direct impact on the number of Prometheus time series, you can selectively enable labels that you are interested in using the `PROMETHEUS_ENABLED_LABELS` environment variable. The supported labels are:
 
-* buildstrategy
-* namespace
-* build
-* buildrun
+* `buildstrategy` - The build strategy name
+* `namespace` - The Kubernetes namespace
+* `build` - The Build resource name
+* `buildrun` - The BuildRun resource name
+* `strategy_kind` - The strategy kind (`BuildStrategy` or `ClusterBuildStrategy`)
+* `executor` - The executor type (`TaskRun` or `PipelineRun`)
+* `result` - The build result (`succeeded`, `failed`, `cancelled`, `timeout`) - only on `build_buildrun_result_total`
+* `source_type` - The source code delivery method (`Git`, `OCI`, `Local`)
 
 Use a comma-separated value to enable multiple labels. For example:
 
@@ -70,7 +81,7 @@ make local
 or
 
 ```bash
-export PROMETHEUS_ENABLED_LABELS=buildstrategy,namespace,build
+export PROMETHEUS_ENABLED_LABELS=buildstrategy,namespace,build,strategy_kind,result
 make local
 ```
 
@@ -80,6 +91,6 @@ When you deploy the build controller in a Kubernetes cluster, you need to extend
 [...]
   env:
   - name: PROMETHEUS_ENABLED_LABELS
-    value: namespace
+    value: namespace,strategy_kind,result
 [...]
 ```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,17 +10,24 @@ The Build component exposes several metrics to help you monitor the health and b
 
 Following build metrics are exposed on port `8383`.
 
-| Name                                                 | Type      | Description                                       | Labels                                                                                                                                                                           | Status       |
-|:-----------------------------------------------------|:----------|:--------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------|
-| `build_builds_registered_total`                      | Counter   | Number of total registered Builds.                | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup>                                          | experimental |
-| `build_buildruns_completed_total`                    | Counter   | Number of total completed BuildRuns.              | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_establish_duration_seconds`          | Histogram | BuildRun establish duration in seconds.           | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_completion_duration_seconds`         | Histogram | BuildRun completion duration in seconds.          | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_rampup_duration_seconds`             | Histogram | BuildRun ramp-up duration in seconds              | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_rampup_duration_seconds`     | Histogram | BuildRun taskrun ramp-up duration in seconds.     | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
-| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds. | buildstrategy=<build_buildstrategy_name> <sup>1</sup><br>namespace=<buildrun_namespace> <sup>1</sup><br>build=<build_name> <sup>1</sup><br>buildrun=<buildrun_name> <sup>1</sup> | experimental |
+| Name                                                 | Type      | Description                                                          | Labels                          | Status       |
+|:-----------------------------------------------------|:----------|:---------------------------------------------------------------------|:--------------------------------|:-------------|
+| `build_builds_registered_total`                      | Counter   | Number of total registered Builds (both successful and failed).      | `buildstrategy` `namespace` `build` `strategy_kind` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_result_total`                        | Counter   | Number of total completed BuildRuns by result.                       | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` `result` <sup>1</sup> | experimental |
+| `build_buildrun_failure_reason_total`                | Counter   | Number of total failed BuildRuns by failure reason.                  | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> `reason` <sup>2</sup> | experimental |
+| `build_buildruns_active`                             | Gauge     | Number of currently running BuildRuns.                               | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildstrategy_count`                          | Gauge     | Number of BuildStrategy and ClusterBuildStrategy objects.            | `strategy_kind` <sup>3</sup>    | experimental |
+| `build_buildrun_establish_duration_seconds`          | Histogram | BuildRun establish duration in seconds.                              | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_completion_duration_seconds`         | Histogram | BuildRun completion duration in seconds.                             | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_rampup_duration_seconds`             | Histogram | BuildRun ramp-up duration in seconds                                 | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_rampup_duration_seconds`     | Histogram | BuildRun taskrun ramp-up duration in seconds.                        | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
+| `build_buildrun_taskrun_pod_rampup_duration_seconds` | Histogram | BuildRun taskrun pod ramp-up duration in seconds.                    | `buildstrategy` `namespace` `build` `buildrun` `strategy_kind` `executor` `source_type` <sup>1</sup> | experimental |
 
 <sup>1</sup> Labels for metric are disabled by default. See [Configuration of metric labels](#configuration-of-metric-labels) to enable them.
+
+<sup>2</sup> The `reason` label on `build_buildrun_failure_reason_total` is always present (not opt-in) because it is the defining dimension of this metric. Values are a bounded set of failure reasons such as `StepOutOfMemory`, `PodEvicted`, `BuildRunTimeout`, `BuildRunCanceled`, etc.
+
+<sup>3</sup> The `strategy_kind` label on `build_buildstrategy_count` is always present (not opt-in). Values are `BuildStrategy` or `ClusterBuildStrategy`.
 
 ## Configuration of histogram buckets
 
@@ -55,10 +62,14 @@ When you deploy the build controller in a Kubernetes cluster, you need to extend
 
 As the amount of buckets and labels has a direct impact on the number of Prometheus time series, you can selectively enable labels that you are interested in using the `PROMETHEUS_ENABLED_LABELS` environment variable. The supported labels are:
 
-* buildstrategy
-* namespace
-* build
-* buildrun
+* `buildstrategy` - The build strategy name
+* `namespace` - The Kubernetes namespace
+* `build` - The Build resource name
+* `buildrun` - The BuildRun resource name
+* `strategy_kind` - The strategy kind (`BuildStrategy` or `ClusterBuildStrategy`)
+* `executor` - The executor type (`TaskRun` or `PipelineRun`)
+* `result` - The build result (`succeeded`, `failed`, `canceled`, `timeout`) - only on `build_buildrun_result_total`
+* `source_type` - The source code delivery method (`Git`, `OCI`, `Local`)
 
 Use a comma-separated value to enable multiple labels. For example:
 
@@ -70,7 +81,7 @@ make local
 or
 
 ```bash
-export PROMETHEUS_ENABLED_LABELS=buildstrategy,namespace,build
+export PROMETHEUS_ENABLED_LABELS=buildstrategy,namespace,build,strategy_kind,result
 make local
 ```
 
@@ -80,6 +91,6 @@ When you deploy the build controller in a Kubernetes cluster, you need to extend
 [...]
   env:
   - name: PROMETHEUS_ENABLED_LABELS
-    value: namespace
+    value: namespace,strategy_kind,result
 [...]
 ```

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,11 +20,22 @@ const (
 	NamespaceLabel     string = "namespace"
 	BuildLabel         string = "build"
 	BuildRunLabel      string = "buildrun"
+	StrategyKindLabel  string = "strategy_kind"
+	ExecutorLabel      string = "executor"
+	ResultLabel        string = "result"
+	SourceTypeLabel    string = "source_type"
+)
+
+// Result label values for build_buildrun_result_total
+const (
+	ResultSucceeded = "succeeded"
+	ResultFailed    = "failed"
+	ResultCancelled = "cancelled"
+	ResultTimeout   = "timeout"
 )
 
 var (
-	buildCount    *prometheus.CounterVec
-	buildRunCount *prometheus.CounterVec
+	buildCount *prometheus.CounterVec
 
 	buildRunEstablishDuration  *prometheus.HistogramVec
 	buildRunCompletionDuration *prometheus.HistogramVec
@@ -33,10 +44,19 @@ var (
 	taskRunRampUpDuration    *prometheus.HistogramVec
 	taskRunPodRampUpDuration *prometheus.HistogramVec
 
+	buildRunResultCount        *prometheus.CounterVec
+	buildRunFailureReasonCount *prometheus.CounterVec
+	buildRunsActive            *prometheus.GaugeVec
+	buildStrategyCount         *prometheus.GaugeVec
+
 	buildStrategyLabelEnabled = false
 	namespaceLabelEnabled     = false
 	buildLabelEnabled         = false
 	buildRunLabelEnabled      = false
+	strategyKindLabelEnabled  = false
+	executorLabelEnabled      = false
+	resultLabelEnabled        = false
+	sourceTypeLabelEnabled    = false
 
 	initialized = false
 )
@@ -73,6 +93,33 @@ func InitPrometheus(config *config.Config) {
 		buildRunLabels = append(buildRunLabels, BuildRunLabel)
 		buildRunLabelEnabled = true
 	}
+	if contains(config.Prometheus.EnabledLabels, StrategyKindLabel) {
+		buildLabels = append(buildLabels, StrategyKindLabel)
+		buildRunLabels = append(buildRunLabels, StrategyKindLabel)
+		strategyKindLabelEnabled = true
+	}
+	if contains(config.Prometheus.EnabledLabels, ExecutorLabel) {
+		buildRunLabels = append(buildRunLabels, ExecutorLabel)
+		executorLabelEnabled = true
+	}
+	if contains(config.Prometheus.EnabledLabels, SourceTypeLabel) {
+		buildLabels = append(buildLabels, SourceTypeLabel)
+		buildRunLabels = append(buildRunLabels, SourceTypeLabel)
+		sourceTypeLabelEnabled = true
+	}
+
+	// buildRunResultLabels includes the result label for build_buildrun_result_total
+	buildRunResultLabels := make([]string, len(buildRunLabels))
+	copy(buildRunResultLabels, buildRunLabels)
+	if contains(config.Prometheus.EnabledLabels, ResultLabel) {
+		buildRunResultLabels = append(buildRunResultLabels, ResultLabel)
+		resultLabelEnabled = true
+	}
+
+	// buildRunFailureReasonLabels always includes the reason label
+	buildRunFailureReasonLabels := make([]string, len(buildRunLabels))
+	copy(buildRunFailureReasonLabels, buildRunLabels)
+	buildRunFailureReasonLabels = append(buildRunFailureReasonLabels, "reason")
 
 	buildCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -80,13 +127,6 @@ func InitPrometheus(config *config.Config) {
 			Help: "Number of total registered Builds.",
 		},
 		buildLabels)
-
-	buildRunCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "build_buildruns_completed_total",
-			Help: "Number of total completed BuildRuns.",
-		},
-		buildRunLabels)
 
 	buildRunEstablishDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -128,15 +168,46 @@ func InitPrometheus(config *config.Config) {
 		},
 		buildRunLabels)
 
+	buildRunResultCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "build_buildrun_result_total",
+			Help: "Number of total completed BuildRuns by result.",
+		},
+		buildRunResultLabels)
+
+	buildRunFailureReasonCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "build_buildrun_failure_reason_total",
+			Help: "Number of total failed BuildRuns by failure reason.",
+		},
+		buildRunFailureReasonLabels)
+
+	buildRunsActive = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "build_buildruns_active",
+			Help: "Number of currently running BuildRuns.",
+		},
+		buildRunLabels)
+
+	buildStrategyCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "build_buildstrategy_count",
+			Help: "Number of BuildStrategy and ClusterBuildStrategy objects.",
+		},
+		[]string{StrategyKindLabel})
+
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(
 		buildCount,
-		buildRunCount,
 		buildRunEstablishDuration,
 		buildRunCompletionDuration,
 		buildRunRampUpDuration,
 		taskRunRampUpDuration,
 		taskRunPodRampUpDuration,
+		buildRunResultCount,
+		buildRunFailureReasonCount,
+		buildRunsActive,
+		buildStrategyCount,
 	)
 }
 
@@ -155,7 +226,7 @@ func contains(slice []string, element string) bool {
 	return false
 }
 
-func createBuildLabels(buildStrategy string, namespace string, build string) prometheus.Labels {
+func createBuildLabels(buildStrategy, namespace, build, strategyKind, sourceType string) prometheus.Labels {
 	labels := prometheus.Labels{}
 
 	if buildStrategyLabelEnabled {
@@ -167,11 +238,17 @@ func createBuildLabels(buildStrategy string, namespace string, build string) pro
 	if buildLabelEnabled {
 		labels[BuildLabel] = build
 	}
+	if strategyKindLabelEnabled {
+		labels[StrategyKindLabel] = strategyKind
+	}
+	if sourceTypeLabelEnabled {
+		labels[SourceTypeLabel] = sourceType
+	}
 
 	return labels
 }
 
-func createBuildRunLabels(buildStrategy string, namespace string, build string, buildRun string) prometheus.Labels {
+func createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string) prometheus.Labels {
 	labels := prometheus.Labels{}
 
 	if buildStrategyLabelEnabled {
@@ -186,55 +263,106 @@ func createBuildRunLabels(buildStrategy string, namespace string, build string, 
 	if buildRunLabelEnabled {
 		labels[BuildRunLabel] = buildRun
 	}
+	if strategyKindLabelEnabled {
+		labels[StrategyKindLabel] = strategyKind
+	}
+	if executorLabelEnabled {
+		labels[ExecutorLabel] = executor
+	}
+	if sourceTypeLabelEnabled {
+		labels[SourceTypeLabel] = sourceType
+	}
 
 	return labels
 }
 
-// BuildCountInc increases a number of the existing build total count
-func BuildCountInc(buildStrategy string, namespace string, build string) {
-	if buildCount != nil {
-		buildCount.With(createBuildLabels(buildStrategy, namespace, build)).Inc()
+func createBuildRunResultLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, result, sourceType string) prometheus.Labels {
+	labels := createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)
+	if resultLabelEnabled {
+		labels[ResultLabel] = result
 	}
+	return labels
 }
 
-// BuildRunCountInc increases a number of the existing build run total count
-func BuildRunCountInc(buildStrategy string, namespace string, build string, buildRun string) {
-	if buildRunCount != nil {
-		buildRunCount.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Inc()
+func createBuildRunFailureReasonLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType, reason string) prometheus.Labels {
+	labels := createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)
+	labels["reason"] = reason
+	return labels
+}
+
+// BuildCountInc increases the total count of registered Builds
+func BuildCountInc(buildStrategy, namespace, build, strategyKind, sourceType string) {
+	if buildCount != nil {
+		buildCount.With(createBuildLabels(buildStrategy, namespace, build, strategyKind, sourceType)).Inc()
 	}
 }
 
 // BuildRunEstablishObserve sets the build run establish time
-func BuildRunEstablishObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func BuildRunEstablishObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if buildRunEstablishDuration != nil {
-		buildRunEstablishDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		buildRunEstablishDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunCompletionObserve sets the build run completion time
-func BuildRunCompletionObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func BuildRunCompletionObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if buildRunCompletionDuration != nil {
-		buildRunCompletionDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		buildRunCompletionDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunRampUpDurationObserve processes the observation of a new buildrun ramp-up duration
-func BuildRunRampUpDurationObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func BuildRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if buildRunRampUpDuration != nil {
-		buildRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		buildRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunRampUpDurationObserve processes the observation of a new taskrun ramp-up duration
-func TaskRunRampUpDurationObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func TaskRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if taskRunRampUpDuration != nil {
-		taskRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		taskRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunPodRampUpDurationObserve processes the observation of a new taskrun pod ramp-up duration
-func TaskRunPodRampUpDurationObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func TaskRunPodRampUpDurationObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if taskRunPodRampUpDuration != nil {
-		taskRunPodRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		taskRunPodRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
+	}
+}
+
+// BuildRunResultCountInc increments the build_buildrun_result_total counter
+func BuildRunResultCountInc(buildStrategy, namespace, build, buildRun, strategyKind, executor, result, sourceType string) {
+	if buildRunResultCount != nil {
+		buildRunResultCount.With(createBuildRunResultLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, result, sourceType)).Inc()
+	}
+}
+
+// BuildRunFailureReasonCountInc increments the build_buildrun_failure_reason_total counter
+func BuildRunFailureReasonCountInc(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType, reason string) {
+	if buildRunFailureReasonCount != nil {
+		buildRunFailureReasonCount.With(createBuildRunFailureReasonLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType, reason)).Inc()
+	}
+}
+
+// BuildRunsActiveInc increments the build_buildruns_active gauge
+func BuildRunsActiveInc(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string) {
+	if buildRunsActive != nil {
+		buildRunsActive.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Inc()
+	}
+}
+
+// BuildRunsActiveDec decrements the build_buildruns_active gauge
+func BuildRunsActiveDec(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string) {
+	if buildRunsActive != nil {
+		buildRunsActive.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Dec()
+	}
+}
+
+// BuildStrategyCountSet sets the build_buildstrategy_count gauge
+func BuildStrategyCountSet(strategyKind string, count float64) {
+	if buildStrategyCount != nil {
+		buildStrategyCount.With(prometheus.Labels{StrategyKindLabel: strategyKind}).Set(count)
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,11 +20,22 @@ const (
 	NamespaceLabel     string = "namespace"
 	BuildLabel         string = "build"
 	BuildRunLabel      string = "buildrun"
+	StrategyKindLabel  string = "strategy_kind"
+	ExecutorLabel      string = "executor"
+	ResultLabel        string = "result"
+	SourceTypeLabel    string = "source_type"
+)
+
+// Result label values for build_buildrun_result_total
+const (
+	ResultSucceeded = "succeeded"
+	ResultFailed    = "failed"
+	ResultCanceled  = "canceled"
+	ResultTimeout   = "timeout"
 )
 
 var (
-	buildCount    *prometheus.CounterVec
-	buildRunCount *prometheus.CounterVec
+	buildCount *prometheus.CounterVec
 
 	buildRunEstablishDuration  *prometheus.HistogramVec
 	buildRunCompletionDuration *prometheus.HistogramVec
@@ -33,10 +44,19 @@ var (
 	taskRunRampUpDuration    *prometheus.HistogramVec
 	taskRunPodRampUpDuration *prometheus.HistogramVec
 
+	buildRunResultCount        *prometheus.CounterVec
+	buildRunFailureReasonCount *prometheus.CounterVec
+	buildRunsActive            *prometheus.GaugeVec
+	buildStrategyCount         *prometheus.GaugeVec
+
 	buildStrategyLabelEnabled = false
 	namespaceLabelEnabled     = false
 	buildLabelEnabled         = false
 	buildRunLabelEnabled      = false
+	strategyKindLabelEnabled  = false
+	executorLabelEnabled      = false
+	resultLabelEnabled        = false
+	sourceTypeLabelEnabled    = false
 
 	initialized = false
 )
@@ -73,6 +93,33 @@ func InitPrometheus(config *config.Config) {
 		buildRunLabels = append(buildRunLabels, BuildRunLabel)
 		buildRunLabelEnabled = true
 	}
+	if contains(config.Prometheus.EnabledLabels, StrategyKindLabel) {
+		buildLabels = append(buildLabels, StrategyKindLabel)
+		buildRunLabels = append(buildRunLabels, StrategyKindLabel)
+		strategyKindLabelEnabled = true
+	}
+	if contains(config.Prometheus.EnabledLabels, ExecutorLabel) {
+		buildRunLabels = append(buildRunLabels, ExecutorLabel)
+		executorLabelEnabled = true
+	}
+	if contains(config.Prometheus.EnabledLabels, SourceTypeLabel) {
+		buildLabels = append(buildLabels, SourceTypeLabel)
+		buildRunLabels = append(buildRunLabels, SourceTypeLabel)
+		sourceTypeLabelEnabled = true
+	}
+
+	// buildRunResultLabels includes the result label for build_buildrun_result_total
+	buildRunResultLabels := make([]string, len(buildRunLabels))
+	copy(buildRunResultLabels, buildRunLabels)
+	if contains(config.Prometheus.EnabledLabels, ResultLabel) {
+		buildRunResultLabels = append(buildRunResultLabels, ResultLabel)
+		resultLabelEnabled = true
+	}
+
+	// buildRunFailureReasonLabels always includes the reason label
+	buildRunFailureReasonLabels := make([]string, len(buildRunLabels))
+	copy(buildRunFailureReasonLabels, buildRunLabels)
+	buildRunFailureReasonLabels = append(buildRunFailureReasonLabels, "reason")
 
 	buildCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -80,13 +127,6 @@ func InitPrometheus(config *config.Config) {
 			Help: "Number of total registered Builds.",
 		},
 		buildLabels)
-
-	buildRunCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "build_buildruns_completed_total",
-			Help: "Number of total completed BuildRuns.",
-		},
-		buildRunLabels)
 
 	buildRunEstablishDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -128,15 +168,46 @@ func InitPrometheus(config *config.Config) {
 		},
 		buildRunLabels)
 
+	buildRunResultCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "build_buildrun_result_total",
+			Help: "Number of total completed BuildRuns by result.",
+		},
+		buildRunResultLabels)
+
+	buildRunFailureReasonCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "build_buildrun_failure_reason_total",
+			Help: "Number of total failed BuildRuns by failure reason.",
+		},
+		buildRunFailureReasonLabels)
+
+	buildRunsActive = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "build_buildruns_active",
+			Help: "Number of currently running BuildRuns.",
+		},
+		buildRunLabels)
+
+	buildStrategyCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "build_buildstrategy_count",
+			Help: "Number of BuildStrategy and ClusterBuildStrategy objects.",
+		},
+		[]string{StrategyKindLabel})
+
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(
 		buildCount,
-		buildRunCount,
 		buildRunEstablishDuration,
 		buildRunCompletionDuration,
 		buildRunRampUpDuration,
 		taskRunRampUpDuration,
 		taskRunPodRampUpDuration,
+		buildRunResultCount,
+		buildRunFailureReasonCount,
+		buildRunsActive,
+		buildStrategyCount,
 	)
 }
 
@@ -155,7 +226,7 @@ func contains(slice []string, element string) bool {
 	return false
 }
 
-func createBuildLabels(buildStrategy string, namespace string, build string) prometheus.Labels {
+func createBuildLabels(buildStrategy, namespace, build, strategyKind, sourceType string) prometheus.Labels {
 	labels := prometheus.Labels{}
 
 	if buildStrategyLabelEnabled {
@@ -167,11 +238,17 @@ func createBuildLabels(buildStrategy string, namespace string, build string) pro
 	if buildLabelEnabled {
 		labels[BuildLabel] = build
 	}
+	if strategyKindLabelEnabled {
+		labels[StrategyKindLabel] = strategyKind
+	}
+	if sourceTypeLabelEnabled {
+		labels[SourceTypeLabel] = sourceType
+	}
 
 	return labels
 }
 
-func createBuildRunLabels(buildStrategy string, namespace string, build string, buildRun string) prometheus.Labels {
+func createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string) prometheus.Labels {
 	labels := prometheus.Labels{}
 
 	if buildStrategyLabelEnabled {
@@ -186,55 +263,106 @@ func createBuildRunLabels(buildStrategy string, namespace string, build string, 
 	if buildRunLabelEnabled {
 		labels[BuildRunLabel] = buildRun
 	}
+	if strategyKindLabelEnabled {
+		labels[StrategyKindLabel] = strategyKind
+	}
+	if executorLabelEnabled {
+		labels[ExecutorLabel] = executor
+	}
+	if sourceTypeLabelEnabled {
+		labels[SourceTypeLabel] = sourceType
+	}
 
 	return labels
 }
 
-// BuildCountInc increases a number of the existing build total count
-func BuildCountInc(buildStrategy string, namespace string, build string) {
-	if buildCount != nil {
-		buildCount.With(createBuildLabels(buildStrategy, namespace, build)).Inc()
+func createBuildRunResultLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, result, sourceType string) prometheus.Labels {
+	labels := createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)
+	if resultLabelEnabled {
+		labels[ResultLabel] = result
 	}
+	return labels
 }
 
-// BuildRunCountInc increases a number of the existing build run total count
-func BuildRunCountInc(buildStrategy string, namespace string, build string, buildRun string) {
-	if buildRunCount != nil {
-		buildRunCount.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Inc()
+func createBuildRunFailureReasonLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType, reason string) prometheus.Labels {
+	labels := createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)
+	labels["reason"] = reason
+	return labels
+}
+
+// BuildCountInc increases the total count of registered Builds
+func BuildCountInc(buildStrategy, namespace, build, strategyKind, sourceType string) {
+	if buildCount != nil {
+		buildCount.With(createBuildLabels(buildStrategy, namespace, build, strategyKind, sourceType)).Inc()
 	}
 }
 
 // BuildRunEstablishObserve sets the build run establish time
-func BuildRunEstablishObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func BuildRunEstablishObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if buildRunEstablishDuration != nil {
-		buildRunEstablishDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		buildRunEstablishDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunCompletionObserve sets the build run completion time
-func BuildRunCompletionObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func BuildRunCompletionObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if buildRunCompletionDuration != nil {
-		buildRunCompletionDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		buildRunCompletionDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // BuildRunRampUpDurationObserve processes the observation of a new buildrun ramp-up duration
-func BuildRunRampUpDurationObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func BuildRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if buildRunRampUpDuration != nil {
-		buildRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		buildRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunRampUpDurationObserve processes the observation of a new taskrun ramp-up duration
-func TaskRunRampUpDurationObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func TaskRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if taskRunRampUpDuration != nil {
-		taskRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		taskRunRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
 	}
 }
 
 // TaskRunPodRampUpDurationObserve processes the observation of a new taskrun pod ramp-up duration
-func TaskRunPodRampUpDurationObserve(buildStrategy string, namespace string, build string, buildRun string, duration time.Duration) {
+func TaskRunPodRampUpDurationObserve(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string, duration time.Duration) {
 	if taskRunPodRampUpDuration != nil {
-		taskRunPodRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun)).Observe(duration.Seconds())
+		taskRunPodRampUpDuration.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Observe(duration.Seconds())
+	}
+}
+
+// BuildRunResultCountInc increments the build_buildrun_result_total counter
+func BuildRunResultCountInc(buildStrategy, namespace, build, buildRun, strategyKind, executor, result, sourceType string) {
+	if buildRunResultCount != nil {
+		buildRunResultCount.With(createBuildRunResultLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, result, sourceType)).Inc()
+	}
+}
+
+// BuildRunFailureReasonCountInc increments the build_buildrun_failure_reason_total counter
+func BuildRunFailureReasonCountInc(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType, reason string) {
+	if buildRunFailureReasonCount != nil {
+		buildRunFailureReasonCount.With(createBuildRunFailureReasonLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType, reason)).Inc()
+	}
+}
+
+// BuildRunsActiveInc increments the build_buildruns_active gauge
+func BuildRunsActiveInc(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string) {
+	if buildRunsActive != nil {
+		buildRunsActive.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Inc()
+	}
+}
+
+// BuildRunsActiveDec decrements the build_buildruns_active gauge
+func BuildRunsActiveDec(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType string) {
+	if buildRunsActive != nil {
+		buildRunsActive.With(createBuildRunLabels(buildStrategy, namespace, build, buildRun, strategyKind, executor, sourceType)).Dec()
+	}
+}
+
+// BuildStrategyCountSet sets the build_buildstrategy_count gauge
+func BuildStrategyCountSet(strategyKind string, count float64) {
+	if buildStrategyCount != nil {
+		buildStrategyCount.With(prometheus.Labels{StrategyKindLabel: strategyKind}).Set(count)
 	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -20,6 +20,8 @@ type buildLabels struct {
 	buildStrategy string
 	namespace     string
 	build         string
+	strategyKind  string
+	sourceType    string
 }
 
 type buildRunLabels struct {
@@ -27,12 +29,40 @@ type buildRunLabels struct {
 	namespace     string
 	build         string
 	buildRun      string
+	strategyKind  string
+	executor      string
+	sourceType    string
+}
+
+type buildRunResultLabels struct {
+	buildStrategy string
+	namespace     string
+	build         string
+	buildRun      string
+	strategyKind  string
+	executor      string
+	sourceType    string
+	result        string
+}
+
+type buildRunFailureReasonLabels struct {
+	buildStrategy string
+	namespace     string
+	build         string
+	buildRun      string
+	strategyKind  string
+	executor      string
+	sourceType    string
+	reason        string
 }
 
 var (
-	buildCounterMetrics      map[string]map[buildLabels]float64
-	buildRunCounterMetrics   map[string]map[buildRunLabels]float64
-	buildRunHistogramMetrics map[string]map[buildRunLabels]float64
+	buildCounterMetrics            map[string]map[buildLabels]float64
+	buildRunHistogramMetrics       map[string]map[buildRunLabels]float64
+	buildRunResultCounterMetrics   map[string]map[buildRunResultLabels]float64
+	buildRunFailureReasonMetrics   map[string]map[buildRunFailureReasonLabels]float64
+	buildRunsActiveGaugeMetrics    map[string]map[buildRunLabels]float64
+	buildStrategyCountGaugeMetrics map[string]map[string]float64
 )
 
 func promLabelPairToBuildLabels(in []*io_prometheus_client.LabelPair) buildLabels {
@@ -45,6 +75,10 @@ func promLabelPairToBuildLabels(in []*io_prometheus_client.LabelPair) buildLabel
 			result.namespace = *label.Value
 		case BuildLabel:
 			result.build = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
 		}
 	}
 
@@ -63,6 +97,64 @@ func promLabelPairToBuildRunLabels(in []*io_prometheus_client.LabelPair) buildRu
 			result.build = *label.Value
 		case BuildRunLabel:
 			result.buildRun = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case ExecutorLabel:
+			result.executor = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
+		}
+	}
+
+	return result
+}
+
+func promLabelPairToBuildRunResultLabels(in []*io_prometheus_client.LabelPair) buildRunResultLabels {
+	result := buildRunResultLabels{}
+	for _, label := range in {
+		switch *label.Name {
+		case BuildStrategyLabel:
+			result.buildStrategy = *label.Value
+		case NamespaceLabel:
+			result.namespace = *label.Value
+		case BuildLabel:
+			result.build = *label.Value
+		case BuildRunLabel:
+			result.buildRun = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case ExecutorLabel:
+			result.executor = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
+		case ResultLabel:
+			result.result = *label.Value
+		}
+	}
+
+	return result
+}
+
+func promLabelPairToBuildRunFailureReasonLabels(in []*io_prometheus_client.LabelPair) buildRunFailureReasonLabels {
+	result := buildRunFailureReasonLabels{}
+	for _, label := range in {
+		switch *label.Name {
+		case BuildStrategyLabel:
+			result.buildStrategy = *label.Value
+		case NamespaceLabel:
+			result.namespace = *label.Value
+		case BuildLabel:
+			result.build = *label.Value
+		case BuildRunLabel:
+			result.buildRun = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case ExecutorLabel:
+			result.executor = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
+		case "reason":
+			result.reason = *label.Value
 		}
 	}
 
@@ -71,13 +163,26 @@ func promLabelPairToBuildRunLabels(in []*io_prometheus_client.LabelPair) buildRu
 
 var _ = BeforeSuite(func() {
 	buildCounterMetrics = map[string]map[buildLabels]float64{}
-	buildRunCounterMetrics = map[string]map[buildRunLabels]float64{}
 	buildRunHistogramMetrics = map[string]map[buildRunLabels]float64{}
+	buildRunResultCounterMetrics = map[string]map[buildRunResultLabels]float64{}
+	buildRunFailureReasonMetrics = map[string]map[buildRunFailureReasonLabels]float64{}
+	buildRunsActiveGaugeMetrics = map[string]map[buildRunLabels]float64{}
+	buildStrategyCountGaugeMetrics = map[string]map[string]float64{}
+
+	type testEntry struct {
+		buildStrategy string
+		namespace     string
+		build         string
+		buildRun      string
+		strategyKind  string
+		executor      string
+		sourceType    string
+	}
 
 	var (
-		testLabels = []buildRunLabels{
-			{buildStrategy: "kaniko", namespace: "default", build: "kaniko-build", buildRun: "kaniko-buildrun"},
-			{buildStrategy: "buildpacks", namespace: "default", build: "buildpacks-build", buildRun: "buildpacks-buildrun"},
+		testLabels = []testEntry{
+			{buildStrategy: "kaniko", namespace: "default", build: "kaniko-build", buildRun: "kaniko-buildrun", strategyKind: "ClusterBuildStrategy", executor: "TaskRun", sourceType: "Git"},
+			{buildStrategy: "buildpacks", namespace: "default", build: "buildpacks-build", buildRun: "buildpacks-buildrun", strategyKind: "BuildStrategy", executor: "PipelineRun", sourceType: "OCI"},
 		}
 
 		knownHistogramMetrics = []string{
@@ -91,7 +196,10 @@ var _ = BeforeSuite(func() {
 
 	// initialize the counter metrics result map with empty maps
 	buildCounterMetrics["build_builds_registered_total"] = map[buildLabels]float64{}
-	buildRunCounterMetrics["build_buildruns_completed_total"] = map[buildRunLabels]float64{}
+	buildRunResultCounterMetrics["build_buildrun_result_total"] = map[buildRunResultLabels]float64{}
+	buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"] = map[buildRunFailureReasonLabels]float64{}
+	buildRunsActiveGaugeMetrics["build_buildruns_active"] = map[buildRunLabels]float64{}
+	buildStrategyCountGaugeMetrics["build_buildstrategy_count"] = map[string]float64{}
 
 	// initialize the histogram metrics result map with empty maps
 	for _, name := range knownHistogramMetrics {
@@ -100,22 +208,44 @@ var _ = BeforeSuite(func() {
 
 	// initialize prometheus (second init should be no-op)
 	config := config.NewDefaultConfig()
-	config.Prometheus.EnabledLabels = []string{BuildStrategyLabel, NamespaceLabel, BuildLabel, BuildRunLabel}
+	config.Prometheus.EnabledLabels = []string{
+		BuildStrategyLabel, NamespaceLabel, BuildLabel, BuildRunLabel,
+		StrategyKindLabel, ExecutorLabel, ResultLabel, SourceTypeLabel,
+	}
 	InitPrometheus(config)
 
 	// and fire some examples
 	for _, entry := range testLabels {
-		buildStrategy, namespace, build, buildRun := entry.buildStrategy, entry.namespace, entry.build, entry.buildRun
+		BuildCountInc(entry.buildStrategy, entry.namespace, entry.build, entry.strategyKind, entry.sourceType)
+		BuildRunEstablishObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(1)*time.Second)
+		BuildRunCompletionObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(200)*time.Second)
+		BuildRunRampUpDurationObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(1)*time.Second)
+		TaskRunRampUpDurationObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(2)*time.Second)
+		TaskRunPodRampUpDurationObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(3)*time.Second)
 
-		// tell prometheus some things have happened
-		BuildCountInc(buildStrategy, namespace, build)
-		BuildRunCountInc(buildStrategy, namespace, build, buildRun)
-		BuildRunEstablishObserve(buildStrategy, namespace, build, buildRun, time.Duration(1)*time.Second)
-		BuildRunCompletionObserve(buildStrategy, namespace, build, buildRun, time.Duration(200)*time.Second)
-		BuildRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, time.Duration(1)*time.Second)
-		TaskRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, time.Duration(2)*time.Second)
-		TaskRunPodRampUpDurationObserve(buildStrategy, namespace, build, buildRun, time.Duration(3)*time.Second)
+		// Record result metrics
+		BuildRunResultCountInc(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, ResultSucceeded, entry.sourceType)
+
+		// Record active gauge (inc and dec to simulate a completed run)
+		BuildRunsActiveInc(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType)
 	}
+
+	// Record some failures
+	BuildRunResultCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", ResultFailed, "Git")
+	BuildRunFailureReasonCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", "Git", "StepOutOfMemory")
+
+	BuildRunResultCountInc("buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", ResultCancelled, "OCI")
+	BuildRunFailureReasonCountInc("buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", "OCI", "BuildRunCanceled")
+
+	BuildRunResultCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", ResultTimeout, "Git")
+	BuildRunFailureReasonCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", "Git", "BuildRunTimeout")
+
+	// Decrement active for the first entry to test net gauge
+	BuildRunsActiveDec(testLabels[0].buildStrategy, testLabels[0].namespace, testLabels[0].build, testLabels[0].buildRun, testLabels[0].strategyKind, testLabels[0].executor, testLabels[0].sourceType)
+
+	// Set strategy counts
+	BuildStrategyCountSet("BuildStrategy", 3)
+	BuildStrategyCountSet("ClusterBuildStrategy", 5)
 
 	// gather metrics from prometheus and fill the result maps
 	metrics, err := crmetrics.Registry.Gather()
@@ -124,19 +254,42 @@ var _ = BeforeSuite(func() {
 	}
 
 	for _, metricFamily := range metrics {
-		if metricFamily.GetType() == io_prometheus_client.MetricType_HISTOGRAM {
+		switch metricFamily.GetName() {
+		case "build_builds_registered_total":
 			for _, metric := range metricFamily.GetMetric() {
-				buildRunHistogramMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetHistogram().GetSampleSum()
+				buildCounterMetrics[metricFamily.GetName()][promLabelPairToBuildLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
 			}
-		} else {
-			switch metricFamily.GetName() {
-			case "build_builds_registered_total":
-				for _, metric := range metricFamily.GetMetric() {
-					buildCounterMetrics[metricFamily.GetName()][promLabelPairToBuildLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+
+		case "build_buildrun_result_total":
+			for _, metric := range metricFamily.GetMetric() {
+				buildRunResultCounterMetrics[metricFamily.GetName()][promLabelPairToBuildRunResultLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+			}
+
+		case "build_buildrun_failure_reason_total":
+			for _, metric := range metricFamily.GetMetric() {
+				buildRunFailureReasonMetrics[metricFamily.GetName()][promLabelPairToBuildRunFailureReasonLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+			}
+
+		case "build_buildruns_active":
+			for _, metric := range metricFamily.GetMetric() {
+				buildRunsActiveGaugeMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetGauge().GetValue()
+			}
+
+		case "build_buildstrategy_count":
+			for _, metric := range metricFamily.GetMetric() {
+				for _, label := range metric.GetLabel() {
+					if *label.Name == StrategyKindLabel {
+						buildStrategyCountGaugeMetrics[metricFamily.GetName()][*label.Value] = metric.GetGauge().GetValue()
+					}
 				}
-			case "build_buildruns_completed_total":
-				for _, metric := range metricFamily.GetMetric() {
-					buildRunCounterMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+			}
+
+		default:
+			if metricFamily.GetType() == io_prometheus_client.MetricType_HISTOGRAM {
+				if _, ok := buildRunHistogramMetrics[metricFamily.GetName()]; ok {
+					for _, metric := range metricFamily.GetMetric() {
+						buildRunHistogramMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetHistogram().GetSampleSum()
+					}
 				}
 			}
 		}
@@ -147,22 +300,17 @@ var _ = Describe("Custom Metrics", func() {
 	Context("when create a new kaniko buildrun", func() {
 		It("should increase the kaniko build count", func() {
 			Expect(buildCounterMetrics).To(HaveKey("build_builds_registered_total"))
-			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"kaniko", "default", "kaniko-build"}]).To(Equal(1.0))
-		})
-
-		It("should increase the kaniko buildrun count", func() {
-			Expect(buildRunCounterMetrics).To(HaveKey("build_buildruns_completed_total"))
-			Expect(buildRunCounterMetrics["build_buildruns_completed_total"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(Equal(1.0))
+			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"kaniko", "default", "kaniko-build", "ClusterBuildStrategy", "Git"}]).To(Equal(1.0))
 		})
 
 		It("should record the kaniko buildrun establish time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_establish_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(Equal(1.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(Equal(1.0))
 		})
 
 		It("should record the kaniko buildrun completion time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_completion_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(Equal(200.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(Equal(200.0))
 		})
 
 		It("should record the kaniko ramp-up durations", func() {
@@ -170,9 +318,9 @@ var _ = Describe("Custom Metrics", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_rampup_duration_seconds"))
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_pod_rampup_duration_seconds"))
 
-			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(BeNumerically(">", 0.0))
 		})
 	})
 
@@ -180,22 +328,17 @@ var _ = Describe("Custom Metrics", func() {
 
 		It("should increase the buildpacks build count", func() {
 			Expect(buildCounterMetrics).To(HaveKey("build_builds_registered_total"))
-			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"buildpacks", "default", "buildpacks-build"}]).To(Equal(1.0))
-		})
-
-		It("should increase the buildpacks buildrun count", func() {
-			Expect(buildRunCounterMetrics).To(HaveKey("build_buildruns_completed_total"))
-			Expect(buildRunCounterMetrics["build_buildruns_completed_total"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(Equal(1.0))
+			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"buildpacks", "default", "buildpacks-build", "BuildStrategy", "OCI"}]).To(Equal(1.0))
 		})
 
 		It("should record the buildpacks buildrun establish time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_establish_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(Equal(1.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(Equal(1.0))
 		})
 
 		It("should record the buildpacks buildrun completion time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_completion_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(Equal(200.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(Equal(200.0))
 		})
 
 		It("should record the buildpacks ramp-up durations", func() {
@@ -203,9 +346,85 @@ var _ = Describe("Custom Metrics", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_rampup_duration_seconds"))
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_pod_rampup_duration_seconds"))
 
-			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(BeNumerically(">", 0.0))
+		})
+	})
+
+	Context("build_buildrun_result_total metric", func() {
+		It("should record succeeded results", func() {
+			Expect(buildRunResultCounterMetrics).To(HaveKey("build_buildrun_result_total"))
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git", ResultSucceeded,
+			}]).To(Equal(1.0))
+		})
+
+		It("should record failed results", func() {
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", "Git", ResultFailed,
+			}]).To(Equal(1.0))
+		})
+
+		It("should record cancelled results", func() {
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", "OCI", ResultCancelled,
+			}]).To(Equal(1.0))
+		})
+
+		It("should record timeout results", func() {
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", "Git", ResultTimeout,
+			}]).To(Equal(1.0))
+		})
+	})
+
+	Context("build_buildrun_failure_reason_total metric", func() {
+		It("should record OOM failure reason", func() {
+			Expect(buildRunFailureReasonMetrics).To(HaveKey("build_buildrun_failure_reason_total"))
+			Expect(buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"][buildRunFailureReasonLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", "Git", "StepOutOfMemory",
+			}]).To(Equal(1.0))
+		})
+
+		It("should record cancel failure reason", func() {
+			Expect(buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"][buildRunFailureReasonLabels{
+				"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", "OCI", "BuildRunCanceled",
+			}]).To(Equal(1.0))
+		})
+
+		It("should record timeout failure reason", func() {
+			Expect(buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"][buildRunFailureReasonLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", "Git", "BuildRunTimeout",
+			}]).To(Equal(1.0))
+		})
+	})
+
+	Context("build_buildruns_active gauge metric", func() {
+		It("should show net active count after inc and dec", func() {
+			Expect(buildRunsActiveGaugeMetrics).To(HaveKey("build_buildruns_active"))
+			// kaniko was incremented then decremented, so should be 0
+			Expect(buildRunsActiveGaugeMetrics["build_buildruns_active"][buildRunLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git",
+			}]).To(Equal(0.0))
+		})
+
+		It("should show positive count when only incremented", func() {
+			// buildpacks was only incremented, so should be 1
+			Expect(buildRunsActiveGaugeMetrics["build_buildruns_active"][buildRunLabels{
+				"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI",
+			}]).To(Equal(1.0))
+		})
+	})
+
+	Context("build_buildstrategy_count gauge metric", func() {
+		It("should show correct BuildStrategy count", func() {
+			Expect(buildStrategyCountGaugeMetrics).To(HaveKey("build_buildstrategy_count"))
+			Expect(buildStrategyCountGaugeMetrics["build_buildstrategy_count"]["BuildStrategy"]).To(Equal(3.0))
+		})
+
+		It("should show correct ClusterBuildStrategy count", func() {
+			Expect(buildStrategyCountGaugeMetrics["build_buildstrategy_count"]["ClusterBuildStrategy"]).To(Equal(5.0))
 		})
 	})
 })

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -20,6 +20,8 @@ type buildLabels struct {
 	buildStrategy string
 	namespace     string
 	build         string
+	strategyKind  string
+	sourceType    string
 }
 
 type buildRunLabels struct {
@@ -27,12 +29,40 @@ type buildRunLabels struct {
 	namespace     string
 	build         string
 	buildRun      string
+	strategyKind  string
+	executor      string
+	sourceType    string
+}
+
+type buildRunResultLabels struct {
+	buildStrategy string
+	namespace     string
+	build         string
+	buildRun      string
+	strategyKind  string
+	executor      string
+	sourceType    string
+	result        string
+}
+
+type buildRunFailureReasonLabels struct {
+	buildStrategy string
+	namespace     string
+	build         string
+	buildRun      string
+	strategyKind  string
+	executor      string
+	sourceType    string
+	reason        string
 }
 
 var (
-	buildCounterMetrics      map[string]map[buildLabels]float64
-	buildRunCounterMetrics   map[string]map[buildRunLabels]float64
-	buildRunHistogramMetrics map[string]map[buildRunLabels]float64
+	buildCounterMetrics            map[string]map[buildLabels]float64
+	buildRunHistogramMetrics       map[string]map[buildRunLabels]float64
+	buildRunResultCounterMetrics   map[string]map[buildRunResultLabels]float64
+	buildRunFailureReasonMetrics   map[string]map[buildRunFailureReasonLabels]float64
+	buildRunsActiveGaugeMetrics    map[string]map[buildRunLabels]float64
+	buildStrategyCountGaugeMetrics map[string]map[string]float64
 )
 
 func promLabelPairToBuildLabels(in []*io_prometheus_client.LabelPair) buildLabels {
@@ -45,6 +75,10 @@ func promLabelPairToBuildLabels(in []*io_prometheus_client.LabelPair) buildLabel
 			result.namespace = *label.Value
 		case BuildLabel:
 			result.build = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
 		}
 	}
 
@@ -63,6 +97,64 @@ func promLabelPairToBuildRunLabels(in []*io_prometheus_client.LabelPair) buildRu
 			result.build = *label.Value
 		case BuildRunLabel:
 			result.buildRun = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case ExecutorLabel:
+			result.executor = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
+		}
+	}
+
+	return result
+}
+
+func promLabelPairToBuildRunResultLabels(in []*io_prometheus_client.LabelPair) buildRunResultLabels {
+	result := buildRunResultLabels{}
+	for _, label := range in {
+		switch *label.Name {
+		case BuildStrategyLabel:
+			result.buildStrategy = *label.Value
+		case NamespaceLabel:
+			result.namespace = *label.Value
+		case BuildLabel:
+			result.build = *label.Value
+		case BuildRunLabel:
+			result.buildRun = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case ExecutorLabel:
+			result.executor = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
+		case ResultLabel:
+			result.result = *label.Value
+		}
+	}
+
+	return result
+}
+
+func promLabelPairToBuildRunFailureReasonLabels(in []*io_prometheus_client.LabelPair) buildRunFailureReasonLabels {
+	result := buildRunFailureReasonLabels{}
+	for _, label := range in {
+		switch *label.Name {
+		case BuildStrategyLabel:
+			result.buildStrategy = *label.Value
+		case NamespaceLabel:
+			result.namespace = *label.Value
+		case BuildLabel:
+			result.build = *label.Value
+		case BuildRunLabel:
+			result.buildRun = *label.Value
+		case StrategyKindLabel:
+			result.strategyKind = *label.Value
+		case ExecutorLabel:
+			result.executor = *label.Value
+		case SourceTypeLabel:
+			result.sourceType = *label.Value
+		case "reason":
+			result.reason = *label.Value
 		}
 	}
 
@@ -71,13 +163,26 @@ func promLabelPairToBuildRunLabels(in []*io_prometheus_client.LabelPair) buildRu
 
 var _ = BeforeSuite(func() {
 	buildCounterMetrics = map[string]map[buildLabels]float64{}
-	buildRunCounterMetrics = map[string]map[buildRunLabels]float64{}
 	buildRunHistogramMetrics = map[string]map[buildRunLabels]float64{}
+	buildRunResultCounterMetrics = map[string]map[buildRunResultLabels]float64{}
+	buildRunFailureReasonMetrics = map[string]map[buildRunFailureReasonLabels]float64{}
+	buildRunsActiveGaugeMetrics = map[string]map[buildRunLabels]float64{}
+	buildStrategyCountGaugeMetrics = map[string]map[string]float64{}
+
+	type testEntry struct {
+		buildStrategy string
+		namespace     string
+		build         string
+		buildRun      string
+		strategyKind  string
+		executor      string
+		sourceType    string
+	}
 
 	var (
-		testLabels = []buildRunLabels{
-			{buildStrategy: "kaniko", namespace: "default", build: "kaniko-build", buildRun: "kaniko-buildrun"},
-			{buildStrategy: "buildpacks", namespace: "default", build: "buildpacks-build", buildRun: "buildpacks-buildrun"},
+		testLabels = []testEntry{
+			{buildStrategy: "kaniko", namespace: "default", build: "kaniko-build", buildRun: "kaniko-buildrun", strategyKind: "ClusterBuildStrategy", executor: "TaskRun", sourceType: "Git"},
+			{buildStrategy: "buildpacks", namespace: "default", build: "buildpacks-build", buildRun: "buildpacks-buildrun", strategyKind: "BuildStrategy", executor: "PipelineRun", sourceType: "OCI"},
 		}
 
 		knownHistogramMetrics = []string{
@@ -91,7 +196,10 @@ var _ = BeforeSuite(func() {
 
 	// initialize the counter metrics result map with empty maps
 	buildCounterMetrics["build_builds_registered_total"] = map[buildLabels]float64{}
-	buildRunCounterMetrics["build_buildruns_completed_total"] = map[buildRunLabels]float64{}
+	buildRunResultCounterMetrics["build_buildrun_result_total"] = map[buildRunResultLabels]float64{}
+	buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"] = map[buildRunFailureReasonLabels]float64{}
+	buildRunsActiveGaugeMetrics["build_buildruns_active"] = map[buildRunLabels]float64{}
+	buildStrategyCountGaugeMetrics["build_buildstrategy_count"] = map[string]float64{}
 
 	// initialize the histogram metrics result map with empty maps
 	for _, name := range knownHistogramMetrics {
@@ -100,22 +208,44 @@ var _ = BeforeSuite(func() {
 
 	// initialize prometheus (second init should be no-op)
 	config := config.NewDefaultConfig()
-	config.Prometheus.EnabledLabels = []string{BuildStrategyLabel, NamespaceLabel, BuildLabel, BuildRunLabel}
+	config.Prometheus.EnabledLabels = []string{
+		BuildStrategyLabel, NamespaceLabel, BuildLabel, BuildRunLabel,
+		StrategyKindLabel, ExecutorLabel, ResultLabel, SourceTypeLabel,
+	}
 	InitPrometheus(config)
 
 	// and fire some examples
 	for _, entry := range testLabels {
-		buildStrategy, namespace, build, buildRun := entry.buildStrategy, entry.namespace, entry.build, entry.buildRun
+		BuildCountInc(entry.buildStrategy, entry.namespace, entry.build, entry.strategyKind, entry.sourceType)
+		BuildRunEstablishObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(1)*time.Second)
+		BuildRunCompletionObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(200)*time.Second)
+		BuildRunRampUpDurationObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(1)*time.Second)
+		TaskRunRampUpDurationObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(2)*time.Second)
+		TaskRunPodRampUpDurationObserve(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType, time.Duration(3)*time.Second)
 
-		// tell prometheus some things have happened
-		BuildCountInc(buildStrategy, namespace, build)
-		BuildRunCountInc(buildStrategy, namespace, build, buildRun)
-		BuildRunEstablishObserve(buildStrategy, namespace, build, buildRun, time.Duration(1)*time.Second)
-		BuildRunCompletionObserve(buildStrategy, namespace, build, buildRun, time.Duration(200)*time.Second)
-		BuildRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, time.Duration(1)*time.Second)
-		TaskRunRampUpDurationObserve(buildStrategy, namespace, build, buildRun, time.Duration(2)*time.Second)
-		TaskRunPodRampUpDurationObserve(buildStrategy, namespace, build, buildRun, time.Duration(3)*time.Second)
+		// Record result metrics
+		BuildRunResultCountInc(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, ResultSucceeded, entry.sourceType)
+
+		// Record active gauge (inc and dec to simulate a completed run)
+		BuildRunsActiveInc(entry.buildStrategy, entry.namespace, entry.build, entry.buildRun, entry.strategyKind, entry.executor, entry.sourceType)
 	}
+
+	// Record some failures
+	BuildRunResultCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", ResultFailed, "Git")
+	BuildRunFailureReasonCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", "Git", "StepOutOfMemory")
+
+	BuildRunResultCountInc("buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", ResultCanceled, "OCI")
+	BuildRunFailureReasonCountInc("buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", "OCI", "BuildRunCanceled")
+
+	BuildRunResultCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", ResultTimeout, "Git")
+	BuildRunFailureReasonCountInc("kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", "Git", "BuildRunTimeout")
+
+	// Decrement active for the first entry to test net gauge
+	BuildRunsActiveDec(testLabels[0].buildStrategy, testLabels[0].namespace, testLabels[0].build, testLabels[0].buildRun, testLabels[0].strategyKind, testLabels[0].executor, testLabels[0].sourceType)
+
+	// Set strategy counts
+	BuildStrategyCountSet("BuildStrategy", 3)
+	BuildStrategyCountSet("ClusterBuildStrategy", 5)
 
 	// gather metrics from prometheus and fill the result maps
 	metrics, err := crmetrics.Registry.Gather()
@@ -124,19 +254,42 @@ var _ = BeforeSuite(func() {
 	}
 
 	for _, metricFamily := range metrics {
-		if metricFamily.GetType() == io_prometheus_client.MetricType_HISTOGRAM {
+		switch metricFamily.GetName() {
+		case "build_builds_registered_total":
 			for _, metric := range metricFamily.GetMetric() {
-				buildRunHistogramMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetHistogram().GetSampleSum()
+				buildCounterMetrics[metricFamily.GetName()][promLabelPairToBuildLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
 			}
-		} else {
-			switch metricFamily.GetName() {
-			case "build_builds_registered_total":
-				for _, metric := range metricFamily.GetMetric() {
-					buildCounterMetrics[metricFamily.GetName()][promLabelPairToBuildLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+
+		case "build_buildrun_result_total":
+			for _, metric := range metricFamily.GetMetric() {
+				buildRunResultCounterMetrics[metricFamily.GetName()][promLabelPairToBuildRunResultLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+			}
+
+		case "build_buildrun_failure_reason_total":
+			for _, metric := range metricFamily.GetMetric() {
+				buildRunFailureReasonMetrics[metricFamily.GetName()][promLabelPairToBuildRunFailureReasonLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+			}
+
+		case "build_buildruns_active":
+			for _, metric := range metricFamily.GetMetric() {
+				buildRunsActiveGaugeMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetGauge().GetValue()
+			}
+
+		case "build_buildstrategy_count":
+			for _, metric := range metricFamily.GetMetric() {
+				for _, label := range metric.GetLabel() {
+					if *label.Name == StrategyKindLabel {
+						buildStrategyCountGaugeMetrics[metricFamily.GetName()][*label.Value] = metric.GetGauge().GetValue()
+					}
 				}
-			case "build_buildruns_completed_total":
-				for _, metric := range metricFamily.GetMetric() {
-					buildRunCounterMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetCounter().GetValue()
+			}
+
+		default:
+			if metricFamily.GetType() == io_prometheus_client.MetricType_HISTOGRAM {
+				if _, ok := buildRunHistogramMetrics[metricFamily.GetName()]; ok {
+					for _, metric := range metricFamily.GetMetric() {
+						buildRunHistogramMetrics[metricFamily.GetName()][promLabelPairToBuildRunLabels(metric.GetLabel())] = metric.GetHistogram().GetSampleSum()
+					}
 				}
 			}
 		}
@@ -147,22 +300,17 @@ var _ = Describe("Custom Metrics", func() {
 	Context("when create a new kaniko buildrun", func() {
 		It("should increase the kaniko build count", func() {
 			Expect(buildCounterMetrics).To(HaveKey("build_builds_registered_total"))
-			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"kaniko", "default", "kaniko-build"}]).To(Equal(1.0))
-		})
-
-		It("should increase the kaniko buildrun count", func() {
-			Expect(buildRunCounterMetrics).To(HaveKey("build_buildruns_completed_total"))
-			Expect(buildRunCounterMetrics["build_buildruns_completed_total"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(Equal(1.0))
+			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"kaniko", "default", "kaniko-build", "ClusterBuildStrategy", "Git"}]).To(Equal(1.0))
 		})
 
 		It("should record the kaniko buildrun establish time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_establish_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(Equal(1.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(Equal(1.0))
 		})
 
 		It("should record the kaniko buildrun completion time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_completion_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(Equal(200.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(Equal(200.0))
 		})
 
 		It("should record the kaniko ramp-up durations", func() {
@@ -170,9 +318,9 @@ var _ = Describe("Custom Metrics", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_rampup_duration_seconds"))
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_pod_rampup_duration_seconds"))
 
-			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git"}]).To(BeNumerically(">", 0.0))
 		})
 	})
 
@@ -180,22 +328,17 @@ var _ = Describe("Custom Metrics", func() {
 
 		It("should increase the buildpacks build count", func() {
 			Expect(buildCounterMetrics).To(HaveKey("build_builds_registered_total"))
-			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"buildpacks", "default", "buildpacks-build"}]).To(Equal(1.0))
-		})
-
-		It("should increase the buildpacks buildrun count", func() {
-			Expect(buildRunCounterMetrics).To(HaveKey("build_buildruns_completed_total"))
-			Expect(buildRunCounterMetrics["build_buildruns_completed_total"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(Equal(1.0))
+			Expect(buildCounterMetrics["build_builds_registered_total"][buildLabels{"buildpacks", "default", "buildpacks-build", "BuildStrategy", "OCI"}]).To(Equal(1.0))
 		})
 
 		It("should record the buildpacks buildrun establish time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_establish_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(Equal(1.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_establish_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(Equal(1.0))
 		})
 
 		It("should record the buildpacks buildrun completion time", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_completion_duration_seconds"))
-			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(Equal(200.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_completion_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(Equal(200.0))
 		})
 
 		It("should record the buildpacks ramp-up durations", func() {
@@ -203,9 +346,85 @@ var _ = Describe("Custom Metrics", func() {
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_rampup_duration_seconds"))
 			Expect(buildRunHistogramMetrics).To(HaveKey("build_buildrun_taskrun_pod_rampup_duration_seconds"))
 
-			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(BeNumerically(">", 0.0))
-			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(BeNumerically(">", 0.0))
+			Expect(buildRunHistogramMetrics["build_buildrun_taskrun_pod_rampup_duration_seconds"][buildRunLabels{"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI"}]).To(BeNumerically(">", 0.0))
+		})
+	})
+
+	Context("build_buildrun_result_total metric", func() {
+		It("should record succeeded results", func() {
+			Expect(buildRunResultCounterMetrics).To(HaveKey("build_buildrun_result_total"))
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git", ResultSucceeded,
+			}]).To(Equal(1.0))
+		})
+
+		It("should record failed results", func() {
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", "Git", ResultFailed,
+			}]).To(Equal(1.0))
+		})
+
+		It("should record canceled results", func() {
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", "OCI", ResultCanceled,
+			}]).To(Equal(1.0))
+		})
+
+		It("should record timeout results", func() {
+			Expect(buildRunResultCounterMetrics["build_buildrun_result_total"][buildRunResultLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", "Git", ResultTimeout,
+			}]).To(Equal(1.0))
+		})
+	})
+
+	Context("build_buildrun_failure_reason_total metric", func() {
+		It("should record OOM failure reason", func() {
+			Expect(buildRunFailureReasonMetrics).To(HaveKey("build_buildrun_failure_reason_total"))
+			Expect(buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"][buildRunFailureReasonLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-fail", "ClusterBuildStrategy", "TaskRun", "Git", "StepOutOfMemory",
+			}]).To(Equal(1.0))
+		})
+
+		It("should record cancel failure reason", func() {
+			Expect(buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"][buildRunFailureReasonLabels{
+				"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun-cancel", "BuildStrategy", "PipelineRun", "OCI", "BuildRunCanceled",
+			}]).To(Equal(1.0))
+		})
+
+		It("should record timeout failure reason", func() {
+			Expect(buildRunFailureReasonMetrics["build_buildrun_failure_reason_total"][buildRunFailureReasonLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun-timeout", "ClusterBuildStrategy", "TaskRun", "Git", "BuildRunTimeout",
+			}]).To(Equal(1.0))
+		})
+	})
+
+	Context("build_buildruns_active gauge metric", func() {
+		It("should show net active count after inc and dec", func() {
+			Expect(buildRunsActiveGaugeMetrics).To(HaveKey("build_buildruns_active"))
+			// kaniko was incremented then decremented, so should be 0
+			Expect(buildRunsActiveGaugeMetrics["build_buildruns_active"][buildRunLabels{
+				"kaniko", "default", "kaniko-build", "kaniko-buildrun", "ClusterBuildStrategy", "TaskRun", "Git",
+			}]).To(Equal(0.0))
+		})
+
+		It("should show positive count when only incremented", func() {
+			// buildpacks was only incremented, so should be 1
+			Expect(buildRunsActiveGaugeMetrics["build_buildruns_active"][buildRunLabels{
+				"buildpacks", "default", "buildpacks-build", "buildpacks-buildrun", "BuildStrategy", "PipelineRun", "OCI",
+			}]).To(Equal(1.0))
+		})
+	})
+
+	Context("build_buildstrategy_count gauge metric", func() {
+		It("should show correct BuildStrategy count", func() {
+			Expect(buildStrategyCountGaugeMetrics).To(HaveKey("build_buildstrategy_count"))
+			Expect(buildStrategyCountGaugeMetrics["build_buildstrategy_count"]["BuildStrategy"]).To(Equal(3.0))
+		})
+
+		It("should show correct ClusterBuildStrategy count", func() {
+			Expect(buildStrategyCountGaugeMetrics["build_buildstrategy_count"]["ClusterBuildStrategy"]).To(Equal(5.0))
 		})
 	})
 })

--- a/pkg/reconciler/build/build.go
+++ b/pkg/reconciler/build/build.go
@@ -22,6 +22,20 @@ import (
 	"github.com/shipwright-io/build/pkg/validate"
 )
 
+func strategyKindFromBuild(b *buildapi.Build) string {
+	if b.Spec.Strategy.Kind == nil {
+		return string(buildapi.NamespacedBuildStrategyKind)
+	}
+	return string(*b.Spec.Strategy.Kind)
+}
+
+func sourceTypeFromBuild(b *buildapi.Build) string {
+	if b.Spec.Source == nil {
+		return ""
+	}
+	return string(b.Spec.Source.Type)
+}
+
 // build a list of current validation types
 var validationTypes = [...]string{
 	validate.OwnerReferences,
@@ -113,6 +127,13 @@ func (r *ReconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 				return reconcile.Result{}, err
 			}
 
+			buildmetrics.BuildCountInc(
+				b.Spec.Strategy.Name,
+				b.Namespace,
+				b.Name,
+				strategyKindFromBuild(b),
+				sourceTypeFromBuild(b),
+			)
 			return reconcile.Result{}, nil
 		}
 	}
@@ -124,7 +145,13 @@ func (r *ReconcileBuild) Reconcile(ctx context.Context, request reconcile.Reques
 	}
 
 	// Increase Build count in metrics
-	buildmetrics.BuildCountInc(b.Spec.Strategy.Name, b.Namespace, b.Name)
+	buildmetrics.BuildCountInc(
+		b.Spec.Strategy.Name,
+		b.Namespace,
+		b.Name,
+		strategyKindFromBuild(b),
+		sourceTypeFromBuild(b),
+	)
 
 	ctxlog.Debug(ctx, "finishing reconciling Build", namespace, request.Namespace, name, request.Name)
 	return reconcile.Result{}, nil

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -34,7 +34,71 @@ const (
 	namespace          string = "namespace"
 	name               string = "name"
 	generatedNameRegex        = "-[a-z0-9]{5,5}$"
+
+	buildRunTimeoutReason = "BuildRunTimeout"
 )
+
+func classifyBuildRunResult(condition *buildapi.Condition) string {
+	if condition == nil {
+		return buildmetrics.ResultFailed
+	}
+	if condition.Status == corev1.ConditionTrue {
+		return buildmetrics.ResultSucceeded
+	}
+	switch condition.Reason {
+	case buildapi.BuildRunStateCancel:
+		return buildmetrics.ResultCancelled
+	case buildRunTimeoutReason:
+		return buildmetrics.ResultTimeout
+	default:
+		return buildmetrics.ResultFailed
+	}
+}
+
+func sourceTypeFromBuildSpec(spec *buildapi.BuildSpec) string {
+	if spec == nil || spec.Source == nil {
+		return ""
+	}
+	return string(spec.Source.Type)
+}
+
+func strategyKindFromBuildSpec(spec *buildapi.BuildSpec) string {
+	if spec == nil || spec.Strategy.Kind == nil {
+		return string(buildapi.NamespacedBuildStrategyKind)
+	}
+	return string(*spec.Strategy.Kind)
+}
+
+func (r *ReconcileBuildRun) recordPreExecutorFailure(buildRun *buildapi.BuildRun, reason, result string) {
+	var strategyName, buildName, strategyKind, sourceType string
+	if buildRun.Status.BuildSpec != nil {
+		strategyName = buildRun.Status.BuildSpec.StrategyName()
+		strategyKind = strategyKindFromBuildSpec(buildRun.Status.BuildSpec)
+		sourceType = sourceTypeFromBuildSpec(buildRun.Status.BuildSpec)
+	}
+	buildName = buildRun.Spec.BuildName()
+
+	buildmetrics.BuildRunResultCountInc(
+		strategyName,
+		buildRun.Namespace,
+		buildName,
+		buildRun.Name,
+		strategyKind,
+		"",
+		result,
+		sourceType,
+	)
+	buildmetrics.BuildRunFailureReasonCountInc(
+		strategyName,
+		buildRun.Namespace,
+		buildName,
+		buildRun.Name,
+		strategyKind,
+		"",
+		sourceType,
+		reason,
+	)
+}
 
 // blank assignment to verify that ReconcileBuildRun implements reconcile.Reconciler
 var _ reconcile.Reconciler = &ReconcileBuildRun{}
@@ -99,24 +163,32 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 		// Validating buildrun name is a valid label value
 		if errs := validation.IsValidLabelValue(buildRun.Name); len(errs) > 0 {
 			// stop reconciling and mark the BuildRun as Failed
-			return reconcile.Result{}, resources.UpdateConditionWithFalseStatus(
+			if err := resources.UpdateConditionWithFalseStatus(
 				ctx,
 				r.client,
 				buildRun,
 				strings.Join(errs, ", "),
 				resources.BuildRunNameInvalid,
-			)
+			); err != nil {
+				return reconcile.Result{}, err
+			}
+			r.recordPreExecutorFailure(buildRun, resources.BuildRunNameInvalid, buildmetrics.ResultFailed)
+			return reconcile.Result{}, nil
 		}
 
 		// Validate BuildRun for disallowed field combinations (could technically be also done in a validating webhook)
 		if reason, message := validate.BuildRunFields(buildRun); reason != "" {
-			return reconcile.Result{}, resources.UpdateConditionWithFalseStatus(
+			if err := resources.UpdateConditionWithFalseStatus(
 				ctx,
 				r.client,
 				buildRun,
 				message,
 				reason,
-			)
+			); err != nil {
+				return reconcile.Result{}, err
+			}
+			r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
+			return reconcile.Result{}, nil
 		}
 	}
 	// if this is a build run event after we've set the task run ref, get the task run using the task run name stored in the build run
@@ -211,6 +283,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if updateErr := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, "the BuildRun is marked canceled.", buildapi.BuildRunStateCancel); updateErr != nil {
 					return reconcile.Result{}, updateErr
 				}
+				r.recordPreExecutorFailure(buildRun, buildapi.BuildRunStateCancel, buildmetrics.ResultCancelled)
 				return reconcile.Result{}, nil
 			}
 
@@ -277,6 +350,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -286,6 +360,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -295,6 +370,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -304,6 +380,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -313,6 +390,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -322,6 +400,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -331,6 +410,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -347,6 +427,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 						ctxlog.Error(ctx, err, "failed to update BuildRun status for multi-arch validation failure", namespace, request.Namespace, name, request.Name)
 						return reconcile.Result{}, err
 					}
+					r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 					return reconcile.Result{}, nil
 				}
 				nodeList := &corev1.NodeList{}
@@ -359,6 +440,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 						ctxlog.Error(ctx, err, "failed to update BuildRun status for multi-arch validation failure", namespace, request.Namespace, name, request.Name)
 						return reconcile.Result{}, err
 					}
+					r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 					return reconcile.Result{}, nil
 				}
 			}
@@ -382,6 +464,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 					if updateErr := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, err.Error(), string(buildapi.VolumeDoesNotExist)); updateErr != nil {
 						return reconcile.Result{}, updateErr
 					}
+					r.recordPreExecutorFailure(buildRun, string(buildapi.VolumeDoesNotExist), buildmetrics.ResultFailed)
 					return reconcile.Result{}, nil // Stop reconciling
 				}
 				// Some other error occurred, return it for reconciliation retry
@@ -413,12 +496,18 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				ctxlog.Error(ctx, err, "Failed to update BuildRun status is ignored", namespace, request.Namespace, name, request.Name)
 			}
 
-			// Increase BuildRun count in metrics
-			buildmetrics.BuildRunCountInc(
+			executorKind := imageBuildRunner.GetExecutorKind()
+			strategyKind := strategyKindFromBuildSpec(buildRun.Status.BuildSpec)
+			sourceType := sourceTypeFromBuildSpec(buildRun.Status.BuildSpec)
+
+			buildmetrics.BuildRunsActiveInc(
 				buildRun.Status.BuildSpec.StrategyName(),
 				buildRun.Namespace,
 				buildRun.Spec.BuildName(),
 				buildRun.Name,
+				strategyKind,
+				executorKind,
+				sourceType,
 			)
 
 			// Report buildrun ramp-up duration (time between buildrun creation and taskrun creation)
@@ -427,6 +516,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				buildRun.Namespace,
 				buildRun.Spec.BuildName(),
 				buildRun.Name,
+				strategyKind,
+				executorKind,
+				sourceType,
 				imageBuildRunner.GetCreationTimestamp().Sub(buildRun.CreationTimestamp.Time),
 			)
 		} else {
@@ -504,6 +596,10 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				}
 			}
 
+			brStrategyKind := strategyKindFromBuildSpec(buildRun.Status.BuildSpec)
+			brExecutorKind := buildRunner.GetExecutorKind()
+			brSourceType := sourceTypeFromBuildSpec(buildRun.Status.BuildSpec)
+
 			executorStartTime := buildRunner.GetStartTime()
 			if buildRun.Status.StartTime == nil && executorStartTime != nil {
 				buildRun.Status.StartTime = executorStartTime
@@ -514,6 +610,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 					buildRun.Namespace,
 					buildRun.Spec.BuildName(),
 					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					brSourceType,
 					buildRun.Status.StartTime.Sub(buildRun.CreationTimestamp.Time),
 				)
 			}
@@ -527,7 +626,50 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 					buildRun.Namespace,
 					buildRun.Spec.BuildName(),
 					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					brSourceType,
 					buildRun.Status.CompletionTime.Sub(buildRun.CreationTimestamp.Time),
+				)
+
+				// Record result and failure metrics
+				condition := buildRun.Status.GetCondition(buildapi.Succeeded)
+				result := classifyBuildRunResult(condition)
+				buildmetrics.BuildRunResultCountInc(
+					buildRun.Status.BuildSpec.StrategyName(),
+					buildRun.Namespace,
+					buildRun.Spec.BuildName(),
+					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					result,
+					brSourceType,
+				)
+				if result != buildmetrics.ResultSucceeded {
+					failureReason := ""
+					if condition != nil {
+						failureReason = condition.Reason
+					}
+					buildmetrics.BuildRunFailureReasonCountInc(
+						buildRun.Status.BuildSpec.StrategyName(),
+						buildRun.Namespace,
+						buildRun.Spec.BuildName(),
+						buildRun.Name,
+						brStrategyKind,
+						brExecutorKind,
+						brSourceType,
+						failureReason,
+					)
+				}
+
+				buildmetrics.BuildRunsActiveDec(
+					buildRun.Status.BuildSpec.StrategyName(),
+					buildRun.Namespace,
+					buildRun.Spec.BuildName(),
+					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					brSourceType,
 				)
 
 				// Look for the pod created by the executor
@@ -556,6 +698,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 									buildRun.Namespace,
 									buildRun.Spec.BuildName(),
 									buildRun.Name,
+									brStrategyKind,
+									brExecutorKind,
+									brSourceType,
 									lastInitPod.State.Terminated.FinishedAt.Sub(pod.CreationTimestamp.Time),
 								)
 							}
@@ -567,6 +712,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 							buildRun.Namespace,
 							buildRun.Spec.BuildName(),
 							buildRun.Name,
+							brStrategyKind,
+							brExecutorKind,
+							brSourceType,
 							pod.CreationTimestamp.Sub(buildRunner.GetCreationTimestamp().Time),
 						)
 					}

--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -34,7 +34,71 @@ const (
 	namespace          string = "namespace"
 	name               string = "name"
 	generatedNameRegex        = "-[a-z0-9]{5,5}$"
+
+	buildRunTimeoutReason = "BuildRunTimeout"
 )
+
+func classifyBuildRunResult(condition *buildapi.Condition) string {
+	if condition == nil {
+		return buildmetrics.ResultFailed
+	}
+	if condition.Status == corev1.ConditionTrue {
+		return buildmetrics.ResultSucceeded
+	}
+	switch condition.Reason {
+	case buildapi.BuildRunStateCancel:
+		return buildmetrics.ResultCanceled
+	case buildRunTimeoutReason:
+		return buildmetrics.ResultTimeout
+	default:
+		return buildmetrics.ResultFailed
+	}
+}
+
+func sourceTypeFromBuildSpec(spec *buildapi.BuildSpec) string {
+	if spec == nil || spec.Source == nil {
+		return ""
+	}
+	return string(spec.Source.Type)
+}
+
+func strategyKindFromBuildSpec(spec *buildapi.BuildSpec) string {
+	if spec == nil || spec.Strategy.Kind == nil {
+		return string(buildapi.NamespacedBuildStrategyKind)
+	}
+	return string(*spec.Strategy.Kind)
+}
+
+func (r *ReconcileBuildRun) recordPreExecutorFailure(buildRun *buildapi.BuildRun, reason, result string) {
+	var strategyName, buildName, strategyKind, sourceType string
+	if buildRun.Status.BuildSpec != nil {
+		strategyName = buildRun.Status.BuildSpec.StrategyName()
+		strategyKind = strategyKindFromBuildSpec(buildRun.Status.BuildSpec)
+		sourceType = sourceTypeFromBuildSpec(buildRun.Status.BuildSpec)
+	}
+	buildName = buildRun.Spec.BuildName()
+
+	buildmetrics.BuildRunResultCountInc(
+		strategyName,
+		buildRun.Namespace,
+		buildName,
+		buildRun.Name,
+		strategyKind,
+		"",
+		result,
+		sourceType,
+	)
+	buildmetrics.BuildRunFailureReasonCountInc(
+		strategyName,
+		buildRun.Namespace,
+		buildName,
+		buildRun.Name,
+		strategyKind,
+		"",
+		sourceType,
+		reason,
+	)
+}
 
 // blank assignment to verify that ReconcileBuildRun implements reconcile.Reconciler
 var _ reconcile.Reconciler = &ReconcileBuildRun{}
@@ -99,24 +163,32 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 		// Validating buildrun name is a valid label value
 		if errs := validation.IsValidLabelValue(buildRun.Name); len(errs) > 0 {
 			// stop reconciling and mark the BuildRun as Failed
-			return reconcile.Result{}, resources.UpdateConditionWithFalseStatus(
+			if err := resources.UpdateConditionWithFalseStatus(
 				ctx,
 				r.client,
 				buildRun,
 				strings.Join(errs, ", "),
 				resources.BuildRunNameInvalid,
-			)
+			); err != nil {
+				return reconcile.Result{}, err
+			}
+			r.recordPreExecutorFailure(buildRun, resources.BuildRunNameInvalid, buildmetrics.ResultFailed)
+			return reconcile.Result{}, nil
 		}
 
 		// Validate BuildRun for disallowed field combinations (could technically be also done in a validating webhook)
 		if reason, message := validate.BuildRunFields(buildRun); reason != "" {
-			return reconcile.Result{}, resources.UpdateConditionWithFalseStatus(
+			if err := resources.UpdateConditionWithFalseStatus(
 				ctx,
 				r.client,
 				buildRun,
 				message,
 				reason,
-			)
+			); err != nil {
+				return reconcile.Result{}, err
+			}
+			r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
+			return reconcile.Result{}, nil
 		}
 	}
 	// if this is a build run event after we've set the task run ref, get the task run using the task run name stored in the build run
@@ -206,11 +278,12 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				buildRun.Labels = make(map[string]string)
 			}
 
-			// make sure the BuildRun has not already been cancelled
+			// make sure the BuildRun has not already been canceled
 			if buildRun.IsCanceled() {
 				if updateErr := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, "the BuildRun is marked canceled.", buildapi.BuildRunStateCancel); updateErr != nil {
 					return reconcile.Result{}, updateErr
 				}
+				r.recordPreExecutorFailure(buildRun, buildapi.BuildRunStateCancel, buildmetrics.ResultCanceled)
 				return reconcile.Result{}, nil
 			}
 
@@ -277,6 +350,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -286,6 +360,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -295,6 +370,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -304,6 +380,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -313,6 +390,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -322,6 +400,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -331,6 +410,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				if err := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, reason); err != nil {
 					return reconcile.Result{}, err
 				}
+				r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 				return reconcile.Result{}, nil
 			}
 
@@ -347,6 +427,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 						ctxlog.Error(ctx, err, "failed to update BuildRun status for multi-arch validation failure", namespace, request.Namespace, name, request.Name)
 						return reconcile.Result{}, err
 					}
+					r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 					return reconcile.Result{}, nil
 				}
 				nodeList := &corev1.NodeList{}
@@ -359,6 +440,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 						ctxlog.Error(ctx, err, "failed to update BuildRun status for multi-arch validation failure", namespace, request.Namespace, name, request.Name)
 						return reconcile.Result{}, err
 					}
+					r.recordPreExecutorFailure(buildRun, reason, buildmetrics.ResultFailed)
 					return reconcile.Result{}, nil
 				}
 			}
@@ -382,6 +464,7 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 					if updateErr := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, err.Error(), string(buildapi.VolumeDoesNotExist)); updateErr != nil {
 						return reconcile.Result{}, updateErr
 					}
+					r.recordPreExecutorFailure(buildRun, string(buildapi.VolumeDoesNotExist), buildmetrics.ResultFailed)
 					return reconcile.Result{}, nil // Stop reconciling
 				}
 				// Some other error occurred, return it for reconciliation retry
@@ -413,12 +496,18 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				ctxlog.Error(ctx, err, "Failed to update BuildRun status is ignored", namespace, request.Namespace, name, request.Name)
 			}
 
-			// Increase BuildRun count in metrics
-			buildmetrics.BuildRunCountInc(
+			executorKind := imageBuildRunner.GetExecutorKind()
+			strategyKind := strategyKindFromBuildSpec(buildRun.Status.BuildSpec)
+			sourceType := sourceTypeFromBuildSpec(buildRun.Status.BuildSpec)
+
+			buildmetrics.BuildRunsActiveInc(
 				buildRun.Status.BuildSpec.StrategyName(),
 				buildRun.Namespace,
 				buildRun.Spec.BuildName(),
 				buildRun.Name,
+				strategyKind,
+				executorKind,
+				sourceType,
 			)
 
 			// Report buildrun ramp-up duration (time between buildrun creation and taskrun creation)
@@ -427,6 +516,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				buildRun.Namespace,
 				buildRun.Spec.BuildName(),
 				buildRun.Name,
+				strategyKind,
+				executorKind,
+				sourceType,
 				imageBuildRunner.GetCreationTimestamp().Sub(buildRun.CreationTimestamp.Time),
 			)
 		} else {
@@ -504,6 +596,10 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 				}
 			}
 
+			brStrategyKind := strategyKindFromBuildSpec(buildRun.Status.BuildSpec)
+			brExecutorKind := buildRunner.GetExecutorKind()
+			brSourceType := sourceTypeFromBuildSpec(buildRun.Status.BuildSpec)
+
 			executorStartTime := buildRunner.GetStartTime()
 			if buildRun.Status.StartTime == nil && executorStartTime != nil {
 				buildRun.Status.StartTime = executorStartTime
@@ -514,6 +610,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 					buildRun.Namespace,
 					buildRun.Spec.BuildName(),
 					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					brSourceType,
 					buildRun.Status.StartTime.Sub(buildRun.CreationTimestamp.Time),
 				)
 			}
@@ -527,7 +626,50 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 					buildRun.Namespace,
 					buildRun.Spec.BuildName(),
 					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					brSourceType,
 					buildRun.Status.CompletionTime.Sub(buildRun.CreationTimestamp.Time),
+				)
+
+				// Record result and failure metrics
+				condition := buildRun.Status.GetCondition(buildapi.Succeeded)
+				result := classifyBuildRunResult(condition)
+				buildmetrics.BuildRunResultCountInc(
+					buildRun.Status.BuildSpec.StrategyName(),
+					buildRun.Namespace,
+					buildRun.Spec.BuildName(),
+					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					result,
+					brSourceType,
+				)
+				if result != buildmetrics.ResultSucceeded {
+					failureReason := ""
+					if condition != nil {
+						failureReason = condition.Reason
+					}
+					buildmetrics.BuildRunFailureReasonCountInc(
+						buildRun.Status.BuildSpec.StrategyName(),
+						buildRun.Namespace,
+						buildRun.Spec.BuildName(),
+						buildRun.Name,
+						brStrategyKind,
+						brExecutorKind,
+						brSourceType,
+						failureReason,
+					)
+				}
+
+				buildmetrics.BuildRunsActiveDec(
+					buildRun.Status.BuildSpec.StrategyName(),
+					buildRun.Namespace,
+					buildRun.Spec.BuildName(),
+					buildRun.Name,
+					brStrategyKind,
+					brExecutorKind,
+					brSourceType,
 				)
 
 				// Look for the pod created by the executor
@@ -556,6 +698,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 									buildRun.Namespace,
 									buildRun.Spec.BuildName(),
 									buildRun.Name,
+									brStrategyKind,
+									brExecutorKind,
+									brSourceType,
 									lastInitPod.State.Terminated.FinishedAt.Sub(pod.CreationTimestamp.Time),
 								)
 							}
@@ -567,6 +712,9 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 							buildRun.Namespace,
 							buildRun.Spec.BuildName(),
 							buildRun.Name,
+							brStrategyKind,
+							brExecutorKind,
+							brSourceType,
 							pod.CreationTimestamp.Sub(buildRunner.GetCreationTimestamp().Time),
 						)
 					}

--- a/pkg/reconciler/buildstrategy/buildstrategy.go
+++ b/pkg/reconciler/buildstrategy/buildstrategy.go
@@ -12,8 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/ctxlog"
+	buildmetrics "github.com/shipwright-io/build/pkg/metrics"
 )
 
 // blank assignment to verify that ReconcileBuildStrategy implements reconcile.Reconciler
@@ -46,5 +48,12 @@ func (r *ReconcileBuildStrategy) Reconcile(ctx context.Context, request reconcil
 	defer cancel()
 
 	ctxlog.Info(ctx, "reconciling BuildStrategy", "namespace", request.Namespace, "name", request.Name)
+
+	list := &buildapi.BuildStrategyList{}
+	if err := r.client.List(ctx, list); err != nil {
+		return reconcile.Result{}, err
+	}
+	buildmetrics.BuildStrategyCountSet(string(buildapi.NamespacedBuildStrategyKind), float64(len(list.Items)))
+
 	return reconcile.Result{}, nil
 }

--- a/pkg/reconciler/buildstrategy/buildstrategy_test.go
+++ b/pkg/reconciler/buildstrategy/buildstrategy_test.go
@@ -31,6 +31,8 @@ var _ = Describe("Reconcile BuildStrategy", func() {
 
 		// Fake the manager and get a reconcile Request
 		manager = &fakes.FakeManager{}
+		client := &fakes.FakeClient{}
+		manager.GetClientReturns(client)
 		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: buildStrategyName, Namespace: namespace}}
 	})
 

--- a/pkg/reconciler/clusterbuildstrategy/clusterbuildstrategy.go
+++ b/pkg/reconciler/clusterbuildstrategy/clusterbuildstrategy.go
@@ -12,8 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/build/pkg/config"
 	"github.com/shipwright-io/build/pkg/ctxlog"
+	buildmetrics "github.com/shipwright-io/build/pkg/metrics"
 )
 
 // blank assignment to verify that ReconcileClusterBuildStrategy implements reconcile.Reconciler
@@ -46,5 +48,12 @@ func (r *ReconcileClusterBuildStrategy) Reconcile(ctx context.Context, request r
 	defer cancel()
 
 	ctxlog.Info(ctx, "reconciling ClusterBuildStrategy", "name", request.Name)
+
+	list := &buildapi.ClusterBuildStrategyList{}
+	if err := r.client.List(ctx, list); err != nil {
+		return reconcile.Result{}, err
+	}
+	buildmetrics.BuildStrategyCountSet(string(buildapi.ClusterBuildStrategyKind), float64(len(list.Items)))
+
 	return reconcile.Result{}, nil
 }

--- a/pkg/reconciler/clusterbuildstrategy/clusterbuildstrategy_test.go
+++ b/pkg/reconciler/clusterbuildstrategy/clusterbuildstrategy_test.go
@@ -30,6 +30,8 @@ var _ = Describe("Reconcile ClusterBuildStrategy", func() {
 
 		// Fake the manager and get a reconcile Request
 		manager = &fakes.FakeManager{}
+		client := &fakes.FakeClient{}
+		manager.GetClientReturns(client)
 		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: buildStrategyName}}
 	})
 


### PR DESCRIPTION
# Changes

Add build_buildrun_result_total counter that tracks BuildRun completions
with outcome (succeeded/failed/cancelled/timeout), replacing the
misleading build_buildruns_completed_total which fired at executor
creation. Add build_buildrun_failure_reason_total counter for failure
breakdown, build_buildruns_active gauge for in-flight BuildRuns, and
build_buildstrategy_count gauge for strategy objects.

Add opt-in labels strategy_kind, executor, result, and source_type
to all metrics. Record pre-executor validation failures in result
metrics. Count both successful and failed Build registrations.

# Related Issue

Fixes #2148

# Type of PR

/kind feature

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
action required: metric changes with new metrics (build_buildrun_result_total, build_buildrun_failure_reason_total, build_buildruns_active, build_buildstrategy_count), new labels (strategy_kind, executor, result, source_type; opt-in via PROMETHEUS_ENABLED_LABELS), deprecation (build_buildruns_completed_total in favor of build_buildrun_result_total), changes (build_builds_registered_total now counts both successful and failed registrations)
```
