### PR TITLE
fix: preserve BuildRun output insecure and timestamp on conversion

### DIFF
--- a/pkg/apis/build/v1beta1/buildrun_conversion.go
+++ b/pkg/apis/build/v1beta1/buildrun_conversion.go
@@ -81,8 +81,10 @@ func (src *BuildRun) ConvertTo(ctx context.Context, obj *unstructured.Unstructur
 	if src.Spec.Output != nil {
 		alphaBuildRun.Spec.Output = &buildapialpha.Image{
 			Image:       src.Spec.Output.Image,
+			Insecure:    src.Spec.Output.Insecure,
 			Annotations: src.Spec.Output.Annotations,
 			Labels:      src.Spec.Output.Labels,
+			Timestamp:   src.Spec.Output.Timestamp,
 		}
 		if src.Spec.Output.PushSecret != nil {
 			alphaBuildRun.Spec.Output.Credentials = &corev1.LocalObjectReference{
@@ -348,8 +350,10 @@ func (dest *BuildRunSpec) ConvertFrom(ctx context.Context, orig *buildapialpha.B
 	if orig.Output != nil {
 		dest.Output = &Image{
 			Image:       orig.Output.Image,
+			Insecure:    orig.Output.Insecure,
 			Annotations: orig.Output.Annotations,
 			Labels:      orig.Output.Labels,
+			Timestamp:   orig.Output.Timestamp,
 		}
 
 		if orig.Output.Credentials != nil {

--- a/pkg/webhook/conversion/converter_test.go
+++ b/pkg/webhook/conversion/converter_test.go
@@ -1187,6 +1187,81 @@ request:
 			// Use ComparableTo and assert the whole object
 			Expect(buildRun).To(BeComparableTo(desiredBuildRun))
 		})
+
+		It("converts for spec output", func() {
+			// Create the yaml in v1beta1
+			buildTemplate := `kind: ConversionReview
+apiVersion: %s
+request:
+  uid: 0000-0000-0000-0000
+  desiredAPIVersion: %s
+  objects:
+    - apiVersion: shipwright.io/v1beta1
+      kind: BuildRun
+      metadata:
+        name: buildkit-run
+      spec:
+        build:
+          name: a_build
+        output:
+          image: %s
+          insecure: true
+          pushSecret: %s
+          timestamp: Zero
+          annotations:
+            org.opencontainers.image.url: https://my-company.com/images
+          labels:
+            maintainer: team@my-company.com
+`
+			o := fmt.Sprintf(buildTemplate, apiVersion,
+				desiredAPIVersion, image,
+				secretName)
+
+			// Invoke the /convert webhook endpoint
+			conversionReview, err := getConversionReview(o)
+			Expect(err).To(BeNil())
+			Expect(conversionReview.Response.Result.Status).To(Equal(v1.StatusSuccess))
+
+			convertedObj, err := ToUnstructured(conversionReview)
+			Expect(err).To(BeNil())
+
+			buildRun, err := toV1Alpha1BuildRunObject(convertedObj)
+			Expect(err).To(BeNil())
+
+			// Prepare our desired v1alpha1 BuildRun
+			desiredBuildRun := buildapialpha.BuildRun{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "buildkit-run",
+				},
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "shipwright.io/v1alpha1",
+					Kind:       "BuildRun",
+				},
+				Spec: buildapialpha.BuildRunSpec{
+					BuildRef: &buildapialpha.BuildRef{
+						Name: "a_build",
+					},
+					ServiceAccount: &buildapialpha.ServiceAccount{},
+					Output: &buildapialpha.Image{
+						Image:     image,
+						Insecure:  ptr.To(true),
+						Timestamp: ptr.To("Zero"),
+						Credentials: &corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Annotations: map[string]string{
+							"org.opencontainers.image.url": "https://my-company.com/images",
+						},
+						Labels: map[string]string{
+							"maintainer": "team@my-company.com",
+						},
+					},
+				},
+			}
+
+			// Use ComparableTo and assert the whole object
+			Expect(buildRun).To(BeComparableTo(desiredBuildRun))
+		})
 	})
 	Context("for a BuildRun CR from v1alpha1 to v1beta1", func() {
 		var desiredAPIVersion = "shipwright.io/v1beta1"
@@ -1421,6 +1496,79 @@ request:
 									},
 								},
 							},
+						},
+					},
+				},
+			}
+
+			// Use ComparableTo and assert the whole object
+			Expect(buildRun).To(BeComparableTo(desiredBuildRun))
+		})
+
+		It("converts for spec output", func() {
+			// Create the yaml in v1alpha1
+			buildTemplate := `kind: ConversionReview
+apiVersion: %s
+request:
+  uid: 0000-0000-0000-0000
+  desiredAPIVersion: %s
+  objects:
+    - apiVersion: shipwright.io/v1alpha1
+      kind: BuildRun
+      metadata:
+        name: buildkit-run
+      spec:
+        buildRef:
+          name: a_build
+        output:
+          image: %s
+          insecure: true
+          credentials:
+            name: %s
+          timestamp: Zero
+          annotations:
+            org.opencontainers.image.url: https://my-company.com/images
+          labels:
+            maintainer: team@my-company.com
+`
+			o := fmt.Sprintf(buildTemplate, apiVersion,
+				desiredAPIVersion, image,
+				secretName)
+
+			// Invoke the /convert webhook endpoint
+			conversionReview, err := getConversionReview(o)
+			Expect(err).To(BeNil())
+			Expect(conversionReview.Response.Result.Status).To(Equal(v1.StatusSuccess))
+
+			convertedObj, err := ToUnstructured(conversionReview)
+			Expect(err).To(BeNil())
+
+			buildRun, err := toV1Beta1BuildRunObject(convertedObj)
+			Expect(err).To(BeNil())
+
+			// Prepare our desired v1beta1 BuildRun
+			desiredBuildRun := buildapi.BuildRun{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "buildkit-run",
+				},
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "shipwright.io/v1beta1",
+					Kind:       "BuildRun",
+				},
+				Spec: buildapi.BuildRunSpec{
+					Build: buildapi.ReferencedBuild{
+						Name: ptr.To("a_build"),
+					},
+					Output: &buildapi.Image{
+						Image:      image,
+						Insecure:   ptr.To(true),
+						Timestamp:  ptr.To("Zero"),
+						PushSecret: ptr.To(secretName),
+						Annotations: map[string]string{
+							"org.opencontainers.image.url": "https://my-company.com/images",
+						},
+						Labels: map[string]string{
+							"maintainer": "team@my-company.com",
 						},
 					},
 				},


### PR DESCRIPTION
# Changes

The `BuildRun` conversion webhook built the output `Image` struct with only `Image`, `Annotations` and `Labels` before attaching the push secret, so `.spec.output.insecure` and `.spec.output.timestamp` were silently dropped in **both** directions. Both fields exist in the `Image` type in `v1alpha1` and `v1beta1`, and the equivalent `Build` conversion already carries them (`build_conversion.go` L201/L208 and L294/L301) — so a `Build` round-tripped its output settings intact while a `BuildRun` overriding the same settings lost them.

A user setting `output.insecure` to push to an insecure registry, or `output.timestamp` for a reproducible image timestamp, on a `BuildRun` had that override discarded without warning once the object passed through conversion, and the build ran with different output settings than requested.

This copies both fields in `ConvertTo` and `ConvertFrom`, mirroring the `Build` conversion, and adds conversion webhook specs covering the `BuildRun` output in both directions.

# Related Issue

Fixes #2303

# Type of PR

/kind bug

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] ~Includes docs if changes are user-facing~ — no API surface or documented behaviour changes; the fix makes existing documented fields behave as documented
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Fixed BuildRun conversion silently dropping `.spec.output.insecure` and `.spec.output.timestamp`. Both fields are now preserved when a BuildRun is converted between v1alpha1 and v1beta1, matching the existing Build conversion behaviour.
```
