### PR TITLE
refactor(tests): move PipelineRun tests to Makefile targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,7 @@ jobs:
 
           make test-integration
       - name: Test-PipelineRun
-        run: |
-          BUILDRUN_EXECUTOR=PipelineRun ginkgo --label-filter="PipelineRun" -v test/integration/...
+        run: make test-integration-pipelinerun
 
   e2e:
     strategy:
@@ -249,32 +248,7 @@ jobs:
           export TEST_E2E_TIMEOUT_MULTIPLIER=2
           make test-e2e
       - name: Test-PipelineRun
-        run: |
-          export TEST_NAMESPACE=shp-e2e
-          export TEST_IMAGE_REPO=registry.registry.svc.cluster.local:32222/shipwright-io/build-e2e
-          export TEST_IMAGE_REPO_INSECURE=true
-          export TEST_E2E_TIMEOUT_MULTIPLIER=1
-          kubectl patch deployment shipwright-build-controller -n shipwright-build --type='json' -p='[
-            {
-              "op": "add",
-              "path": "/spec/template/spec/containers/0/env/-",
-              "value": {
-                "name": "BUILDRUN_EXECUTOR",
-                "value": "PipelineRun"
-              }
-            }
-          ]'
-          # Wait for the rollout to complete
-          kubectl rollout restart deployment shipwright-build-controller -n shipwright-build
-          kubectl rollout status deployment shipwright-build-controller -n shipwright-build
-
-          # Run PipelineRun tests
-          TEST_CONTROLLER_NAMESPACE=${TEST_NAMESPACE} \
-          TEST_WATCH_NAMESPACE=${TEST_NAMESPACE} \
-          TEST_E2E_SERVICEACCOUNT_NAME=pipeline \
-          TEST_E2E_TIMEOUT_MULTIPLIER=${TEST_E2E_TIMEOUT_MULTIPLIER} \
-          TEST_E2E_VERIFY_TEKTONOBJECTS=true \
-          ginkgo --label-filter="PipelineRun" --procs 8 --timeout=1h --vv test/e2e/v1beta1/
+        run: make test-e2e-pipelinerun
       - name: Build controller logs
         if: ${{ failure() }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,33 @@ test-e2e-plain: ginkgo
 	TEST_E2E_VERIFY_TEKTONOBJECTS=${TEST_E2E_VERIFY_TEKTONOBJECTS} \
 	$(GINKGO) --label-filter="!PipelineRun" ${TEST_E2E_FLAGS} test/e2e/
 
+.PHONY: test-integration-pipelinerun
+test-integration-pipelinerun: install-apis ginkgo
+	./hack/setup-webhook-cert-integration-test.sh
+	BUILDRUN_EXECUTOR=PipelineRun \
+	$(GINKGO) --label-filter="PipelineRun" -v test/integration/...
+
+.PHONY: test-e2e-pipelinerun
+test-e2e-pipelinerun: ginkgo
+	kubectl patch deployment shipwright-build-controller -n shipwright-build --type='json' -p='[\
+	  {\
+	    "op": "add",\
+	    "path": "/spec/template/spec/containers/0/env/-",\
+	    "value": {\
+	      "name": "BUILDRUN_EXECUTOR",\
+	      "value": "PipelineRun"\
+	    }\
+	  }\
+	]'
+	kubectl rollout restart deployment shipwright-build-controller -n shipwright-build
+	kubectl rollout status deployment shipwright-build-controller -n shipwright-build
+	TEST_CONTROLLER_NAMESPACE=${TEST_NAMESPACE} \
+	TEST_WATCH_NAMESPACE=${TEST_NAMESPACE} \
+	TEST_E2E_SERVICEACCOUNT_NAME=${TEST_E2E_SERVICEACCOUNT_NAME} \
+	TEST_E2E_TIMEOUT_MULTIPLIER=${TEST_E2E_TIMEOUT_MULTIPLIER} \
+	TEST_E2E_VERIFY_TEKTONOBJECTS=true \
+	$(GINKGO) --label-filter="PipelineRun" --procs 8 --timeout=1h --vv test/e2e/v1beta1/
+
 .PHONY: test-e2e-kind-with-prereq-install
 test-e2e-kind-with-prereq-install: ginkgo install-controller-kind install-strategies test-e2e-plain
 


### PR DESCRIPTION
# Changes

Moves PipelineRun e2e and integration test logic out of GitHub Actions yaml and into the Makefile for better maintainability and local testability.

<!-- Describe your changes here. Ideally you can get that description straight from
your descriptive commit message(s)! -->

# Related Issue

Fixes #2134

# Type of PR

/kind cleanup


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE


# Release Notes

<!-- Describe any user-facing changes here, or mark as NONE.

Examples of user-facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

If this PR requires additional action from users switching to the new release,
include the string "action required" (case insensitive) in the release note.

If there are no user-facing changes, write NONE below. -->

```release-note
None
```
