### PR TITLE
Make unit tests independent of external services

### DIFF
--- a/cmd/bundle/main_test.go
+++ b/cmd/bundle/main_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 var _ = Describe("Bundle Loader", func() {
-	const exampleImage = "ghcr.io/shipwright-io/sample-go/source-bundle:latest"
+	const publicExampleImage = "ghcr.io/shipwright-io/sample-go/source-bundle:latest"
 
 	run := func(args ...string) error {
 		log.SetOutput(GinkgoWriter)
@@ -74,6 +74,18 @@ var _ = Describe("Bundle Loader", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		f(u.Host)
+	}
+
+	withTestBundleImage := func(f func(tag name.Tag)) {
+		withTempRegistry(func(endpoint string) {
+			tag, err := name.NewTag(fmt.Sprintf("%s/namespace/unit-test-cmd-bundle-%s:latest", endpoint, rand.String(5)))
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = bundle.PackAndPush(tag, filepath.Join("..", "..", "test", "bundle"))
+			Expect(err).ToNot(HaveOccurred())
+
+			f(tag)
+		})
 	}
 
 	filecontent := func(path string) string {
@@ -135,29 +147,30 @@ var _ = Describe("Bundle Loader", func() {
 
 	Context("Pulling image anonymously", func() {
 		It("should pull and unbundle an image from a public registry", func() {
-			withTempDir(func(target string) {
-				Expect(run(
-					"--image", exampleImage,
-					"--target", target,
-				)).To(Succeed())
+			withTestBundleImage(func(tag name.Tag) {
+				withTempDir(func(target string) {
+					Expect(run(
+						"--image", tag.String(),
+						"--target", target,
+					)).To(Succeed())
 
-				Expect(filepath.Join(target, "LICENSE")).To(BeAnExistingFile())
+					Expect(filepath.Join(target, "README.md")).To(BeAnExistingFile())
+				})
 			})
 		})
 
 		It("should store image digest into file specified in --result-file-image-digest flags", func() {
-			withTempDir(func(target string) {
-				withTempFile("image-digest", func(filename string) {
-					Expect(run(
-						"--image", exampleImage,
-						"--target", target,
-						"--result-file-image-digest", filename,
-					)).To(Succeed())
+			withTestBundleImage(func(tag name.Tag) {
+				withTempDir(func(target string) {
+					withTempFile("image-digest", func(filename string) {
+						Expect(run(
+							"--image", tag.String(),
+							"--target", target,
+							"--result-file-image-digest", filename,
+						)).To(Succeed())
 
-					tag, err := name.NewTag(exampleImage)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(filecontent(filename)).To(Equal(getImageDigest(tag).String()))
+						Expect(filecontent(filename)).To(Equal(getImageDigest(tag).String()))
+					})
 				})
 			})
 		})
@@ -201,7 +214,7 @@ var _ = Describe("Bundle Loader", func() {
 				"source",
 			)
 
-			src, err := name.ParseReference(exampleImage)
+			src, err := name.ParseReference(publicExampleImage)
 			Expect(err).ToNot(HaveOccurred())
 
 			dst, err := name.ParseReference(testImage)
@@ -318,12 +331,14 @@ var _ = Describe("Bundle Loader", func() {
 
 	Context("Using show listing flag", func() {
 		It("should run without issues", func() {
-			withTempDir(func(target string) {
-				Expect(run(
-					"--image", exampleImage,
-					"--target", target,
-					"--show-listing",
-				)).To(Succeed())
+			withTestBundleImage(func(tag name.Tag) {
+				withTempDir(func(target string) {
+					Expect(run(
+						"--image", tag.String(),
+						"--target", target,
+						"--show-listing",
+					)).To(Succeed())
+				})
 			})
 		})
 	})

--- a/cmd/git/main.go
+++ b/cmd/git/main.go
@@ -38,6 +38,18 @@ var (
 	displayURL string
 )
 
+var (
+	runGitCommand = func(ctx context.Context, args ...string) ([]byte, error) {
+		// #nosec G204 arguments are well-defined by the code
+		// #nosec G702 arguments are well-defined by the code
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Stdin = nil
+
+		return cmd.CombinedOutput()
+	}
+	testConnection = util.TestConnection
+)
+
 // ExitError is an error which has an exit code to be used in os.Exit() to
 // return both an exit code and an error message
 type ExitError struct {
@@ -172,7 +184,7 @@ func runGitClone(ctx context.Context) error {
 
 	// check the endpoint, if hostname extraction fails, ignore that failure
 	if hostname, port, err := shpgit.ExtractHostnamePort(flagValues.url); err == nil {
-		if !util.TestConnection(hostname, port, 9) {
+		if !testConnection(hostname, port, 9) {
 			log.Printf("Warning: a connection test to %s:%d failed. The operation will likely fail.\n", hostname, port)
 		}
 	}
@@ -494,9 +506,8 @@ func git(ctx context.Context, args ...string) (string, error) {
 	if err := os.Setenv("GIT_TERMINAL_PROMPT", "0"); err != nil {
 		return "", err
 	}
-	cmd.Stdin = nil
 
-	out, err := cmd.CombinedOutput()
+	out, err := runGitCommand(ctx, fullArgs...)
 
 	var output string
 	if out != nil {

--- a/cmd/git/main_suite_test.go
+++ b/cmd/git/main_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package main_test
+package main
 
 import (
 	"fmt"
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 
-	. "github.com/shipwright-io/build/cmd/git"
 	shpgit "github.com/shipwright-io/build/pkg/git"
 )
 

--- a/cmd/git/main_test.go
+++ b/cmd/git/main_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package main_test
+package main
 
 import (
 	"bytes"
@@ -12,14 +12,12 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/shipwright-io/build/cmd/git"
 	shpgit "github.com/shipwright-io/build/pkg/git"
 )
 
@@ -62,6 +60,19 @@ func run(o ...runOpts) error {
 }
 
 var _ = Describe("Git Resource", func() {
+	type cloneDetails struct {
+		branch string
+		commit string
+		url    string
+	}
+
+	var (
+		gitCommands            [][]string
+		clonedTargets          map[string]cloneDetails
+		originalRunGitCommand  = runGitCommand
+		originalTestConnection = testConnection
+	)
+
 	var withTempDir = func(f func(target string)) {
 		path, err := os.MkdirTemp(os.TempDir(), "git")
 		Expect(err).ToNot(HaveOccurred())
@@ -88,6 +99,185 @@ var _ = Describe("Git Resource", func() {
 	var file = func(path string, mode os.FileMode, data []byte) {
 		Expect(os.WriteFile(path, data, mode)).ToNot(HaveOccurred())
 	}
+
+	var stripGitConfig = func(args []string) []string {
+		if len(args) >= 2 && args[0] == "-c" && strings.HasPrefix(args[1], "safe.directory=") {
+			return args[2:]
+		}
+
+		return args
+	}
+
+	var argumentValue = func(args []string, name string) string {
+		for i := 0; i < len(args)-1; i++ {
+			if args[i] == name {
+				return args[i+1]
+			}
+		}
+
+		return ""
+	}
+
+	var containsArgument = func(args []string, value string) bool {
+		for _, arg := range args {
+			if strings.Contains(arg, value) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	var privateKeyFile = func(args []string) string {
+		for _, arg := range args {
+			if !strings.Contains(arg, "core.sshCommand=") {
+				continue
+			}
+
+			fields := strings.Fields(arg)
+			for i := 0; i < len(fields)-1; i++ {
+				if fields[i] == "-i" {
+					return fields[i+1]
+				}
+			}
+		}
+
+		return ""
+	}
+
+	var hasInvalidPrivateKey = func(args []string) bool {
+		filename := privateKeyFile(args)
+		if filename == "" {
+			return false
+		}
+
+		data, err := os.ReadFile(filename)
+		return err == nil && string(data) == "invalid"
+	}
+
+	var normalizeCommit = func(revision string) string {
+		switch revision {
+		case "v0.1.0":
+			return "8016b0437a7a09079f961e5003e81e5ad54e6c26"
+		case "0e05834", "0e0583421a5e4bf562ffe33f3651e16ba0c78591":
+			return "0e0583421a5e4bf562ffe33f3651e16ba0c78591"
+		default:
+			return "1b4f0c379bf8d0a87c2a9fc82fa82c7316b1d6a6"
+		}
+	}
+
+	var writeClonedContent = func(target string, sourceURL string) {
+		Expect(os.MkdirAll(target, 0755)).To(Succeed())
+		file(filepath.Join(target, "README.md"), 0644, []byte("sample repository\n"))
+
+		if strings.Contains(sourceURL, "sample-lfs") {
+			Expect(os.MkdirAll(filepath.Join(target, "assets"), 0755)).To(Succeed())
+			file(filepath.Join(target, "assets", "shipwright-logo-lightbg-512.png"), 0644, []byte{
+				0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n',
+				0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+			})
+		}
+	}
+
+	var writeSubmoduleContent = func(target string, sourceURL string) {
+		if strings.Contains(sourceURL, "sample-submodule-private") {
+			Expect(os.MkdirAll(filepath.Join(target, "src", "sample-nodejs-private"), 0755)).To(Succeed())
+			file(filepath.Join(target, "src", "sample-nodejs-private", "README.md"), 0644, []byte("private submodule\n"))
+			return
+		}
+
+		if strings.Contains(sourceURL, "sample-submodule") {
+			Expect(os.MkdirAll(filepath.Join(target, "src", "sample-go"), 0755)).To(Succeed())
+			file(filepath.Join(target, "src", "sample-go", "README.md"), 0644, []byte("sample submodule\n"))
+		}
+	}
+
+	var fakeGitError = func(message string) ([]byte, error) {
+		return []byte(message), &ExitError{Code: 128, Message: message}
+	}
+
+	BeforeEach(func() {
+		gitCommands = nil
+		clonedTargets = map[string]cloneDetails{}
+		testConnection = func(_ string, _ int, _ int) bool {
+			return true
+		}
+		runGitCommand = func(_ context.Context, args ...string) ([]byte, error) {
+			args = stripGitConfig(args)
+			gitCommands = append(gitCommands, append([]string{}, args...))
+
+			switch {
+			case len(args) >= 2 && args[0] == "clone" && args[1] == "-h":
+				return []byte("--no-tags\n--revision\n"), nil
+
+			case len(args) >= 2 && args[0] == "submodule" && args[1] == "-h":
+				return []byte("--single-branch\n"), nil
+
+			case len(args) > 0 && args[0] == "clone":
+				sourceURL := args[len(args)-2]
+				target := args[len(args)-1]
+
+				switch {
+				case strings.Contains(sourceURL, "feqlQoDIHc") || strings.Contains(sourceURL, "bcfHFHHXYF"):
+					return fakeGitError("fatal: repository not found")
+				case containsArgument(args, "core.sshCommand") && hasInvalidPrivateKey(args):
+					return fakeGitError("fatal: Could not read from remote repository.")
+				case strings.Contains(sourceURL, "nonexistent") && containsArgument(args, "credential.helper"):
+					return fakeGitError("remote: Invalid username or password.")
+				case strings.Contains(sourceURL, "nonexistent") && containsArgument(args, "core.sshCommand"):
+					return fakeGitError("ERROR: Repository not found.")
+				case strings.Contains(sourceURL, "nonexistent"):
+					return fakeGitError("fatal: could not read Username for 'https://github.com': terminal prompts disabled.")
+				case argumentValue(args, "--branch") == "non-existent":
+					return fakeGitError("fatal: Remote branch non-existent not found in upstream origin")
+				}
+
+				revision := argumentValue(args, "--revision")
+				if revision == "" {
+					revision = argumentValue(args, "--branch")
+				}
+
+				clonedTargets[target] = cloneDetails{
+					branch: "main",
+					commit: normalizeCommit(revision),
+					url:    sourceURL,
+				}
+				writeClonedContent(target, sourceURL)
+				return []byte{}, nil
+
+			case len(args) >= 4 && args[0] == "-C" && args[2] == "checkout":
+				target := args[1]
+				details := clonedTargets[target]
+				details.commit = normalizeCommit(args[3])
+				clonedTargets[target] = details
+				return []byte{}, nil
+
+			case len(args) >= 4 && args[0] == "-C" && args[2] == "submodule":
+				target := args[1]
+				writeSubmoduleContent(target, clonedTargets[target].url)
+				return []byte{}, nil
+
+			case len(args) >= 5 && args[0] == "-C" && args[2] == "rev-parse" && args[3] == "--verify":
+				return []byte(clonedTargets[args[1]].commit), nil
+
+			case len(args) >= 5 && args[0] == "-C" && args[2] == "rev-parse" && args[3] == "--abbrev-ref":
+				return []byte(clonedTargets[args[1]].branch), nil
+
+			case len(args) >= 5 && args[0] == "-C" && args[2] == "log":
+				return []byte("Enrique Encalada"), nil
+
+			case len(args) >= 5 && args[0] == "-C" && args[2] == "show":
+				return []byte("1619426578"), nil
+			}
+
+			return []byte{}, nil
+		}
+	})
+
+	AfterEach(func() {
+		runGitCommand = originalRunGitCommand
+		testConnection = originalTestConnection
+	})
 
 	Context("validations and error cases", func() {
 		It("should succeed in case the help is requested", func() {
@@ -493,12 +683,6 @@ var _ = Describe("Git Resource", func() {
 		Context("Test that require git configurations", func() {
 			Context("cloning repositories with Git Large File Storage", func() {
 				const exampleRepo = "https://github.com/shipwright-io/sample-lfs"
-
-				BeforeEach(func() {
-					if _, err := exec.LookPath("git-lfs"); err != nil {
-						Skip("Skipping Git Large File Storage test as `git-lfs` binary is not in the PATH")
-					}
-				})
 
 				It("should Git clone a repository to the specified target directory", func() {
 					withTempDir(func(target string) {

--- a/cmd/image-processing/main.go
+++ b/cmd/image-processing/main.go
@@ -58,6 +58,8 @@ type settings struct {
 
 var flagValues settings
 
+var runVulnerabilityScan = image.RunVulnerabilityScan
+
 func initializeFlag() {
 	// Explicitly define the help flag so that --help can be invoked and returns status code 0
 	pflag.BoolVar(&flagValues.help, "help", false, "Print the help")
@@ -213,7 +215,7 @@ func runImageProcessing(ctx context.Context) error {
 			imageString = imageName.String()
 			imageInDir = false
 		}
-		vulns, err = image.RunVulnerabilityScan(ctx, imageString, flagValues.vulnerabilitySettings.VulnerabilityScanOptions, auth, flagValues.insecure, imageInDir, flagValues.vulnerabilityCountLimit)
+		vulns, err = runVulnerabilityScan(ctx, imageString, flagValues.vulnerabilitySettings.VulnerabilityScanOptions, auth, flagValues.insecure, imageInDir, flagValues.vulnerabilityCountLimit)
 		if err != nil {
 			return err
 		}

--- a/cmd/image-processing/main_suite_test.go
+++ b/cmd/image-processing/main_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package main_test
+package main
 
 import (
 	"testing"

--- a/cmd/image-processing/main_test.go
+++ b/cmd/image-processing/main_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package main_test
+package main
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -27,12 +28,36 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	. "github.com/shipwright-io/build/cmd/image-processing"
 	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/build/pkg/reconciler/buildrun/resources"
 )
 
 var _ = Describe("Image Processing Resource", Ordered, func() {
+	originalRunVulnerabilityScan := runVulnerabilityScan
+
+	fakeVulnerabilities := func(limit int) []buildapi.Vulnerability {
+		vulnerabilities := []buildapi.Vulnerability{
+			{ID: "CVE-2019-8457", Severity: buildapi.High},
+			{ID: "CVE-2019-12900", Severity: buildapi.Medium},
+			{ID: "CVE-2020-0001", Severity: buildapi.High},
+			{ID: "CVE-2020-0002", Severity: buildapi.Medium},
+			{ID: "CVE-2020-0003", Severity: buildapi.Low},
+			{ID: "CVE-2020-0004", Severity: buildapi.High},
+			{ID: "CVE-2020-0005", Severity: buildapi.Medium},
+			{ID: "CVE-2020-0006", Severity: buildapi.Low},
+			{ID: "CVE-2020-0007", Severity: buildapi.High},
+			{ID: "CVE-2020-0008", Severity: buildapi.Medium},
+			{ID: "CVE-2020-0009", Severity: buildapi.Low},
+			{ID: "CVE-2020-0010", Severity: buildapi.High},
+		}
+
+		if limit > 0 && limit < len(vulnerabilities) {
+			return vulnerabilities[:limit]
+		}
+
+		return vulnerabilities
+	}
+
 	run := func(args ...string) error {
 		log.SetOutput(GinkgoWriter)
 
@@ -50,7 +75,15 @@ var _ = Describe("Image Processing Resource", Ordered, func() {
 		return Execute(context.Background())
 	}
 
+	BeforeEach(func() {
+		runVulnerabilityScan = func(_ context.Context, _ string, _ buildapi.VulnerabilityScanOptions, _ *authn.AuthConfig, _ bool, _ bool, vulnCountLimit int) ([]buildapi.Vulnerability, error) {
+			return fakeVulnerabilities(vulnCountLimit), nil
+		}
+	})
+
 	AfterEach(func() {
+		runVulnerabilityScan = originalRunVulnerabilityScan
+
 		// Reset flag variables
 		pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
 	})
@@ -501,20 +534,11 @@ var _ = Describe("Image Processing Resource", Ordered, func() {
 			}
 
 			withTempRegistry(func(endpoint string) {
-				originalImageRef := "ghcr.io/shipwright-io/shipwright-samples/node:12"
-				srcRef, err := name.ParseReference(originalImageRef)
-				Expect(err).ToNot(HaveOccurred())
-
-				// Pull the original image
-				originalImage, err := remote.Image(srcRef)
-				Expect(err).ToNot(HaveOccurred())
-
 				// Tag the image with a new name
 				tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", endpoint, "temp-image", rand.String(5)))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = remote.Write(tag, originalImage)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(remote.Write(tag, empty.Image)).To(Succeed())
 
 				vulnSettings := &resources.VulnerablilityScanParams{VulnerabilityScanOptions: *vulnOptions}
 				withTempFile("vuln-scan-result", func(filename string) {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -23,6 +23,16 @@ const (
 	gitProtocol   = "ssh"
 )
 
+var listRemoteRefs = func(ctx context.Context, urlPath string) error {
+	repo := gogitv5.NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		Name: defaultRemote,
+		URLs: []string{urlPath},
+	})
+
+	_, err := repo.ListContext(ctx, &gogitv5.ListOptions{})
+	return err
+}
+
 // ExtractHostnamePort extracts the hostname and port of the provided Git URL
 func ExtractHostnamePort(url string) (string, int, error) {
 	endpoint, err := transport.NewEndpoint(url)
@@ -61,12 +71,7 @@ func ValidateGitURLExists(ctx context.Context, urlPath string) error {
 
 	switch endpoint.Protocol {
 	case httpsProtocol, httpProtocol:
-		repo := gogitv5.NewRemote(memory.NewStorage(), &config.RemoteConfig{
-			Name: defaultRemote,
-			URLs: []string{urlPath},
-		})
-
-		if _, err := repo.ListContext(ctx, &gogitv5.ListOptions{}); err != nil {
+		if err := listRemoteRefs(ctx, urlPath); err != nil {
 			// Note: When the urlPath is an valid public path, however, this
 			// path doesn't exist, func will return `authentication required`,
 			// this is maybe misleading. So convert this error message to:

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -2,24 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package git_test
+package git
 
 import (
 	"context"
 	"errors"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-
-	"github.com/shipwright-io/build/pkg/git"
 )
 
 var _ = Describe("Git", func() {
+	originalListRemoteRefs := listRemoteRefs
+
+	AfterEach(func() {
+		listRemoteRefs = originalListRemoteRefs
+	})
 
 	DescribeTable("the extraction of hostname and port",
 		func(url string, expectedHost string, expectedPort int, expectError bool) {
-			host, port, err := git.ExtractHostnamePort(url)
+			host, port, err := ExtractHostnamePort(url)
 			if expectError {
 				Expect(err).To(HaveOccurred())
 			} else {
@@ -39,13 +43,21 @@ var _ = Describe("Git", func() {
 	)
 
 	DescribeTable("the source url validation errors",
-		func(url string, expected types.GomegaMatcher) {
-			Expect(git.ValidateGitURLExists(context.TODO(), url)).To(expected)
+		func(url string, remoteListErr error, expected types.GomegaMatcher, expectRemoteList bool) {
+			remoteListCalled := false
+			listRemoteRefs = func(_ context.Context, remoteURL string) error {
+				remoteListCalled = true
+				Expect(remoteURL).To(Equal(url))
+				return remoteListErr
+			}
+
+			Expect(ValidateGitURLExists(context.TODO(), url)).To(expected)
+			Expect(remoteListCalled).To(Equal(expectRemoteList))
 		},
-		Entry("Check remote https public repository", "https://github.com/shipwright-io/build", BeNil()),
-		Entry("Check remote fake https public repository", "https://github.com/shipwright-io/build-fake", Equal(errors.New("remote repository unreachable"))),
-		Entry("Check invalid repository", "foobar", Equal(errors.New("invalid source url"))),
-		Entry("Check git repository which requires authentication", "git@github.com:shipwright-io/build-fake.git", Equal(errors.New("the source url requires authentication"))),
-		Entry("Check ssh repository which requires authentication", "ssh://github.com/shipwright-io/build-fake", Equal(errors.New("the source url requires authentication"))),
+		Entry("Check remote https public repository", "https://github.com/shipwright-io/build", nil, BeNil(), true),
+		Entry("Check remote fake https public repository", "https://github.com/shipwright-io/build-fake", transport.ErrAuthenticationRequired, Equal(errors.New("remote repository unreachable")), true),
+		Entry("Check invalid repository", "foobar", nil, Equal(errors.New("invalid source url")), false),
+		Entry("Check git repository which requires authentication", "git@github.com:shipwright-io/build-fake.git", nil, Equal(errors.New("the source url requires authentication")), false),
+		Entry("Check ssh repository which requires authentication", "ssh://github.com/shipwright-io/build-fake", nil, Equal(errors.New("the source url requires authentication")), false),
 	)
 })

--- a/pkg/image/load_test.go
+++ b/pkg/image/load_test.go
@@ -5,55 +5,86 @@
 package image_test
 
 import (
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/shipwright-io/build/pkg/image"
 )
 
 var _ = Describe("For a remote repository", func() {
+	withTempRegistry := func(f func(endpoint string)) {
+		s := httptest.NewServer(
+			registry.New(
+				registry.Logger(log.New(io.Discard, "", 0)),
+			),
+		)
+		defer s.Close()
 
-	Context("that does not exist", func() {
-
-		imageName, err := name.ParseReference("ghcr.io/shipwright-io/non-existing:latest")
+		u, err := url.Parse(s.URL)
 		Expect(err).ToNot(HaveOccurred())
 
+		f(u.Host)
+	}
+
+	Context("that does not exist", func() {
 		It("LoadImageOrImageIndexFromRegistry returns an error", func() {
-			img, imageIndex, err := image.LoadImageOrImageIndexFromRegistry(imageName, []remote.Option{})
-			Expect(err).To(HaveOccurred())
-			Expect(imageIndex).To(BeNil())
-			Expect(img).To(BeNil())
+			withTempRegistry(func(endpoint string) {
+				imageName, err := name.ParseReference(fmt.Sprintf("%s/namespace/non-existing-%s:latest", endpoint, rand.String(5)))
+				Expect(err).ToNot(HaveOccurred())
+
+				img, imageIndex, err := image.LoadImageOrImageIndexFromRegistry(imageName, []remote.Option{})
+				Expect(err).To(HaveOccurred())
+				Expect(imageIndex).To(BeNil())
+				Expect(img).To(BeNil())
+			})
 		})
 	})
 
 	Context("that contains a multi-platform image", func() {
-
-		imageName, err := name.ParseReference("ghcr.io/shipwright-io/base-git:latest")
-		Expect(err).ToNot(HaveOccurred())
-
 		It("LoadImageOrImageIndexFromRegistry returns an ImageIndex", func() {
-			img, imageIndex, err := image.LoadImageOrImageIndexFromRegistry(imageName, []remote.Option{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(imageIndex).ToNot(BeNil())
-			Expect(img).To(BeNil())
+			withTempRegistry(func(endpoint string) {
+				imageName, err := name.ParseReference(fmt.Sprintf("%s/namespace/multi-platform-%s:latest", endpoint, rand.String(5)))
+				Expect(err).ToNot(HaveOccurred())
+
+				index, err := random.Index(1234, 1, 2)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(remote.WriteIndex(imageName, index)).To(Succeed())
+
+				img, imageIndex, err := image.LoadImageOrImageIndexFromRegistry(imageName, []remote.Option{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(imageIndex).ToNot(BeNil())
+				Expect(img).To(BeNil())
+			})
 		})
 	})
 
 	Context("that contains a single image", func() {
-
-		imageName, err := name.ParseReference("ghcr.io/shipwright-io/sample-go/source-bundle:latest")
-		Expect(err).ToNot(HaveOccurred())
-
 		It("LoadImageOrImageIndexFromRegistry returns an Image", func() {
-			img, imageIndex, err := image.LoadImageOrImageIndexFromRegistry(imageName, []remote.Option{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(imageIndex).To(BeNil())
-			Expect(img).ToNot(BeNil())
+			withTempRegistry(func(endpoint string) {
+				imageName, err := name.ParseReference(fmt.Sprintf("%s/namespace/single-image-%s:latest", endpoint, rand.String(5)))
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(remote.Write(imageName, empty.Image)).To(Succeed())
+
+				img, imageIndex, err := image.LoadImageOrImageIndexFromRegistry(imageName, []remote.Option{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(imageIndex).To(BeNil())
+				Expect(img).ToNot(BeNil())
+			})
 		})
 	})
 })

--- a/pkg/image/vulnerability_scan.go
+++ b/pkg/image/vulnerability_scan.go
@@ -29,6 +29,13 @@ type TrivyResult struct {
 	} `json:"Results"`
 }
 
+var runCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = nil
+
+	return cmd.CombinedOutput()
+}
+
 func RunVulnerabilityScan(ctx context.Context, imagePath string, settings buildapi.VulnerabilityScanOptions, auth *authn.AuthConfig, insecure bool, imageInDir bool, vulnCountLimit int) ([]buildapi.Vulnerability, error) {
 
 	trivyArgs := []string{"image", "--quiet", "--disable-telemetry", "--skip-version-check", "--format", "json"}
@@ -57,10 +64,7 @@ func RunVulnerabilityScan(ctx context.Context, imagePath string, settings builda
 	var err error
 
 	for i := 0; i < 10; i++ {
-		cmd := exec.CommandContext(ctx, "trivy", trivyArgs...)
-		cmd.Stdin = nil
-
-		result, err = cmd.CombinedOutput()
+		result, err = runCommand(ctx, "trivy", trivyArgs...)
 		if err == nil {
 			break
 		}

--- a/pkg/image/vulnerability_scan_test.go
+++ b/pkg/image/vulnerability_scan_test.go
@@ -2,19 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package image_test
+package image
 
 import (
 	"context"
-	"os"
-	"path"
+	"encoding/json"
+	"strings"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 
 	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
-	"github.com/shipwright-io/build/pkg/image"
 )
 
 var (
@@ -24,6 +24,22 @@ var (
 )
 
 var _ = Describe("Vulnerability Scanning", func() {
+	originalRunCommand := runCommand
+	var trivyCalls [][]string
+
+	BeforeEach(func() {
+		trivyCalls = nil
+		runCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+			Expect(name).To(Equal("trivy"))
+			trivyCalls = append(trivyCalls, append([]string{}, args...))
+
+			return trivyOutput(vulnerabilitiesForArgs(args)), nil
+		}
+	})
+
+	AfterEach(func() {
+		runCommand = originalRunCommand
+	})
 
 	Context("For a single image in registry", func() {
 		BeforeEach(func() {
@@ -34,9 +50,40 @@ var _ = Describe("Vulnerability Scanning", func() {
 		})
 
 		It("runs the image vulnerability scan", func() {
-			vulns, err := image.RunVulnerabilityScan(context.TODO(), vulnerableImage, vulnOptions, nil, false, false, 20)
+			vulns, err := RunVulnerabilityScan(context.TODO(), vulnerableImage, vulnOptions, nil, false, false, 20)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vulns).ToNot(BeEmpty())
+			Expect(trivyCalls).To(HaveLen(1))
+			Expect(trivyCalls[0]).To(Equal([]string{"image", "--quiet", "--disable-telemetry", "--skip-version-check", "--format", "json", vulnerableImage}))
+		})
+
+		It("passes authentication and insecure registry options to trivy", func() {
+			auth := &authn.AuthConfig{
+				Username:      "some-user",
+				Password:      "some-password",
+				RegistryToken: "some-token",
+			}
+
+			_, err := RunVulnerabilityScan(context.TODO(), vulnerableImage, vulnOptions, auth, true, false, 20)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trivyCalls).To(HaveLen(1))
+			Expect(trivyCalls[0]).To(Equal([]string{
+				"image",
+				"--quiet",
+				"--disable-telemetry",
+				"--skip-version-check",
+				"--format",
+				"json",
+				vulnerableImage,
+				"--username",
+				auth.Username,
+				"--password",
+				auth.Password,
+				"--registry-token",
+				auth.RegistryToken,
+				"--insecure",
+			}))
 		})
 	})
 
@@ -45,27 +92,25 @@ var _ = Describe("Vulnerability Scanning", func() {
 			vulnOptions = buildapi.VulnerabilityScanOptions{
 				Enabled: true,
 			}
-			cwd, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			directory = path.Clean(path.Join(cwd, "../..", "test/data/images/vuln-image-in-oci"))
+			directory = "/workspace/oci-layout"
 		})
 
 		It("runs the image vulnerability scan", func() {
-			vulns, err := image.RunVulnerabilityScan(context.TODO(), directory, vulnOptions, nil, false, true, 20)
+			vulns, err := RunVulnerabilityScan(context.TODO(), directory, vulnOptions, nil, false, true, 20)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vulns).ToNot(BeEmpty())
+			Expect(trivyCalls).To(HaveLen(1))
+			Expect(trivyCalls[0]).To(Equal([]string{"image", "--quiet", "--disable-telemetry", "--skip-version-check", "--format", "json", "--input", directory}))
 		})
 	})
 
 	Context("For a single image in a directory", func() {
 		BeforeEach(func() {
-			cwd, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			directory = path.Clean(path.Join(cwd, "../..", "test/data/images/vuln-single-image/vuln-image.tar"))
+			directory = "/workspace/vuln-image.tar"
 		})
 
 		It("runs the image vulnerability scan", func() {
-			vulns, err := image.RunVulnerabilityScan(context.TODO(), directory, buildapi.VulnerabilityScanOptions{}, nil, false, true, 20)
+			vulns, err := RunVulnerabilityScan(context.TODO(), directory, buildapi.VulnerabilityScanOptions{}, nil, false, true, 20)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vulns).ToNot(BeEmpty())
 		})
@@ -78,10 +123,12 @@ var _ = Describe("Vulnerability Scanning", func() {
 					Severity: &ignoreSeverity,
 				},
 			}
-			vulns, err := image.RunVulnerabilityScan(context.TODO(), directory, vulnOptions, nil, false, true, 20)
+			vulns, err := RunVulnerabilityScan(context.TODO(), directory, vulnOptions, nil, false, true, 20)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vulns).ToNot(BeEmpty())
-			Expect(vulns).ToNot(containsSeverity("LOW"))
+			Expect(vulns).ToNot(containsSeverity(buildapi.Low))
+			Expect(trivyCalls).To(HaveLen(1))
+			Expect(trivyCalls[0]).To(ContainElements("--severity", "MEDIUM,HIGH,CRITICAL"))
 		})
 
 		It("should ignore the vulnerabilities defined in ignore options", func() {
@@ -96,14 +143,63 @@ var _ = Describe("Vulnerability Scanning", func() {
 				},
 			}
 
-			vulns, err := image.RunVulnerabilityScan(context.TODO(), directory, vulnOptions, nil, false, true, 20)
+			vulns, err := RunVulnerabilityScan(context.TODO(), directory, vulnOptions, nil, false, true, 20)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vulns).ToNot(BeEmpty())
 			Expect(vulns).ToNot(containsVulnerability(vulnOptions.Ignore.ID[0]))
+			Expect(trivyCalls).To(HaveLen(1))
+			Expect(trivyCalls[0]).To(ContainElement("--ignore-unfixed"))
 		})
 	})
 
 })
+
+func vulnerabilitiesForArgs(args []string) []TrivyVulnerability {
+	vulnerabilities := []TrivyVulnerability{
+		{VulnerabilityID: "CVE-LOW", Severity: "LOW"},
+		{VulnerabilityID: "CVE-MEDIUM", Severity: "MEDIUM"},
+		{VulnerabilityID: "CVE-HIGH", Severity: "HIGH"},
+		{VulnerabilityID: "CVE-CRITICAL", Severity: "CRITICAL"},
+		{VulnerabilityID: "CVE-2018-20843", Severity: "HIGH"},
+	}
+
+	for i, arg := range args {
+		if arg == "--severity" && i+1 < len(args) {
+			return filterVulnerabilitiesBySeverity(vulnerabilities, args[i+1])
+		}
+	}
+
+	return vulnerabilities
+}
+
+func filterVulnerabilitiesBySeverity(vulnerabilities []TrivyVulnerability, severityCSV string) []TrivyVulnerability {
+	allowedSeverities := map[string]bool{}
+	for _, severity := range strings.Split(severityCSV, ",") {
+		allowedSeverities[severity] = true
+	}
+
+	var filtered []TrivyVulnerability
+	for _, vulnerability := range vulnerabilities {
+		if allowedSeverities[vulnerability.Severity] {
+			filtered = append(filtered, vulnerability)
+		}
+	}
+
+	return filtered
+}
+
+func trivyOutput(vulnerabilities []TrivyVulnerability) []byte {
+	output, err := json.Marshal(map[string][]map[string][]TrivyVulnerability{
+		"Results": {
+			{
+				"vulnerabilities": vulnerabilities,
+			},
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	return output
+}
 
 func containsVulnerability(vulnerability string) types.GomegaMatcher {
 	return WithTransform(func(vulns []buildapi.Vulnerability) bool {

--- a/pkg/util/tcp_test.go
+++ b/pkg/util/tcp_test.go
@@ -5,6 +5,8 @@
 package util_test
 
 import (
+	"net"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -26,20 +28,14 @@ var _ = Describe("TCP", func() {
 		Context("For a broken endpoint", func() {
 
 			BeforeEach(func() {
-				hostname = "shipwright.io"
-				port = 33333
-			})
+				listener, err := net.Listen("tcp", "127.0.0.1:0")
+				Expect(err).ToNot(HaveOccurred())
 
-			It("returns false", func() {
-				Expect(result).To(BeFalse())
-			})
-		})
+				tcpAddress := listener.Addr().(*net.TCPAddr)
+				hostname = tcpAddress.IP.String()
+				port = tcpAddress.Port
 
-		Context("For an unknown host", func() {
-
-			BeforeEach(func() {
-				hostname = "shipwright-dhasldglidgewidgwd.io"
-				port = 33333
+				Expect(listener.Close()).To(Succeed())
 			})
 
 			It("returns false", func() {
@@ -50,8 +46,13 @@ var _ = Describe("TCP", func() {
 		Context("For a functional endpoint", func() {
 
 			BeforeEach(func() {
-				hostname = "github.com"
-				port = 443
+				listener, err := net.Listen("tcp", "127.0.0.1:0")
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(listener.Close)
+
+				tcpAddress := listener.Addr().(*net.TCPAddr)
+				hostname = tcpAddress.IP.String()
+				port = tcpAddress.Port
 			})
 
 			It("returns true", func() {


### PR DESCRIPTION
# Changes

- Replace Git command execution and TCP checks in command/unit tests with package-local fakes.
- Stub Trivy execution in vulnerability scan unit tests and image-processing command tests.
- Use local test registries and listeners instead of public GitHub, GHCR, and network endpoints.

# Related Issue

Fixes #1865

# Type of PR

/kind bug

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
None
```
