### PR TITLE
FIX: Ensure `SetOwnerReferenceFailed` updates the `BuildRun` status instead of the parent `Build`.

### DIFF
--- a/pkg/reconciler/buildrun/buildrun.go
+++ b/pkg/reconciler/buildrun/buildrun.go
@@ -218,11 +218,11 @@ func (r *ReconcileBuildRun) Reconcile(ctx context.Context, request reconcile.Req
 			if build.Spec.Retention != nil && build.Spec.Retention.AtBuildDeletion != nil {
 				if *build.Spec.Retention.AtBuildDeletion && !resources.IsOwnedByBuild(build, buildRun.OwnerReferences) {
 					if err := r.setOwnerReferenceFunc(build, buildRun, r.scheme); err != nil {
-						build.Status.Reason = ptr.To(buildapi.SetOwnerReferenceFailed)
-						build.Status.Message = ptr.To(fmt.Sprintf("unexpected error when trying to set the ownerreference: %v", err))
-						if err := r.client.Status().Update(ctx, build); err != nil {
-							return reconcile.Result{}, err
+						message := fmt.Sprintf("unexpected error when trying to set the ownerreference: %v", err)
+						if updateErr := resources.UpdateConditionWithFalseStatus(ctx, r.client, buildRun, message, resources.ConditionSetOwnerReferenceFailed); updateErr != nil {
+							return reconcile.Result{}, updateErr
 						}
+						return reconcile.Result{}, nil
 					}
 					ctxlog.Info(ctx, fmt.Sprintf("updating BuildRun %s OwnerReferences, owner is Build %s", buildRun.Name, build.Name), namespace, request.Namespace, name, request.Name)
 					updateBuildRunRequired = true

--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -1243,7 +1243,7 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(client.CreateCallCount()).To(Equal(1))
 			})
 
-			It("updates Build with error when BuildRun is already owned", func() {
+			It("fails the BuildRun when it is already owned by another controller", func() {
 				fakeOwnerName := "fakeOwner"
 
 				// Set the build spec
@@ -1263,18 +1263,31 @@ var _ = Describe("Reconcile BuildRun", func() {
 					ctl.DefaultNamespacedBuildStrategy()),
 				)
 
-				statusCall := ctl.StubBuildStatusReason(buildapi.SetOwnerReferenceFailed,
-					fmt.Sprintf("unexpected error when trying to set the ownerreference: Object /%s is already owned by another %s controller ", buildRunName, fakeOwnerName),
-				)
-				statusWriter.UpdateCalls(statusCall)
+				var sawOwnerReferenceFailure bool
+				statusWriter.UpdateCalls(func(_ context.Context, o crc.Object, _ ...crc.SubResourceUpdateOption) error {
+					br, ok := o.(*buildapi.BuildRun)
+					if !ok {
+						return nil
+					}
+					if c := br.Status.GetCondition(buildapi.Succeeded); c != nil && c.Status == corev1.ConditionFalse &&
+						c.Reason == resources.ConditionSetOwnerReferenceFailed {
+						sawOwnerReferenceFailure = true
+						Expect(c.Message).To(ContainSubstring("unexpected error when trying to set the ownerreference"))
+						Expect(c.Message).To(ContainSubstring(fmt.Sprintf("already owned by another %s controller", fakeOwnerName)))
+					}
+					return nil
+				})
 
+				// the BuildRun is marked Failed and we stop reconciling: the parent
+				// Build's status is left untouched and no TaskRun is created
 				_, err := reconciler.Reconcile(context.TODO(), buildRunRequest)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(sawOwnerReferenceFailure).To(BeTrue())
 
-				Expect(client.CreateCallCount()).To(Equal(1))
+				Expect(client.CreateCallCount()).To(Equal(0)) // proving the TaskRun is no longer created
 			})
 
-			It("updates Build with error when BuildRun and Build are not in the same ns when setting ownerreferences", func() {
+			It("fails the BuildRun when BuildRun and Build are not in the same ns when setting ownerreferences", func() {
 				// Set the build spec
 				buildRunSample = ctl.BuildRunWithFakeNamespace(buildRunName, buildName)
 				buildRunSample.Status.BuildSpec = &buildSample.Spec
@@ -1292,15 +1305,27 @@ var _ = Describe("Reconcile BuildRun", func() {
 					ctl.DefaultNamespacedBuildStrategy()),
 				)
 
-				statusCall := ctl.StubBuildStatusReason(buildapi.SetOwnerReferenceFailed,
-					fmt.Sprintf("unexpected error when trying to set the ownerreference: cross-namespace owner references are disallowed, owner's namespace %s, obj's namespace %s", buildSample.Namespace, buildRunSample.Namespace),
-				)
-				statusWriter.UpdateCalls(statusCall)
+				var sawOwnerReferenceFailure bool
+				statusWriter.UpdateCalls(func(_ context.Context, o crc.Object, _ ...crc.SubResourceUpdateOption) error {
+					br, ok := o.(*buildapi.BuildRun)
+					if !ok {
+						return nil
+					}
+					if c := br.Status.GetCondition(buildapi.Succeeded); c != nil && c.Status == corev1.ConditionFalse &&
+						c.Reason == resources.ConditionSetOwnerReferenceFailed {
+						sawOwnerReferenceFailure = true
+						Expect(c.Message).To(ContainSubstring(fmt.Sprintf("cross-namespace owner references are disallowed, owner's namespace %s, obj's namespace %s", buildSample.Namespace, buildRunSample.Namespace)))
+					}
+					return nil
+				})
 
+				// the BuildRun is marked Failed and we stop reconciling: the parent
+				// Build's status is left untouched and no TaskRun is created
 				_, err := reconciler.Reconcile(context.TODO(), buildRunRequest)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(sawOwnerReferenceFailure).To(BeTrue())
 
-				Expect(client.CreateCallCount()).To(Equal(1))
+				Expect(client.CreateCallCount()).To(Equal(0))
 			})
 
 			It("ensure the Build can own a BuildRun when using the proper annotation", func() {

--- a/pkg/reconciler/buildrun/buildrun_test.go
+++ b/pkg/reconciler/buildrun/buildrun_test.go
@@ -1285,6 +1285,14 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(sawOwnerReferenceFailure).To(BeTrue())
 
 				Expect(client.CreateCallCount()).To(Equal(0)) // proving the TaskRun is no longer created
+
+				// walk every Status().Update call recorded by the fake
+				// to prove the Build was never one of the updated objects
+				for i := 0; i < statusWriter.UpdateCallCount(); i++ {
+					_, obj, _ := statusWriter.UpdateArgsForCall(i)
+					_, isBuild := obj.(*buildapi.Build)
+					Expect(isBuild).To(BeFalse(), "Build status should not be updated on ownerreference failure")
+				}
 			})
 
 			It("fails the BuildRun when BuildRun and Build are not in the same ns when setting ownerreferences", func() {
@@ -1326,6 +1334,14 @@ var _ = Describe("Reconcile BuildRun", func() {
 				Expect(sawOwnerReferenceFailure).To(BeTrue())
 
 				Expect(client.CreateCallCount()).To(Equal(0))
+
+				// walk every Status().Update call recorded by the fake
+				// to prove the Build was never one of the updated objects
+				for i := 0; i < statusWriter.UpdateCallCount(); i++ {
+					_, obj, _ := statusWriter.UpdateArgsForCall(i)
+					_, isBuild := obj.(*buildapi.Build)
+					Expect(isBuild).To(BeFalse(), "Build status should not be updated on ownerreference failure")
+				}
 			})
 
 			It("ensure the Build can own a BuildRun when using the proper annotation", func() {


### PR DESCRIPTION
# Changes

during `buildrun` reconciliation if any preflight checks fails existing logic correctly updates the `buildrun` status and sets `Succeded` to fail
only the Ownerreference validation logic was incorrectly updating the parent build object's status

- updated that inconsistency to follow the same pattern as the sibling validation checks

the original tests such as `"updates Build with error when BuildRun is already owned"` were written with the incorrect assumption that the `Build` should receive the error.

- updated unit tests to inspect the `BuildRun`'s status instead of the `Build`'s


Fixes #827

# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug
/kind feature
/kind cleanup
/kind documentation

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

/kind bug

---

Tested locally by assigning a configmap as parent to the buildrun
Tested build.yaml
```yaml
apiVersion: shipwright.io/v1beta1
kind: Build
metadata:
  name: repro-build
spec:
  source:
    type: Git
    git:
      url: https://github.com/shipwright-io/sample-go
  strategy:
    name: buildpacks-v3
    kind: ClusterBuildStrategy
  output:
    image: docker.io/voidmoon/shipwright-build-test:latest
    pushSecret: docker-secret
  retention:
    atBuildDeletion: true

```

Tested buildrun.yaml
```yaml
apiVersion: shipwright.io/v1beta1
kind: BuildRun
metadata:
  name: test-buildrun-fake-owner
  ownerReferences:
    - apiVersion: v1
      kind: ConfigMap
      name: fake-owner
      uid: e42fb5a5-9921-44c9-a32a-73b4bf91b142
      controller: true
spec:
  build:
    name: repro-build

```

<img width="943" height="713" alt="image" src="https://github.com/user-attachments/assets/30a27a17-3ff6-43a1-8394-eb1b679308d5" />


# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
`SetOwnerReferenceFailed` updates `buildrun` status instead of `build` and stops reconciliation instead of continuing to build
```
