### PR TITLE
Stop storage migration wait loop on failed jobs

### DIFF
--- a/hack/storage-version-migration.sh
+++ b/hack/storage-version-migration.sh
@@ -98,7 +98,7 @@ EOF
 
 JOB_NAME=$(kubectl -n shipwright-build get job --selector app=storage-version-migration-shipwright -o jsonpath='{.items[0].metadata.name}')
 
-while [ "$(kubectl -n shipwright-build get job "${JOB_NAME}" -o json | jq -r '.status.completionTime // ""')" == "" ]; do
+while [ "$(kubectl -n shipwright-build get job "${JOB_NAME}" -o json | jq -r '.status.conditions[]? | select((.type == "Complete" or .type == "Failed") and .status == "True") | .type')" == "" ]; do
     echo "[INFO] Storage version migraton job is still running"
     sleep 10
 done


### PR DESCRIPTION
# Changes

- Wait for the storage version migration Job to reach either `Complete=True` or `Failed=True`.
- Preserve the existing failure handling so failed migration logs are printed before the script exits.

# Related Issue

Fixes #1680

# Type of PR

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
The storage version migration script now exits when the migration job reaches a failed terminal state instead of waiting indefinitely.
```
