### PR TITLE
fix: prevent scheduled workflows on forks

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -6,7 +6,7 @@ on:
     types: [created, edited]
 jobs:
   check-new-versions:
-    if: contains(github.event.comment.body, '/rebase') || github.event_name == 'schedule'
+    if: ${{ contains(github.event.comment.body, '/rebase') || (github.event_name == 'schedule' && github.repository == 'shipwright-io/build') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/report-release-vulnerabilities.yaml
+++ b/.github/workflows/report-release-vulnerabilities.yaml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch: {}
 jobs:
   report-vulnerabilities:
+    if: ${{ github.repository == 'shipwright-io/build' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/update-tekton-version.yaml
+++ b/.github/workflows/update-tekton-version.yaml
@@ -12,7 +12,7 @@ on:
     types: [created, edited]
 jobs:
   check-new-versions:
-    if: contains(github.event.comment.body, '/rebase') || github.event_name == 'schedule'
+    if: ${{ contains(github.event.comment.body, '/rebase') || (github.event_name == 'schedule' && github.repository == 'shipwright-io/build') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Changes

Update the following workflow actions to only run on the `shipwright-io` repository when run on a schedule.

- Check latest images
- Update Tekton verison
- Report release vulnerabilities

This prevents action workflows from running on forks, which may not have required prerequisite information (secrets, assumed content, etc.).

# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Fixes #2264 

# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
