### PR TITLE
Verify that annotation and label keys are not empty and do not contain an = character

### DIFF
--- a/deploy/crds/shipwright.io_buildruns.yaml
+++ b/deploy/crds/shipwright.io_buildruns.yaml
@@ -97,6 +97,10 @@ spec:
                         description: Annotations references the additional annotations
                           to be applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: annotation keys must not be empty and must not
+                            contain '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       credentials:
                         description: |-
                           Credentials references a Secret that contains credentials to access
@@ -126,6 +130,10 @@ spec:
                         description: Labels references the additional labels to be
                           applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: label keys must not be empty and must not contain
+                            '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       timestamp:
                         description: |-
                           Timestamp references the optional image timestamp to be set, valid values are:
@@ -316,6 +324,10 @@ spec:
                         description: Annotations references the additional annotations
                           to be applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: annotation keys must not be empty and must not
+                            contain '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       credentials:
                         description: |-
                           Credentials references a Secret that contains credentials to access
@@ -345,6 +357,10 @@ spec:
                         description: Labels references the additional labels to be
                           applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: label keys must not be empty and must not contain
+                            '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       timestamp:
                         description: |-
                           Timestamp references the optional image timestamp to be set, valid values are:
@@ -2765,6 +2781,10 @@ spec:
                     description: Annotations references the additional annotations
                       to be applied on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: annotation keys must not be empty and must not contain
+                        '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   credentials:
                     description: |-
                       Credentials references a Secret that contains credentials to access
@@ -2793,6 +2813,9 @@ spec:
                     description: Labels references the additional labels to be applied
                       on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: label keys must not be empty and must not contain '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   timestamp:
                     description: |-
                       Timestamp references the optional image timestamp to be set, valid values are:
@@ -4900,6 +4923,10 @@ spec:
                         description: Annotations references the additional annotations
                           to be applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: annotation keys must not be empty and must not
+                            contain '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       credentials:
                         description: |-
                           Credentials references a Secret that contains credentials to access
@@ -4929,6 +4956,10 @@ spec:
                         description: Labels references the additional labels to be
                           applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: label keys must not be empty and must not contain
+                            '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       timestamp:
                         description: |-
                           Timestamp references the optional image timestamp to be set, valid values are:
@@ -5119,6 +5150,10 @@ spec:
                         description: Annotations references the additional annotations
                           to be applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: annotation keys must not be empty and must not
+                            contain '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       credentials:
                         description: |-
                           Credentials references a Secret that contains credentials to access
@@ -5148,6 +5183,10 @@ spec:
                         description: Labels references the additional labels to be
                           applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: label keys must not be empty and must not contain
+                            '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       timestamp:
                         description: |-
                           Timestamp references the optional image timestamp to be set, valid values are:
@@ -7772,6 +7811,10 @@ spec:
                             description: Annotations references the additional annotations
                               to be applied on the image
                             type: object
+                            x-kubernetes-validations:
+                            - message: annotation keys must not be empty and must
+                                not contain '='
+                              rule: self.all(k, k != '' && !k.contains('='))
                           image:
                             description: Image is the reference of the image.
                             type: string
@@ -7785,6 +7828,10 @@ spec:
                             description: Labels references the additional labels to
                               be applied on the image
                             type: object
+                            x-kubernetes-validations:
+                            - message: label keys must not be empty and must not contain
+                                '='
+                              rule: self.all(k, k != '' && !k.contains('='))
                           platforms:
                             description: |-
                               Platforms is the list of OS and CPU architecture combinations to build for.
@@ -10417,6 +10464,10 @@ spec:
                     description: Annotations references the additional annotations
                       to be applied on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: annotation keys must not be empty and must not contain
+                        '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   image:
                     description: Image is the reference of the image.
                     type: string
@@ -10429,6 +10480,9 @@ spec:
                     description: Labels references the additional labels to be applied
                       on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: label keys must not be empty and must not contain '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   platforms:
                     description: |-
                       Platforms is the list of OS and CPU architecture combinations to build for.
@@ -12885,6 +12939,10 @@ spec:
                         description: Annotations references the additional annotations
                           to be applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: annotation keys must not be empty and must not
+                            contain '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       image:
                         description: Image is the reference of the image.
                         type: string
@@ -12898,6 +12956,10 @@ spec:
                         description: Labels references the additional labels to be
                           applied on the image
                         type: object
+                        x-kubernetes-validations:
+                        - message: label keys must not be empty and must not contain
+                            '='
+                          rule: self.all(k, k != '' && !k.contains('='))
                       platforms:
                         description: |-
                           Platforms is the list of OS and CPU architecture combinations to build for.

--- a/deploy/crds/shipwright.io_builds.yaml
+++ b/deploy/crds/shipwright.io_builds.yaml
@@ -84,6 +84,10 @@ spec:
                     description: Annotations references the additional annotations
                       to be applied on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: annotation keys must not be empty and must not contain
+                        '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   credentials:
                     description: |-
                       Credentials references a Secret that contains credentials to access
@@ -112,6 +116,9 @@ spec:
                     description: Labels references the additional labels to be applied
                       on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: label keys must not be empty and must not contain '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   timestamp:
                     description: |-
                       Timestamp references the optional image timestamp to be set, valid values are:
@@ -301,6 +308,10 @@ spec:
                     description: Annotations references the additional annotations
                       to be applied on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: annotation keys must not be empty and must not contain
+                        '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   credentials:
                     description: |-
                       Credentials references a Secret that contains credentials to access
@@ -329,6 +340,9 @@ spec:
                     description: Labels references the additional labels to be applied
                       on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: label keys must not be empty and must not contain '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   timestamp:
                     description: |-
                       Timestamp references the optional image timestamp to be set, valid values are:
@@ -2818,6 +2832,10 @@ spec:
                     description: Annotations references the additional annotations
                       to be applied on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: annotation keys must not be empty and must not contain
+                        '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   image:
                     description: Image is the reference of the image.
                     type: string
@@ -2830,6 +2848,9 @@ spec:
                     description: Labels references the additional labels to be applied
                       on the image
                     type: object
+                    x-kubernetes-validations:
+                    - message: label keys must not be empty and must not contain '='
+                      rule: self.all(k, k != '' && !k.contains('='))
                   platforms:
                     description: |-
                       Platforms is the list of OS and CPU architecture combinations to build for.

--- a/pkg/apis/build/v1alpha1/build_types.go
+++ b/pkg/apis/build/v1alpha1/build_types.go
@@ -241,11 +241,13 @@ type Image struct {
 	// Annotations references the additional annotations to be applied on the image
 	//
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self.all(k, k != '' && !k.contains('='))",message="annotation keys must not be empty and must not contain '='"
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Labels references the additional labels to be applied on the image
 	//
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self.all(k, k != '' && !k.contains('='))",message="label keys must not be empty and must not contain '='"
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Timestamp references the optional image timestamp to be set, valid values are:

--- a/pkg/apis/build/v1beta1/build_types.go
+++ b/pkg/apis/build/v1beta1/build_types.go
@@ -314,11 +314,13 @@ type Image struct {
 	// Annotations references the additional annotations to be applied on the image
 	//
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self.all(k, k != '' && !k.contains('='))",message="annotation keys must not be empty and must not contain '='"
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Labels references the additional labels to be applied on the image
 	//
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self.all(k, k != '' && !k.contains('='))",message="label keys must not be empty and must not contain '='"
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// VulnerabilityScan provides configurations about running a scan for your generated image


### PR DESCRIPTION
Assisted-by: GitHub Copilot/Claude Opus 5

# Changes

This declares the limitations added in #2276 already in the custom resource definition.

# Related Issue

Fixes #2249

# Type of PR

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
You can no longer create Builds and BuildRuns that have an empty annotation or label key for the output object. Also, keys are validated to not contain the `=` character which is actually a limitation Shipwright enforces due to how it handles this data in its processing.
```
