### PR TITLE
fix(waiter): stop ticker goroutine with NewTicker

### DIFF
--- a/cmd/waiter/waiter.go
+++ b/cmd/waiter/waiter.go
@@ -44,8 +44,8 @@ func (w *Waiter) retry() error {
 	timer := time.NewTimer(w.flagValues.timeout)
 	defer timer.Stop()
 
-	// Verify on file existence every 100ms. Prefer NewTicker over time.Tick so
-	// the underlying goroutine can be stopped when retry returns.
+	// Verify file existence every 100ms. Use NewTicker so the ticker can be
+	// stopped immediately when retry returns.
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/cmd/waiter/waiter.go
+++ b/cmd/waiter/waiter.go
@@ -44,14 +44,16 @@ func (w *Waiter) retry() error {
 	timer := time.NewTimer(w.flagValues.timeout)
 	defer timer.Stop()
 
-	// Verify on file existence every 100ms
-	ticker := time.Tick(100 * time.Millisecond)
+	// Verify on file existence every 100ms. Prefer NewTicker over time.Tick so
+	// the underlying goroutine can be stopped when retry returns.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-timer.C:
 			return fmt.Errorf("%w: elapsed %v seconds", ErrTimeout, w.flagValues.timeout.Seconds())
-		case <-ticker:
+		case <-ticker.C:
 			if _, err := os.Stat(w.flagValues.lockFile); err != nil && os.IsNotExist(err) {
 				log.Printf("Done! Condition has been reached\n")
 				return nil


### PR DESCRIPTION
# Changes

Replace time.Tick with time.NewTicker and defer Stop so the polling goroutine is cleaned up when retry returns on done or timeout.


# Type of PR

/kind cleanup


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes


```release-note
None
```
