### PR TITLE
Add environment variable to overwrite IBM Cloud's IAM endpoint

### DIFF
--- a/pkg/image/delete.go
+++ b/pkg/image/delete.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -221,9 +222,12 @@ func icrLogin(registry, username, apikey string) (string, string, error) {
 		return "", "", fmt.Errorf("provided access credentials for %q do not contain an IBM API key", registry)
 	}
 
-	iamEndpoint := "https://iam.cloud.ibm.com/identity/token"
-	if isIcrStageEndpoint(registry) {
-		iamEndpoint = "https://iam.test.cloud.ibm.com/identity/token"
+	iamEndpoint, found := os.LookupEnv("IBM_CLOUD_IAM_ENDPOINT")
+	if !found {
+		iamEndpoint = "https://iam.cloud.ibm.com/identity/token"
+		if isIcrStageEndpoint(registry) {
+			iamEndpoint = "https://iam.test.cloud.ibm.com/identity/token"
+		}
 	}
 
 	data := fmt.Sprintf("grant_type=%s&apikey=%s",


### PR DESCRIPTION
# Changes

When we have source code from a container image, we have an option to delete the image. If the image is hosted in IBM Cloud Container Registry, we have vendor-specific code with hard-coded IAM endpoints. This code change allows to overwrite this endpoint using an environment variable that would be set in the container template of the controller configuration.

/kind feature

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
