### PR TITLE
Fix:#2328

### DIFF
--- a/hack/install-spruce.sh
+++ b/hack/install-spruce.sh
@@ -31,12 +31,15 @@ fi
 
 echo "[INFO] Retrieving spruce binary release location"
 DOWNLOAD_URI="$(curl --silent --location "https://api.github.com/repos/${ORG}/${REPO}/releases/tags/${VERSION}" | jq --raw-output ".assets[] | select( (.name | contains(\"${SYSTEM_UNAME}\")) and (.name | contains(\"${SYSTEM_ARCH}\")) and (.name | contains(\"sha1\") | not) ) | .browser_download_url")"
-if [[ -z ${DOWNLOAD_URI} ]]; then
+CHECKSUM_URI="$(curl --silent --location "https://api.github.com/repos/${ORG}/${REPO}/releases/tags/${VERSION}" | jq --raw-output ".assets[] | select( (.name | contains(\"${SYSTEM_UNAME}\")) and (.name | contains(\"${SYSTEM_ARCH}\")) and (.name | contains(\"sha1\")) ) | .browser_download_url")"
+if [[ -z ${DOWNLOAD_URI} ]] || [[ -z ${CHECKSUM_URI} ]]; then
   echo -e "Unsupported operating system or machine type"
   exit 1
 fi
 
 echo "[INFO] Downloading spruce binary with version ${VERSION}"
 if curl --progress-bar --location "${DOWNLOAD_URI}" --output "${TARGET_DIR}/spruce"; then
+  echo "[INFO] Validating spruce binary..."
+  sha1sum --check <<<"$(curl --fail --silent --location "${CHECKSUM_URI}" | awk '{print $1}')  ${TARGET_DIR}/spruce"
   chmod a+rx "${TARGET_DIR}/spruce"
 fi


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Updates `hack/install-spruce.sh` to securely download the matching SHA1 checksum asset and verify the Spruce binary's integrity (`sha1sum --check`) before installing it. 

This resolves a potential vulnerability where corrupted or maliciously modified binaries could be silently executed and installed, bringing the script in line with the secure validation pattern already used in `install-kubectl.sh`.

# Related Issue

Fixes: #2343 
# Type of PR

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [] Kind label has been set
- [] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Fixed a potential security vulnerability in `hack/install-spruce.sh` by verifying the SHA1 checksum of the downloaded Spruce binary before installation.
