### PR TITLE
Pin Trivy installer and verify checksum

### DIFF
--- a/hack/install-trivy.sh
+++ b/hack/install-trivy.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
-
-# Copyright The Shipwright Contributors
-#
-# SPDX-License-Identifier: Apache-2.0
-
-#
-#!/bin/bash
 # Copyright The Shipwright Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -32,11 +25,20 @@ if [[ -z ${TARGET_DIR:-} ]]; then
   exit 1
 fi
 
-# Determine the architecture
+# Determine the operating system and architecture
+case "$(uname -s)" in
+  Linux)  OS_NAME="Linux"  ;;
+  Darwin) OS_NAME="macOS"  ;;
+  *)
+    echo "Unsupported operating system: $(uname -s)"
+    exit 1
+    ;;
+esac
+
 ARCH=$(uname -m | sed -e 's/x86_64/64bit/' -e 's/aarch64/ARM64/' -e 's/arm64/ARM64/')
 
 BASE_URL="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"
-TARBALL="trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz"
+TARBALL="trivy_${TRIVY_VERSION}_${OS_NAME}-${ARCH}.tar.gz"
 
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TEMP_DIR}"' EXIT

--- a/hack/install-trivy.sh
+++ b/hack/install-trivy.sh
@@ -5,10 +5,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #
+#!/bin/bash
+# Copyright The Shipwright Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 # Installs "trivy"
 #
 
 set -euo pipefail
+
+# Pinned Trivy release. Bump deliberately; do not track a moving branch.
+TRIVY_VERSION="${TRIVY_VERSION:-0.74.0}"
 
 # Find a suitable install location
 for CANDIDATE in "$HOME/bin" "/usr/local/bin" "/usr/bin"; do
@@ -24,8 +32,25 @@ if [[ -z ${TARGET_DIR:-} ]]; then
   exit 1
 fi
 
-echo "# Install Trivy"
-curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b "$TARGET_DIR"
+# Determine the architecture
+ARCH=$(uname -m | sed -e 's/x86_64/64bit/' -e 's/aarch64/ARM64/' -e 's/arm64/ARM64/')
+
+BASE_URL="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"
+TARBALL="trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz"
+
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+echo "# Downloading Trivy ${TRIVY_VERSION}..."
+curl --fail --progress-bar --location "${BASE_URL}/${TARBALL}" --output "${TEMP_DIR}/${TARBALL}"
+
+echo "# Validating Trivy archive..."
+curl --fail --silent --location "${BASE_URL}/trivy_${TRIVY_VERSION}_checksums.txt" --output "${TEMP_DIR}/checksums.txt"
+(cd "${TEMP_DIR}" && grep " ${TARBALL}\$" checksums.txt | sha256sum --check --strict -)
+
+echo "# Installing Trivy into ${TARGET_DIR}..."
+tar -xzf "${TEMP_DIR}/${TARBALL}" -C "${TEMP_DIR}" trivy
+install -m 0755 "${TEMP_DIR}/trivy" "${TARGET_DIR}/trivy"
 
 echo "# Trivy version"
 trivy --version


### PR DESCRIPTION
# Changes

`hack/install-trivy.sh` piped Trivy's install script from upstream `main` straight into `sh`. The script was unpinned and unverified, so any change to it would run immediately in CI and on contributor machines.

This PR drops the fetched-script execution entirely. The script now:

1. Downloads the pinned release archive from the Trivy GitHub release.
2. Verifies it against that release's published `trivy_<version>_checksums.txt` using `sha256sum --check --strict`.
3. Extracts the binary and installs it into the existing `TARGET_DIR`.

No upstream code is executed at install time, only the release artifact is used. This follows the download-then-verify pattern already in `hack/install-kubectl.sh`, as suggested in the issue. The install-location detection at the top of the script is unchanged.

Notes:

* Pinned to Trivy 0.74.0 (current release). `TRIVY_VERSION` is env-overridable so a bump can be tested without editing the file.
* OS and arch come from `uname`, mapped to Trivy's release naming (`Linux` / `macOS`, `64bit` / `ARM64`). Anything else exits with a clear message instead of building a URL that 404s.
* Downloads go to a `mktemp -d` directory with a `trap` for cleanup, so nothing is written into the repo working directory and nothing is left behind on failure.
* Fails closed: `pipefail` catches a missing checksum entry, `--strict` catches a malformed one.

One limitation: macOS has `shasum -a 256`, not `sha256sum`, so the mac path downloads the right archive and then fails at verification. Happy to add a fallback if macOS should be fully supported here. `install-kubectl.sh` has the same issue today.

On version bumps, Dependabot doesn't track versions in shell variables, so there's no marker to add. The pin needs a manual bump.

Tested locally on Linux/amd64:

```
# Downloading Trivy 0.74.0...
# Validating Trivy archive...
trivy_0.74.0_Linux-64bit.tar.gz: OK
# Installing Trivy into /home/lenovo/bin...
# Trivy version
Version: 0.74.0
```

# Related Issue

Fixes: #2327

# Type of PR

/kind bug

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```