### PR TITLE
Pin crane to v0.21.5 as v0.21.6 is broken

### DIFF
--- a/test/e2e/v1beta1/e2e_vulnerability_scanning_test.go
+++ b/test/e2e/v1beta1/e2e_vulnerability_scanning_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Vulnerability Scanning", Label("VulnerabilityScanning"), func(
 				Name("crane-pull-" + testID).
 				BuildStep(buildapi.Step{
 					Name:       "crane-pull",
-					Image:      "gcr.io/go-containerregistry/crane:latest",
+					Image:      "gcr.io/go-containerregistry/crane:v0.21.5",
 					WorkingDir: "$(params.shp-source-root)",
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser:  ptr.To[int64](1000),

--- a/test/v1alpha1_samples/buildstrategy_samples.go
+++ b/test/v1alpha1_samples/buildstrategy_samples.go
@@ -379,7 +379,7 @@ metadata:
 spec:
   buildSteps:
   - name: store-tarball
-    image: gcr.io/go-containerregistry/crane:v0.19.2
+    image: gcr.io/go-containerregistry/crane:v0.21.5
     command:
     - crane
     args:

--- a/test/v1beta1_samples/buildstrategy_samples.go
+++ b/test/v1beta1_samples/buildstrategy_samples.go
@@ -372,7 +372,7 @@ metadata:
 spec:
   steps:
   - name: store-tarball
-    image: gcr.io/go-containerregistry/crane:v0.19.2
+    image: gcr.io/go-containerregistry/crane:v0.21.5
     command:
     - crane
     args:

--- a/test/v1beta1_samples/clusterbuildstrategy_samples.go
+++ b/test/v1beta1_samples/clusterbuildstrategy_samples.go
@@ -129,7 +129,7 @@ metadata:
 spec:
   steps:
   - name: crane-pull
-    image: gcr.io/go-containerregistry/crane:latest
+    image: gcr.io/go-containerregistry/crane:v0.21.5
     workingDir: $(params.shp-source-root)
     securityContext:
       runAsUser: 1000


### PR DESCRIPTION
# Changes

Since crane v0.21.6 was shipped, all our integration and e2e tests fail. Cause is https://github.com/google/go-containerregistry/issues/2309. Mitigating by pinning our tests to use v0.21.5.

/kind failing-test

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
