### PR TITLE
CHORE: update readme with correct release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright deployment. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/latest/release.yaml --server-side
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.20.14/hack/setup-webhook-cert.sh | bash
-  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.20.14/hack/storage-version-migration.sh | bash
+  VERSION=$(curl -s https://api.github.com/repos/shipwright-io/build/releases/latest | jq -r .tag_name)
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/${VERSION}/release.yaml --server-side
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/${VERSION}/hack/setup-webhook-cert.sh | bash
+  curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/${VERSION}/hack/storage-version-migration.sh | bash
   ```
 
   To install the latest nightly release, run:
@@ -64,7 +65,8 @@ Shipwright supports any tool that can build container images in Kubernetes clust
 - Install the Shipwright strategies. To install the latest version, run:
 
   ```bash
-  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/latest/sample-strategies.yaml --server-side
+  VERSION=$(curl -s https://api.github.com/repos/shipwright-io/build/releases/latest | jq -r .tag_name)
+  kubectl apply --filename https://github.com/shipwright-io/build/releases/download/${VERSION}/sample-strategies.yaml --server-side
   ```
 
   To install the latest nightly release, run:


### PR DESCRIPTION
# Changes

the changes made from #2314 caused the installation commands to fail
<img width="933" height="108" alt="image" src="https://github.com/user-attachments/assets/3edab4b8-8de8-4728-b0a0-aa71505bad31" />


we've discussed about bulding an automation that automatically updates the release tags in readme
i think this should solve the problem without needing to create an automation 



# Related Issue


Fixes #

# Type of PR



/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [ ] Release notes block has been filled in, or marked NONE

# Release Notes


```release-note
NONE
```
