### PR TITLE
fix(BuildStrategy): follow shp-output-insecure properly with buildpacks

### DIFF
--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -66,12 +66,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -42,8 +42,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -52,7 +64,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -66,15 +81,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -46,11 +46,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -141,11 +143,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -66,12 +66,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -42,8 +42,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -52,7 +64,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -66,15 +81,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -46,11 +46,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -141,11 +143,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -56,12 +56,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -36,11 +36,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -131,11 +133,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -32,8 +32,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -42,7 +54,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -56,15 +71,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -56,12 +56,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -36,11 +36,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -131,11 +133,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -32,8 +32,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -42,7 +54,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -56,15 +71,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -66,12 +66,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -42,8 +42,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -52,7 +64,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -66,15 +81,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml
@@ -46,11 +46,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -141,11 +143,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -66,12 +66,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -42,8 +42,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -52,7 +64,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -66,15 +81,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml
@@ -46,11 +46,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -141,11 +143,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -56,12 +56,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -36,11 +36,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -131,11 +133,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -32,8 +32,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -42,7 +54,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -56,15 +71,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -56,12 +56,12 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-          fi
 
-          if [[ ! -z "$insecureRegistries" ]]; then
-            echo "> Using insecure registries: $insecureRegistries"
+            if [[ ! -z "$insecureRegistries" ]]; then
+              echo "> Using insecure registries: $insecureRegistries"
 
-            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+            fi
           fi
 
           set -euo pipefail

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -32,8 +32,20 @@ spec:
       args:
         - -c
         - |
+          set -euo pipefail
+
           insecureRegistries=""
           inInsecureRegistries=false
+
+          function validate_insecure_output() {
+            if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
+              if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+              else
+                echo "> WARNING: insecure output registry $1 doubly listed"
+              fi
+            fi
+          }
 
           while [[ $# -gt 0 ]]; do
             arg="$1"
@@ -42,7 +54,10 @@ spec:
             if [ "${arg}" == "--insecure-registries" ]; then
               inInsecureRegistries=true
             elif [ "${inInsecureRegistries}" == "true" ]; then
-              insecureRegistries="${insecureRegistries}${arg},"
+              if [[ ! -z "${arg}" ]]; then
+                validate_insecure_output ${arg}
+                insecureRegistries="${insecureRegistries}${arg},"
+              fi
             else
               echo "Invalid usage"
               exit 1
@@ -56,15 +71,13 @@ spec:
             else
               insecureRegistries="${insecureRegistries}${outputImageHost},"
             fi
-
-            if [[ ! -z "$insecureRegistries" ]]; then
-              echo "> Using insecure registries: $insecureRegistries"
-
-              export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
-            fi
           fi
 
-          set -euo pipefail
+          if [[ ! -z "$insecureRegistries" ]]; then
+            echo "> Using insecure registries: $insecureRegistries"
+
+            export CNB_INSECURE_REGISTRIES="${insecureRegistries}"
+          fi
 
           echo "> Processing environment variables..."
           ENV_DIR="/platform/env"
@@ -100,7 +113,7 @@ spec:
           mkdir -p "$CACHE_DIR" "$LAYERS_DIR"
 
           function announce_phase {
-            printf "===> %s\n" "$1" 
+            printf "===> %s\n" "$1"
           }
 
           announce_phase "ANALYZING"
@@ -116,7 +129,7 @@ spec:
           /cnb/lifecycle/builder -app="${PARAM_SOURCE_CONTEXT}" -layers="$LAYERS_DIR"
 
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
-          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web ) 
+          grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
           announce_phase "EXPORTING"
           /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -36,11 +36,13 @@ spec:
 
           insecureRegistries=""
           inInsecureRegistries=false
+          shouldExport=true
 
           function validate_insecure_output() {
             if [[ ${PARAM_OUTPUT_IMAGE} =~ $1 ]]; then
               if [[ "${PARAM_OUTPUT_INSECURE}" != "true" ]]; then
-                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled"
+                echo "> WARNING: insecure output registry $1 listed while insecure output is disabled, disabling export"
+                shouldExport=false
               else
                 echo "> WARNING: insecure output registry $1 doubly listed"
               fi
@@ -131,11 +133,15 @@ spec:
           exporter_args=( -layers="$LAYERS_DIR" -report=/tmp/report.toml -cache-dir="$CACHE_DIR" -app="${PARAM_SOURCE_CONTEXT}")
           grep -q "buildpack-default-process-type" "$LAYERS_DIR/config/metadata.toml" || exporter_args+=( -process-type web )
 
-          announce_phase "EXPORTING"
-          /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
+          if [[ "$shouldExport" == true ]]; then
+            announce_phase "EXPORTING"
+            /cnb/lifecycle/exporter "${exporter_args[@]}" "${PARAM_OUTPUT_IMAGE}"
 
-          # Store the image digest
-          grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+            # Store the image digest
+            grep digest /tmp/report.toml | tail -n 1 | tr -d ' \"\n' | sed s/digest=// > "$(results.shp-image-digest.path)"
+          else
+            exit 1
+          fi
         - --
         - --insecure-registries
         - $(params.insecure-registries[*])


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here. Ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR refactors the implementation to:

- Better handle empty `insecure-registries` both as empty list or empty values in it.
- Adds a warning if the registry used for the insecure output is listed in the `insecure-registries`
- Disable the upload stage if that is the case
- 
# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Fixes #2237

# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug
/kind feature
/kind cleanup
/kind documentation

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

/kind bug

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!-- Describe any user-facing changes here, or mark as NONE.

Examples of user-facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

If this PR requires additional action from users switching to the new release,
include the string "action required" (case insensitive) in the release note.

If there are no user-facing changes, write NONE below. -->

```release-note
Fixed buildpacks-v3 BuildStrategy examples: improved `shp-output-insecure` handling.
```
