### PR TITLE
fix(api): add omitempty to SingleValue optional fields

### DIFF
--- a/pkg/apis/build/v1beta1/parameter.go
+++ b/pkg/apis/build/v1beta1/parameter.go
@@ -25,15 +25,15 @@ type SingleValue struct {
 
 	// The value of the parameter
 	// +optional
-	Value *string `json:"value"`
+	Value *string `json:"value,omitempty"`
 
 	// The ConfigMap value of the parameter
 	// +optional
-	ConfigMapValue *ObjectKeyRef `json:"configMapValue"`
+	ConfigMapValue *ObjectKeyRef `json:"configMapValue,omitempty"`
 
 	// The secret value of the parameter
 	// +optional
-	SecretValue *ObjectKeyRef `json:"secretValue"`
+	SecretValue *ObjectKeyRef `json:"secretValue,omitempty"`
 }
 
 // ParamValue is a key/value that populates a strategy parameter

--- a/pkg/apis/build/v1beta1/parameter_test.go
+++ b/pkg/apis/build/v1beta1/parameter_test.go
@@ -2,63 +2,50 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package v1beta1
+package v1beta1_test
 
 import (
 	"encoding/json"
-	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
-// TestSingleValueOmitsNilFields verifies that the mutually-exclusive optional
-// fields of SingleValue are omitted from the serialized output when unset,
-// instead of being rendered as explicit nulls (e.g. "configMapValue": null).
-func TestSingleValueOmitsNilFields(t *testing.T) {
+var _ = Describe("SingleValue", func() {
+
 	value := "BUILD_VERSION=1.0.0"
 
-	tests := []struct {
-		name        string
-		param       ParamValue
-		wantPresent []string
-		wantAbsent  []string
-	}{
-		{
-			name:        "literal value set",
-			param:       ParamValue{Name: "build-args", SingleValue: &SingleValue{Value: &value}},
-			wantPresent: []string{`"value":"BUILD_VERSION=1.0.0"`},
-			wantAbsent:  []string{`"configMapValue"`, `"secretValue"`},
-		},
-		{
-			name:        "configMap value set",
-			param:       ParamValue{Name: "p", SingleValue: &SingleValue{ConfigMapValue: &ObjectKeyRef{Name: "cm", Key: "k"}}},
-			wantPresent: []string{`"configMapValue"`},
-			wantAbsent:  []string{`"value"`, `"secretValue"`},
-		},
-		{
-			name:        "secret value set",
-			param:       ParamValue{Name: "p", SingleValue: &SingleValue{SecretValue: &ObjectKeyRef{Name: "s", Key: "k"}}},
-			wantPresent: []string{`"secretValue"`},
-			wantAbsent:  []string{`"value"`, `"configMapValue"`},
-		},
-	}
+	// verifies that the mutually-exclusive optional fields of SingleValue are
+	// omitted from the serialized output when unset, instead of being rendered
+	// as explicit nulls (e.g. "configMapValue": null)
+	DescribeTable("the serialization of a ParamValue",
+		func(param buildapi.ParamValue, wantPresent []string, wantAbsent []string) {
+			out, err := json.Marshal(param)
+			Expect(err).ToNot(HaveOccurred())
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			out, err := json.Marshal(tt.param)
-			if err != nil {
-				t.Fatalf("failed to marshal ParamValue: %v", err)
+			for _, want := range wantPresent {
+				Expect(string(out)).To(ContainSubstring(want))
 			}
-			got := string(out)
-			for _, want := range tt.wantPresent {
-				if !strings.Contains(got, want) {
-					t.Errorf("expected %q in output, got: %s", want, got)
-				}
+			for _, absent := range wantAbsent {
+				Expect(string(out)).ToNot(ContainSubstring(absent))
 			}
-			for _, absent := range tt.wantAbsent {
-				if strings.Contains(got, absent) {
-					t.Errorf("expected %q to be omitted, got: %s", absent, got)
-				}
-			}
-		})
-	}
-}
+		},
+		Entry("literal value set",
+			buildapi.ParamValue{Name: "build-args", SingleValue: &buildapi.SingleValue{Value: &value}},
+			[]string{`"value":"BUILD_VERSION=1.0.0"`},
+			[]string{`"configMapValue"`, `"secretValue"`},
+		),
+		Entry("configMap value set",
+			buildapi.ParamValue{Name: "p", SingleValue: &buildapi.SingleValue{ConfigMapValue: &buildapi.ObjectKeyRef{Name: "cm", Key: "k"}}},
+			[]string{`"configMapValue"`},
+			[]string{`"value"`, `"secretValue"`},
+		),
+		Entry("secret value set",
+			buildapi.ParamValue{Name: "p", SingleValue: &buildapi.SingleValue{SecretValue: &buildapi.ObjectKeyRef{Name: "s", Key: "k"}}},
+			[]string{`"secretValue"`},
+			[]string{`"value"`, `"configMapValue"`},
+		),
+	)
+})

--- a/pkg/apis/build/v1beta1/parameter_test.go
+++ b/pkg/apis/build/v1beta1/parameter_test.go
@@ -1,0 +1,64 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSingleValueOmitsNilFields verifies that the mutually-exclusive optional
+// fields of SingleValue are omitted from the serialized output when unset,
+// instead of being rendered as explicit nulls (e.g. "configMapValue": null).
+func TestSingleValueOmitsNilFields(t *testing.T) {
+	value := "BUILD_VERSION=1.0.0"
+
+	tests := []struct {
+		name        string
+		param       ParamValue
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "literal value set",
+			param:       ParamValue{Name: "build-args", SingleValue: &SingleValue{Value: &value}},
+			wantPresent: []string{`"value":"BUILD_VERSION=1.0.0"`},
+			wantAbsent:  []string{`"configMapValue"`, `"secretValue"`},
+		},
+		{
+			name:        "configMap value set",
+			param:       ParamValue{Name: "p", SingleValue: &SingleValue{ConfigMapValue: &ObjectKeyRef{Name: "cm", Key: "k"}}},
+			wantPresent: []string{`"configMapValue"`},
+			wantAbsent:  []string{`"value"`, `"secretValue"`},
+		},
+		{
+			name:        "secret value set",
+			param:       ParamValue{Name: "p", SingleValue: &SingleValue{SecretValue: &ObjectKeyRef{Name: "s", Key: "k"}}},
+			wantPresent: []string{`"secretValue"`},
+			wantAbsent:  []string{`"value"`, `"configMapValue"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := json.Marshal(tt.param)
+			if err != nil {
+				t.Fatalf("failed to marshal ParamValue: %v", err)
+			}
+			got := string(out)
+			for _, want := range tt.wantPresent {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected %q in output, got: %s", want, got)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("expected %q to be omitted, got: %s", absent, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/apis/build/v1beta1/v1beta1_suite_test.go
+++ b/pkg/apis/build/v1beta1/v1beta1_suite_test.go
@@ -1,0 +1,17 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1Beta1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Build v1beta1 API Suite")
+}


### PR DESCRIPTION
# Changes

The `Value`, `ConfigMapValue` and `SecretValue` fields of the `SingleValue`
type are mutually exclusive and optional, but their JSON tags lacked
`omitempty`. As a result, serialized build parameter values always rendered
the two unset fields as explicit nulls:

```yaml
- name: build-args
  values:
  - configMapValue: null
    secretValue: null
    value: BUILD_VERSION=1.0.0
```

This adds `omitempty` to all three fields so only the field that is actually
set appears in the output, producing cleaner Build/BuildRun YAML.

This is a serialization-only change — the CRD schema is unaffected, since
optionality is already driven by the `+optional` markers (verified: no CRD
regeneration diff). A unit test covering the value, configMap and secret
cases is included.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Unset optional build parameter value fields are now omitted from serialized output instead of appearing as `null`.
```

Co-Authored-By: Claude
