### PR TITLE
Fix nil-pointer panic converting OCIArtifact source with nil sub-object

### DIFF
--- a/pkg/apis/build/v1beta1/build_conversion.go
+++ b/pkg/apis/build/v1beta1/build_conversion.go
@@ -436,14 +436,16 @@ func getAlphaBuildSource(src BuildSpec) buildapialpha.Source {
 
 	switch src.Source.Type {
 	case OCIArtifactType:
-		if src.Source.OCIArtifact != nil && src.Source.OCIArtifact.PullSecret != nil {
-			credentials = corev1.LocalObjectReference{
-				Name: *src.Source.OCIArtifact.PullSecret,
+		if src.Source.OCIArtifact != nil {
+			if src.Source.OCIArtifact.PullSecret != nil {
+				credentials = corev1.LocalObjectReference{
+					Name: *src.Source.OCIArtifact.PullSecret,
+				}
 			}
-		}
-		source.BundleContainer = &buildapialpha.BundleContainer{
-			Image: src.Source.OCIArtifact.Image,
-			Prune: (*buildapialpha.PruneOption)(src.Source.OCIArtifact.Prune),
+			source.BundleContainer = &buildapialpha.BundleContainer{
+				Image: src.Source.OCIArtifact.Image,
+				Prune: (*buildapialpha.PruneOption)(src.Source.OCIArtifact.Prune),
+			}
 		}
 	default:
 		if src.Source.Git != nil && src.Source.Git.CloneSecret != nil {

--- a/pkg/apis/build/v1beta1/build_conversion_test.go
+++ b/pkg/apis/build/v1beta1/build_conversion_test.go
@@ -1,0 +1,35 @@
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	buildapialpha "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildapi "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+)
+
+var _ = Describe("BuildSpec ConvertTo", func() {
+
+	// verifies that converting a BuildSpec whose source type is OCIArtifact but
+	// whose OCIArtifact field is unset does not panic, and instead produces an
+	// empty BundleContainer, matching the existing nil-safe handling of Git sources
+	It("does not panic when the source type is OCIArtifact but OCIArtifact is nil", func() {
+		src := buildapi.BuildSpec{
+			Source: &buildapi.Source{
+				Type: buildapi.OCIArtifactType,
+			},
+		}
+
+		dest := &buildapialpha.BuildSpec{}
+
+		Expect(func() {
+			Expect(src.ConvertTo(dest)).To(Succeed())
+		}).ToNot(Panic())
+
+		Expect(dest.Source.BundleContainer).To(BeNil())
+	})
+})


### PR DESCRIPTION
Motivation:
getAlphaBuildSource, used when converting a v1beta1 Build to v1alpha1,
dereferenced src.Source.OCIArtifact.Image and .Prune unconditionally
whenever spec.source.type was set to OCI. There is no synchronous
validation webhook enforcing that spec.source.ociArtifact is set when
the type is OCI, so a Build with a mismatched type/sub-object pairing
can reach the conversion webhook and trigger a nil-pointer dereference.

The webhook server here is a plain net/http.Server/ServeMux with no
panic-recovery middleware of its own, so the panic is only caught by
net/http's per-connection recovery, which logs it and closes the TCP
connection without writing any response, instead of the request
failing with a clear validation error. This does not crash the
webhook process itself; only the single request fails ungracefully.

Approach:
Wrap the whole OCIArtifact-handling branch (both the PullSecret lookup
and the BundleContainer construction) in a single
`src.Source.OCIArtifact != nil` guard, mirroring the nil-safe pattern
already used a few lines below for the Git source case in the same
function. Behavior when OCIArtifact is set is unchanged.

Validation:
- go build ./... passes.
- go test ./pkg/apis/build/v1beta1/... -race -v passes (4/4 specs).
- golangci-lint run --timeout=10m ./pkg/apis/build/v1beta1/... reports
  0 issues.
- Added a Ginkgo test in build_conversion_test.go that converts a
  BuildSpec with Source.Type=OCIArtifactType and Source.OCIArtifact=nil.
  Verified by temporarily reverting the fix: the test panics with
  "invalid memory address or nil pointer dereference" without the fix,
  and passes (BundleContainer left nil) with it.
- Did not run make test-integration/test-e2e: this is a pure unit-level
  conversion bug with no cluster interaction, fully covered by the unit
  test above.

Report: https://github.com/shipwright-io/build/issues/2324
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #2324

```release-note
Fix nil-pointer panic converting OCIArtifact source with nil sub-object
```
