### PR TITLE
fix: explicitly handle exhausted Trivy retries

### DIFF
--- a/pkg/image/vulnerability_scan.go
+++ b/pkg/image/vulnerability_scan.go
@@ -74,12 +74,18 @@ func RunVulnerabilityScan(ctx context.Context, imagePath string, settings builda
 		//  GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 508.904┬Ás, allowed: 44000/minute
 		//
 		// FATAL	Fatal error	init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from any source
-		if i < 10 && strings.Contains(sResult, "failed to download vulnerability DB") {
+		if strings.Contains(sResult, "failed to download vulnerability DB") {
 			log.Println("Will retry")
 			time.Sleep(time.Second)
 		} else {
 			return nil, fmt.Errorf("failed to run trivy: %w", err)
 		}
+	}
+
+	// All retry attempts were exhausted return the underlying Trivy error
+	// rather than falling through to json.Unmarshal with error output.
+	if err != nil {
+		return nil, fmt.Errorf("failed to run trivy: %w", err)
 	}
 
 	var trivyResult TrivyResult


### PR DESCRIPTION
# Changes

This PR fixes a bug in the image vulnerability scanning retry logic. 

Previously, if all 10 retry attempts to download the Trivy vulnerability database failed, the loop would exit and incorrectly fall through to `json.Unmarshal`. Because the output contained the plain text connection error instead of valid JSON, this would cause a confusing JSON parsing panic (`invalid character...`) that masked the real execution error.

This PR:
1. Adds an explicit check after the loop to return the underlying Trivy execution error if all retries are exhausted.
2. Cleans up a redundant `i < 10` check inside the `for i := 0; i < 10; i++` loop.

# Related Issue

Fixes #2329

# Type of PR

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE


# Release Notes

<!-- Describe any user-facing changes here, or mark as NONE. -->

```release-note
Fixed an issue where vulnerability scanning failures caused by Trivy database download timeouts would result in a confusing JSON parsing error instead of correctly reporting the underlying connection issue.
```
