### PR TITLE
feat(webhook): add TLS flags and remove hardcoded curves/ciphers

### DIFF
--- a/cmd/shipwright-build-webhook/main.go
+++ b/cmd/shipwright-build-webhook/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -20,11 +19,14 @@ import (
 
 	"github.com/shipwright-io/build/pkg/ctxlog"
 	"github.com/shipwright-io/build/pkg/webhook/conversion"
+	"github.com/shipwright-io/build/pkg/webhook/tlsconfig"
 	"github.com/shipwright-io/build/version"
 )
 
 var (
-	versionGiven = flag.String("version", "devel", "Version of Shipwright webhook running")
+	versionGiven    = flag.String("version", "devel", "Version of Shipwright webhook running")
+	tlsMinVersion   = pflag.String("tls-min-version", "", "Minimum TLS version for the webhook HTTPS server (VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
+	tlsCipherSuites = pflag.String("tls-cipher-suites", "", "Comma-separated list of TLS 1.2 cipher suites (Go cipher suite names). Only applies when the minimum TLS version is below TLS 1.3. Defaults to Go runtime selection.")
 )
 
 func printVersion(ctx context.Context) {
@@ -66,22 +68,29 @@ func Execute() error {
 	mux.HandleFunc("/convert", conversion.CRDConvertHandler(ctx))
 	ctxlog.Info(ctx, "adding handlefunc() /convert")
 
+	serverTLSConfig, warning, err := tlsconfig.BuildServerTLSConfig(*tlsMinVersion, *tlsCipherSuites)
+	if err != nil {
+		ctxlog.Error(ctx, err, "invalid TLS configuration")
+		return err
+	}
+	if warning != "" {
+		ctxlog.Info(ctx, warning)
+	}
+	ctxlog.Info(
+		ctx,
+		fmt.Sprintf(
+			"effective TLS configuration: minVersion=%d cipherSuitesConfigured=%t cipherSuitesCount=%d",
+			serverTLSConfig.MinVersion,
+			serverTLSConfig.CipherSuites != nil,
+			len(serverTLSConfig.CipherSuites),
+		),
+	)
+
 	server := &http.Server{
 		Addr:              ":8443",
 		Handler:           mux,
 		ReadHeaderTimeout: 32 * time.Second,
-		TLSConfig: &tls.Config{
-			MinVersion:       tls.VersionTLS12,
-			CurvePreferences: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.X25519},
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			},
-		},
+		TLSConfig:         serverTLSConfig,
 	}
 
 	go func() {

--- a/pkg/webhook/tlsconfig/tlsconfig.go
+++ b/pkg/webhook/tlsconfig/tlsconfig.go
@@ -1,0 +1,108 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+)
+
+// BuildServerTLSConfig builds a tls.Config for serving HTTPS.
+//
+// Defaults:
+//   - Minimum TLS version is TLS 1.2.
+//   - Cipher suites and curve preferences are left unset to allow Go defaults
+//     (including TLS 1.3 cipher negotiation and updated curve defaults).
+//
+// Flags:
+// - minVersionFlag accepts: VersionTLS10|VersionTLS11|VersionTLS12|VersionTLS13
+// - cipherSuitesFlag is a comma-separated list of Go cipher suite names (TLS 1.2 only).
+//
+// Returns (cfg, warning, err). A warning is returned when cipher suites are provided
+// but ignored due to TLS 1.3 minimum.
+func BuildServerTLSConfig(minVersionFlag, cipherSuitesFlag string) (*tls.Config, string, error) {
+	minVersion, err := parseMinVersionFlag(minVersionFlag)
+	if err != nil {
+		return nil, "", err
+	}
+
+	cfg := &tls.Config{
+		MinVersion: minVersion,
+	}
+
+	cipherSuitesFlag = strings.TrimSpace(cipherSuitesFlag)
+	if cipherSuitesFlag == "" {
+		return cfg, "", nil
+	}
+
+	if minVersion >= tls.VersionTLS13 {
+		return cfg, "ignoring --tls-cipher-suites because --tls-min-version is TLS 1.3 or higher", nil
+	}
+
+	ciphers, err := parseCipherSuitesFlag(cipherSuitesFlag)
+	if err != nil {
+		return nil, "", err
+	}
+	cfg.CipherSuites = ciphers
+
+	return cfg, "", nil
+}
+
+func parseMinVersionFlag(v string) (uint16, error) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return tls.VersionTLS12, nil
+	}
+
+	switch v {
+	case "VersionTLS10":
+		return tls.VersionTLS10, nil
+	case "VersionTLS11":
+		return tls.VersionTLS11, nil
+	case "VersionTLS12":
+		return tls.VersionTLS12, nil
+	case "VersionTLS13":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("invalid --tls-min-version %q (allowed: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13)", v)
+	}
+}
+
+func parseCipherSuitesFlag(csv string) ([]uint16, error) {
+	parts := strings.Split(csv, ",")
+	var names []string
+	for _, p := range parts {
+		n := strings.TrimSpace(p)
+		if n != "" {
+			names = append(names, n)
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("invalid --tls-cipher-suites: no cipher suites provided")
+	}
+
+	byName := cipherSuiteNameMap()
+	out := make([]uint16, 0, len(names))
+	for _, name := range names {
+		id, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("invalid --tls-cipher-suites entry %q (must be a Go cipher suite name, e.g. TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)", name)
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func cipherSuiteNameMap() map[string]uint16 {
+	m := make(map[string]uint16, 64)
+	for _, cs := range tls.CipherSuites() {
+		m[cs.Name] = cs.ID
+	}
+	for _, cs := range tls.InsecureCipherSuites() {
+		m[cs.Name] = cs.ID
+	}
+	return m
+}

--- a/pkg/webhook/tlsconfig/tlsconfig_test.go
+++ b/pkg/webhook/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,291 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tlsconfig
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildServerTLSConfig_MinVersionDefaultsToTLS12(t *testing.T) {
+	cfg, warning, err := BuildServerTLSConfig("", "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if warning != "" {
+		t.Fatalf("expected no warning, got %q", warning)
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS1.2, got %d", cfg.MinVersion)
+	}
+	if cfg.CipherSuites != nil {
+		t.Fatalf("expected CipherSuites to be unset by default")
+	}
+	if cfg.CurvePreferences != nil {
+		t.Fatalf("expected CurvePreferences to be unset by default")
+	}
+}
+
+func TestBuildServerTLSConfig_MinVersionParsing(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint16
+	}{
+		{"VersionTLS10", tls.VersionTLS10},
+		{"VersionTLS11", tls.VersionTLS11},
+		{"VersionTLS12", tls.VersionTLS12},
+		{"VersionTLS13", tls.VersionTLS13},
+		{"  VersionTLS12  ", tls.VersionTLS12},
+	}
+
+	for _, tc := range cases {
+		cfg, warning, err := BuildServerTLSConfig(tc.in, "")
+		if err != nil {
+			t.Fatalf("minVersion %q: expected no error, got %v", tc.in, err)
+		}
+		if warning != "" {
+			t.Fatalf("minVersion %q: expected no warning, got %q", tc.in, warning)
+		}
+		if cfg.MinVersion != tc.want {
+			t.Fatalf("minVersion %q: expected %d, got %d", tc.in, tc.want, cfg.MinVersion)
+		}
+	}
+
+	if _, _, err := BuildServerTLSConfig("VersionTLS14", ""); err == nil {
+		t.Fatalf("expected error for invalid min version")
+	}
+}
+
+func TestBuildServerTLSConfig_CipherSuiteParsingAndOrderPreserved(t *testing.T) {
+	a := "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+	b := "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+
+	cfg, warning, err := BuildServerTLSConfig("VersionTLS12", a+","+b)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if warning != "" {
+		t.Fatalf("expected no warning, got %q", warning)
+	}
+	if cfg.CipherSuites == nil || len(cfg.CipherSuites) != 2 {
+		t.Fatalf("expected 2 cipher suites, got %#v", cfg.CipherSuites)
+	}
+
+	m := cipherSuiteNameMap()
+	if cfg.CipherSuites[0] != m[a] || cfg.CipherSuites[1] != m[b] {
+		t.Fatalf("expected order [%d,%d], got [%d,%d]", m[a], m[b], cfg.CipherSuites[0], cfg.CipherSuites[1])
+	}
+}
+
+func TestBuildServerTLSConfig_TLS13IgnoresCipherSuitesWithWarning(t *testing.T) {
+	cfg, warning, err := BuildServerTLSConfig("VersionTLS13", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("expected MinVersion TLS1.3, got %d", cfg.MinVersion)
+	}
+	if warning == "" || !strings.Contains(warning, "ignoring --tls-cipher-suites") {
+		t.Fatalf("expected ignore warning, got %q", warning)
+	}
+	if cfg.CipherSuites != nil {
+		t.Fatalf("expected CipherSuites to be unset for TLS 1.3 minimum")
+	}
+}
+
+func TestBuildServerTLSConfig_InvalidCipherSuitesFailFast(t *testing.T) {
+	if _, _, err := BuildServerTLSConfig("VersionTLS12", ""); err != nil {
+		t.Fatalf("empty flag should be treated as unset, got %v", err)
+	}
+
+	if _, _, err := BuildServerTLSConfig("VersionTLS12", " , , "); err == nil {
+		t.Fatalf("expected error for empty cipher suite list")
+	}
+
+	if _, _, err := BuildServerTLSConfig("VersionTLS12", "TLS_NOT_A_REAL_CIPHER"); err == nil {
+		t.Fatalf("expected error for invalid cipher suite name")
+	}
+}
+
+func testTLSClientConfig(t *testing.T, minVersion, maxVersion uint16, cipherSuites []uint16) *tls.Config {
+	t.Helper()
+
+	cfg := &tls.Config{
+		MinVersion: minVersion,
+		MaxVersion: maxVersion,
+	}
+	if len(cipherSuites) > 0 {
+		cfg.CipherSuites = cipherSuites
+	}
+	// #nosec:G402 test code uses ephemeral self-signed certificates
+	cfg.InsecureSkipVerify = true
+	return cfg
+}
+
+func TestHandshake_DefaultConfigAcceptsTLS12Client(t *testing.T) {
+	serverCfg, _, err := BuildServerTLSConfig("", "")
+	if err != nil {
+		t.Fatalf("expected no error building server config, got %v", err)
+	}
+
+	addr, stop := startHandshakeTestServer(t, serverCfg)
+	defer stop()
+
+	clientCfg := testTLSClientConfig(t, tls.VersionTLS12, tls.VersionTLS12, nil)
+
+	if err := dialTLS(addr, clientCfg); err != nil {
+		t.Fatalf("expected TLS 1.2 handshake to succeed with defaults, got %v", err)
+	}
+}
+
+func TestHandshake_TLS13MinimumRejectsTLS12Client(t *testing.T) {
+	serverCfg, _, err := BuildServerTLSConfig("VersionTLS13", "")
+	if err != nil {
+		t.Fatalf("expected no error building server config, got %v", err)
+	}
+
+	addr, stop := startHandshakeTestServer(t, serverCfg)
+	defer stop()
+
+	clientCfg := testTLSClientConfig(t, tls.VersionTLS12, tls.VersionTLS12, nil)
+
+	if err := dialTLS(addr, clientCfg); err == nil {
+		t.Fatal("expected TLS 1.2 client to be rejected when server minimum is TLS 1.3")
+	}
+}
+
+func TestHandshake_TLS13MinimumAcceptsTLS13Client(t *testing.T) {
+	serverCfg, _, err := BuildServerTLSConfig("VersionTLS13", "")
+	if err != nil {
+		t.Fatalf("expected no error building server config, got %v", err)
+	}
+
+	addr, stop := startHandshakeTestServer(t, serverCfg)
+	defer stop()
+
+	clientCfg := testTLSClientConfig(t, tls.VersionTLS13, tls.VersionTLS13, nil)
+
+	if err := dialTLS(addr, clientCfg); err != nil {
+		t.Fatalf("expected TLS 1.3 handshake to succeed, got %v", err)
+	}
+}
+
+func TestHandshake_CipherAllowlistRestrictsTLS12Negotiation(t *testing.T) {
+	const allowedCipher = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+	const disallowedCipher = "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+
+	serverCfg, _, err := BuildServerTLSConfig("VersionTLS12", allowedCipher)
+	if err != nil {
+		t.Fatalf("expected no error building server config, got %v", err)
+	}
+
+	addr, stop := startHandshakeTestServer(t, serverCfg)
+	defer stop()
+
+	suiteIDs := cipherSuiteNameMap()
+	allowedID, ok := suiteIDs[allowedCipher]
+	if !ok {
+		t.Fatalf("expected cipher suite %q to exist", allowedCipher)
+	}
+	disallowedID, ok := suiteIDs[disallowedCipher]
+	if !ok {
+		t.Fatalf("expected cipher suite %q to exist", disallowedCipher)
+	}
+
+	allowedClient := testTLSClientConfig(t, tls.VersionTLS12, tls.VersionTLS12, []uint16{allowedID})
+	if err := dialTLS(addr, allowedClient); err != nil {
+		t.Fatalf("expected allowed cipher suite to handshake successfully, got %v", err)
+	}
+
+	disallowedClient := testTLSClientConfig(t, tls.VersionTLS12, tls.VersionTLS12, []uint16{disallowedID})
+	if err := dialTLS(addr, disallowedClient); err == nil {
+		t.Fatal("expected disallowed cipher suite to be rejected by server allowlist")
+	}
+}
+
+func generateTestCertificate(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "shipwright-webhook-test",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}
+}
+
+func startHandshakeTestServer(t *testing.T, serverCfg *tls.Config) (string, func()) {
+	t.Helper()
+
+	serverCfg = serverCfg.Clone()
+	serverCfg.Certificates = []tls.Certificate{generateTestCertificate(t)}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				tlsConn, ok := c.(*tls.Conn)
+				if !ok {
+					return
+				}
+				_ = tlsConn.Handshake()
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		_ = ln.Close()
+		<-done
+	}
+}
+
+func dialTLS(addr string, cfg *tls.Config) error {
+	conn, err := tls.Dial("tcp", addr, cfg)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}

--- a/test/utils/v1beta1/webhook.go
+++ b/test/utils/v1beta1/webhook.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"context"
-	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/shipwright-io/build/pkg/webhook/conversion"
+	"github.com/shipwright-io/build/pkg/webhook/tlsconfig"
 	"github.com/shipwright-io/build/test/utils"
 )
 
@@ -22,23 +22,15 @@ func StartBuildWebhook() *http.Server {
 	mux.HandleFunc("/convert", conversion.CRDConvertHandler(context.Background()))
 	mux.HandleFunc("/health", health)
 
+	serverTLSConfig, _, err := tlsconfig.BuildServerTLSConfig("", "")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
 	webhookServer := &http.Server{
 		Addr:              ":30443",
 		Handler:           mux,
 		ReadHeaderTimeout: 32 * time.Second,
 		IdleTimeout:       time.Second,
-		TLSConfig: &tls.Config{
-			MinVersion:       tls.VersionTLS12,
-			CurvePreferences: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.X25519},
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			},
-		},
+		TLSConfig:         serverTLSConfig,
 	}
 
 	// start server

--- a/test/utils/webhook.go
+++ b/test/utils/webhook.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/shipwright-io/build/pkg/webhook/conversion"
+	"github.com/shipwright-io/build/pkg/webhook/tlsconfig"
 )
 
 func TestClient() *http.Client {
@@ -39,23 +40,15 @@ func StartBuildWebhook() *http.Server {
 	mux.HandleFunc("/convert", conversion.CRDConvertHandler(context.Background()))
 	mux.HandleFunc("/health", health)
 
+	serverTLSConfig, _, err := tlsconfig.BuildServerTLSConfig("", "")
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
 	webhookServer := &http.Server{
 		Addr:              ":30443",
 		Handler:           mux,
 		ReadHeaderTimeout: 32 * time.Second,
 		IdleTimeout:       time.Second,
-		TLSConfig: &tls.Config{
-			MinVersion:       tls.VersionTLS12,
-			CurvePreferences: []tls.CurveID{tls.CurveP256, tls.CurveP384, tls.X25519},
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			},
-		},
+		TLSConfig:         serverTLSConfig,
 	}
 
 	// start server


### PR DESCRIPTION
# Changes

Remove pinned CurvePreferences/CipherSuites so Go defaults (incl. ML-KEM) apply, keep TLS 1.2 minimum by default, and add --tls-min-version and --tls-cipher-suites via a shared tlsconfig helper with handshake tests.

Implements SHIP-0047

/kind feature

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] Kind label has been set
- [X] Release notes block has been filled in, or marked NONE


# Release Notes

```release-note
NONE
```
