### PR TITLE
Fix buildpacks-v3 samples using a floating builder tag by pinning it and adding it to the image-bump workflow

### DIFF
--- a/.github/workflows/check-latest-images.yaml
+++ b/.github/workflows/check-latest-images.yaml
@@ -17,6 +17,8 @@ jobs:
             latest-release-url: https://api.github.com/repos/moby/buildkit/releases/latest
           - image: quay.io/containers/buildah
             latest-release-url: https://quay.io/api/v1/repository/containers/buildah/tag/
+          - image: docker.io/paketobuildpacks/builder-jammy-full
+            latest-release-url: https://hub.docker.com/v2/repositories/paketobuildpacks/builder-jammy-full/tags
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/hack/check-latest-images.sh
+++ b/hack/check-latest-images.sh
@@ -47,6 +47,9 @@ function update() {
         QUERY=".tag_name"
         if [[ ${IMAGE} == *buildah* ]]; then
                 QUERY='[.tags[] | select(.name | endswith("immutable") | not) ] | sort_by(.name) | reverse | .[0].name'
+        elif [[ ${IMAGE} == *paketobuildpacks* ]]; then
+                # Docker Hub tags API: pick the highest x.y.z tag, ignoring "latest"
+                QUERY='[.results[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name] | sort_by(split(".") | map(tonumber)) | last'
         fi
 
         CURL_FLAGS=(

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -17,7 +17,7 @@ spec:
       defaults: []
   buildSteps:
     - name: build-and-push
-      image: docker.io/paketobuildpacks/builder-jammy-full:latest
+      image: docker.io/paketobuildpacks/builder-jammy-full:0.3.650
       env:
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)

--- a/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1alpha1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -17,7 +17,7 @@ spec:
       defaults: []
   buildSteps:
     - name: build-and-push
-      image: docker.io/paketobuildpacks/builder-jammy-full:latest
+      image: docker.io/paketobuildpacks/builder-jammy-full:0.3.650
       env:
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml
@@ -17,7 +17,7 @@ spec:
       defaults: []
   steps:
     - name: build-and-push
-      image: docker.io/paketobuildpacks/builder-jammy-full:latest
+      image: docker.io/paketobuildpacks/builder-jammy-full:0.3.650
       env:
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)

--- a/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
+++ b/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml
@@ -17,7 +17,7 @@ spec:
       defaults: []
   steps:
     - name: build-and-push
-      image: docker.io/paketobuildpacks/builder-jammy-full:latest
+      image: docker.io/paketobuildpacks/builder-jammy-full:0.3.650
       env: 
         - name: CNB_PLATFORM_API
           value: $(params.platform-api-version)


### PR DESCRIPTION
# Changes

The `buildpacks-v3` sample strategies referenced `docker.io/paketobuildpacks/builder-jammy-full:latest`, so their behavior changed whenever Paketo moved the tag, without any change in this repository.

- Pin the builder to `0.3.650` in the four `buildpacks-v3` sample files (v1alpha1 and v1beta1, cluster and namespaced), like the other sample images.
- Add the image to `.github/workflows/check-latest-images.yaml` so future updates arrive as reviewable PRs.
- `hack/check-latest-images.sh`: Paketo publishes no GitHub releases, so use the Docker Hub tags API with a jq query that picks the highest `x.y.z` tag (ignoring `latest`).

Verified locally: with the samples temporarily set to `0.3.639`, `hack/check-latest-images.sh docker.io/paketobuildpacks/builder-jammy-full https://hub.docker.com/v2/repositories/paketobuildpacks/builder-jammy-full/tags samples` resolves `0.3.644` and rewrites all four files.

This PR was assisted by Claude.

# Related Issue

Fixes #2301

# Type of PR

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The buildpacks-v3 sample build strategies now pin the Paketo builder image to a specific tag instead of using the floating latest tag.
```
