### PR TITLE
Fix release notes linter failing on LF-only and multi-line PR bodies

### DIFF
--- a/.github/workflows/release-notes-linter.yaml
+++ b/.github/workflows/release-notes-linter.yaml
@@ -19,19 +19,13 @@ jobs:
       run: |
         # Validate PR release notes
         echo "Going to validate PR ${PR_NUMBER}"
-
-        echo "First making sure you have not left the PR template as is"
-        # Describe any user facing changes here, or delete this block.
-        TEMPLATE_LEFT_AS_IS=$(wget -q  -O- https://api.github.com/repos/shipwright-io/build/pulls/${PR_NUMBER} | jq '.body | match("(Describe any user facing changes here, or delete this block)")')
-        if [ -z "${TEMPLATE_LEFT_AS_IS}" ]; then
-          echo "You appear to have attempted to update the PR template to define a release note."
-        else
-          echo "You have not made any changes for release notes in your PR description.  Edit your PR description per the instructions at https://raw.githubusercontent.com/shipwright-io/build/main/.github/pull_request_template.md"
-          exit 1
-        fi
+        PR_BODY=$(wget -q -O- https://api.github.com/repos/shipwright-io/build/pulls/${PR_NUMBER} | jq '.body')
 
         echo "Now checking against valid structure for release notes"
-        MATCHES=$(wget -q  -O- https://api.github.com/repos/shipwright-io/build/pulls/${PR_NUMBER} | jq '.body | match("(```release-note\r\n(.*|NONE|action required: .*)\r\n```)")')
+        # Strip CR so the match works for both CRLF (web UI) and LF (API, gh CLI) bodies.
+        # The block must contain at least one non-blank line and may span multiple lines
+        # (e.g. "action required" followed by a bullet list).
+        MATCHES=$(echo "${PR_BODY}" | jq 'gsub("\r"; "") | match("```release-note\n(.*[^[:space:]].*\n(?:.*\n)*?)```")')
         if [ -z "${MATCHES}" ]; then
           echo "Your Release Notes were not properly defined or they are not in place, please make sure you add them."
           echo "See our PR template for more information: https://raw.githubusercontent.com/shipwright-io/build/main/.github/pull_request_template.md"


### PR DESCRIPTION
# Changes

The release-notes-linter regex required CRLF line endings and a single-line note, so PRs whose body uses LF (edited via the API or `gh` CLI) or whose release note spans several lines (e.g. `action required` followed by a bullet list) failed despite a valid `release-note` block. This is currently failing on #2195 (LF-only `NONE`) and #2187 (multi-line `action required`).

- Strip `\r` before matching so both CRLF and LF bodies pass
- Allow multi-line notes, still requiring at least one non-blank line
- Remove the stale "template left as-is" check (its text is not in this repository's PR template)
- Fetch the PR body once

Verified by running the workflow's script locally against the bodies of #2187, #2195 and #2292 (pass) and a body without a block (fail). Same fix as shipwright-io/cli#406, extended for multi-line notes.

Developed with the assistance of Claude (Anthropic); reviewed by the author.

# Related Issue

N/A

# Type of PR

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```