### PR TITLE
fix(e2e): use tag-based image references instead of nested repo paths

### DIFF
--- a/test/e2e/v1beta1/e2e_image_mutate_test.go
+++ b/test/e2e/v1beta1/e2e_image_mutate_test.go
@@ -110,10 +110,9 @@ var _ = Describe("For a Kubernetes cluster with Tekton and build installed", fun
 		BeforeEach(func() {
 			testID = generateTestID("timestamp")
 
-			outputImage, err = name.ParseReference(fmt.Sprintf("%s/%s:%s",
+			outputImage, err = name.ParseReference(fmt.Sprintf("%s:%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,
-				"latest",
 			))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/test/e2e/v1beta1/e2e_ociartifact_test.go
+++ b/test/e2e/v1beta1/e2e_ociartifact_test.go
@@ -65,10 +65,9 @@ var _ = Describe("Test local source code (bundle) functionality", Label("OCIArti
 			testID = generateTestID("bundle")
 
 			inputImage = "ghcr.io/shipwright-io/sample-go/source-bundle:latest"
-			outputImage = fmt.Sprintf("%s/%s:%s",
+			outputImage = fmt.Sprintf("%s:%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,
-				"latest",
 			)
 		})
 
@@ -160,10 +159,9 @@ var _ = Describe("Test local source code (bundle) functionality", Label("OCIArti
 			var secretName = os.Getenv(EnvVarImageRepoSecret)
 			var registryName string
 			var auth authn.Authenticator
-			var tmpImage = fmt.Sprintf("%s/source-%s:%s",
+			var tmpImage = fmt.Sprintf("%s:source-%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,
-				"latest",
 			)
 
 			By("looking up the registry name", func() {

--- a/test/e2e/v1beta1/e2e_one_off_builds_test.go
+++ b/test/e2e/v1beta1/e2e_one_off_builds_test.go
@@ -53,10 +53,9 @@ var _ = Describe("Using One-Off Builds", Label("OneOffBuild"), func() {
 		BeforeEach(func() {
 			testID = generateTestID("onoff")
 
-			outputImage, err = name.ParseReference(fmt.Sprintf("%s/%s:%s",
+			outputImage, err = name.ParseReference(fmt.Sprintf("%s:%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,
-				"latest",
 			))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/test/e2e/v1beta1/e2e_pipelinerun_test.go
+++ b/test/e2e/v1beta1/e2e_pipelinerun_test.go
@@ -77,10 +77,9 @@ var _ = Describe("PipelineRun E2E Tests", Label("PipelineRun", "CORE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("pipelinerun-onoff")
-			outputImage, err = name.ParseReference(fmt.Sprintf("%s/%s:%s",
+			outputImage, err = name.ParseReference(fmt.Sprintf("%s:%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,
-				"latest",
 			))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -191,10 +190,9 @@ var _ = Describe("PipelineRun E2E Tests", Label("PipelineRun", "CORE"), func() {
 
 		BeforeEach(func() {
 			testID = generateTestID("pipelinerun-multi-task")
-			outputImage, err = name.ParseReference(fmt.Sprintf("%s/%s:%s",
+			outputImage, err = name.ParseReference(fmt.Sprintf("%s:%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,
-				"latest",
 			))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/test/e2e/v1beta1/e2e_vulnerability_scanning_test.go
+++ b/test/e2e/v1beta1/e2e_vulnerability_scanning_test.go
@@ -32,10 +32,9 @@ var _ = Describe("Vulnerability Scanning", Label("VulnerabilityScanning"), func(
 		var outputImage string
 		BeforeEach(func() {
 			testID = generateTestID("vuln")
-			outputImage = fmt.Sprintf("%s/%s:%s",
+			outputImage = fmt.Sprintf("%s:%s",
 				os.Getenv(EnvVarImageRepo),
 				testID,
-				"latest",
 			)
 
 			// Assume we use secure registry unless it is a cluster


### PR DESCRIPTION
# Changes

Several e2e tests construct output image references as
TEST_IMAGE_REPO/<testID>:latest, creating nested repository paths. This only
works with registries that support arbitrary nested repos (e.g. ttl.sh).
Registries like Quay.io and the OpenShift internal registry expect
<namespace>/<repo>:<tag> and reject nested paths with 401/400 errors.

Change to TEST_IMAGE_REPO:<testID> to match the pattern used by
amendOutputImage in common_test.go, making TEST_IMAGE_REPO work consistently
regardless of the registry backend

# Type of PR

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```


